### PR TITLE
feat(cli): support process.env.PORT in serve command

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -40,7 +40,7 @@ class AvenxCLI {
                 this.buildProject();
                 break;
             case 'serve':
-                this.serveProject(args[0] || 3000);
+                this.serveProject(args[0] || process.env.PORT || 3000);
                 break;
             case 'help':
             default:


### PR DESCRIPTION
## Summary

Updated the `serve` command to respect `process.env.PORT` when no port argument is provided.

### Changes

* Added `process.env.PORT` as a fallback when starting the development server.
* Preserved existing behavior for explicit CLI port arguments.
* Kept the default fallback port as `3000`.

### Priority Order

1. CLI argument (`avenx serve 5000`)
2. `process.env.PORT`
3. Default `3000`

### Testing

Verified that:

* `node bin/avenx.js serve` starts on port `3000`
* Setting `PORT=8080` starts the server on port `8080`
* Explicit CLI arguments continue to take precedence

Closes #32
