### PR TITLE
feat(runtime): dispatch lifecycle DOM events

### DIFF
--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -156,6 +156,12 @@ export class AvenxComponent {
         this.#listManager.process(this.#element, this.#createScope(), this.state);
         this.#eventBinder.bind(this.#element, this.#eventExecutor);
 
+        if (this.#isMounted && this.#element?.dispatchEvent) {
+            this.#element.dispatchEvent(
+                new CustomEvent('avenx:update')
+            );
+        }
+
         if (this.#isMounted && this.#methods.onUpdate) {
             this.#methods.onUpdate();
         }
@@ -176,6 +182,13 @@ export class AvenxComponent {
      */
     __afterMount() {
         this.#isMounted = true;
+
+        if (this.#element?.dispatchEvent) {
+            this.#element.dispatchEvent(
+                new CustomEvent('avenx:mount')
+            );
+        }
+
         if (this.#methods.onMount) {
             this.#methods.onMount();
         }
@@ -185,12 +198,20 @@ export class AvenxComponent {
      * Unmounts the component and triggers cleanup.
      */
     unmount() {
+        if (this.#element?.dispatchEvent) {
+            this.#element.dispatchEvent(
+                new CustomEvent('avenx:unmount')
+            );
+        }
+
         if (this.#methods.onUnmount) {
             this.#methods.onUnmount();
         }
+
         if (this.#element) {
             this.#element.innerHTML = '';
         }
+
         this.#isMounted = false;
     }
 

--- a/test/integration/lifecycle.test.js
+++ b/test/integration/lifecycle.test.js
@@ -17,6 +17,7 @@ try {
         appendChild: () => {},
         removeChild: () => {},
         replaceWith: () => {},
+        dispatchEvent: () => {},
         childNodes: []
     };
 


### PR DESCRIPTION
**Summary**

Added native DOM lifecycle events for Avenx components to make lifecycle transitions observable from outside the component.

**Changes**

- Dispatch avenx:mount after a component is mounted.
- Dispatch avenx:update whenever a mounted component updates.
- Dispatch avenx:unmount before component cleanup.
- Updated the lifecycle integration test mock to support DOM event dispatching.

**Testing**

Verified that:

- Existing lifecycle hooks (onMount, onUpdate, onUnmount) continue to work.
- Lifecycle integration tests pass successfully.
- No regressions were introduced in other test suites.

Closes #55