### PR TITLE
feat(cli): add build command alias

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -37,6 +37,7 @@ class AvenxCLI {
                 }
                 break;
             case 'build':
+            case 'b':
                 this.buildProject();
                 break;
             case 'serve':
@@ -116,7 +117,7 @@ class AvenxCLI {
             .split(/[-_]/)
             .map(part => part.charAt(0).toUpperCase() + part.slice(1))
             .join('') + "Bridge";
-        
+
         const globalDir = path.join(this.baseDir, 'src/global');
         if (!fs.existsSync(globalDir)) {
             fs.mkdirSync(globalDir, { recursive: true });
@@ -154,7 +155,7 @@ class AvenxCLI {
             .split(/[-_]/)
             .map(part => part.charAt(0).toUpperCase() + part.slice(1))
             .join('');
-        
+
         const pageDir = path.join(this.baseDir, 'src/pages');
         if (!fs.existsSync(pageDir)) {
             fs.mkdirSync(pageDir, { recursive: true });
@@ -192,7 +193,7 @@ class AvenxCLI {
             .split(/[-_]/)
             .map(part => part.charAt(0).toUpperCase() + part.slice(1))
             .join('');
-        
+
         const compDir = path.join(this.baseDir, 'src/components', lowerName);
 
         if (fs.existsSync(compDir)) {
@@ -283,7 +284,7 @@ class AvenxCLI {
 
         const server = http.createServer((req, res) => {
             let filePath = path.join(this.baseDir, req.url === '/' ? 'index.html' : req.url);
-            
+
             if (!fs.existsSync(filePath) && !path.extname(filePath)) {
                 filePath = path.join(this.baseDir, 'index.html');
             }
@@ -378,7 +379,7 @@ Commands:
   generate component <name> Generate a new component (alias: g)
   generate page <name>      Generate a new page (alias: g p)
   generate bridge <name>    Generate a new shared reactive bridge
-  build                     Build the project into dist/bundle.js
+  build (b)                 Build the project into dist/bundle.js
   serve [port]              Start dev server with hot-reload (default: 3000)
   help                      Show this help message
         `);


### PR DESCRIPTION
## Summary

Added a shorthand alias `b` for the `build` command.

### Changes

- Added support for `avenx b` as an alias for `avenx build`.
- Updated the CLI help menu to document the shorthand alias.

### Testing

Verified that:
- `avenx build` continues to work as before.
- `avenx b` triggers the same build behavior.
- The help menu displays the new alias.

Closes #31