### PR TITLE
Add duplicate bridge registration error handling

### DIFF
--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -69,6 +69,18 @@ export class AvenxApp {
      * @param {Object|Function} bridgeData - The bridge data or constructor.
      */
     registerBridge(name, bridgeData) {
+
+        if(Object.prototype.hasOwnProperty.call(this.bridges, name)){
+            const availableBridges = Object.keys(this.bridges).join(',');
+            const suggestion = `Please use a unique name`;
+            throw new AvenxError (
+                AvenxErrorCodes.BRIDGE_aLREADY_EXISTS,
+                name,
+                availableBridges || 'none',
+                suggestion
+            );
+        }
+
         let instance = bridgeData;
 
         if (typeof bridgeData === 'function') {

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -36,7 +36,8 @@ export const AvenxErrorCodes = {
     ROUTER_GUARD_DENIED: 'AVX_R06',
     ROUTER_GUARD_ERROR: 'AVX_R07',
     TEMPLATE_RENDER_ERROR: 'AVX_R08',
-    EVENT_HANDLER_ERROR: 'AVX_R09'
+    EVENT_HANDLER_ERROR: 'AVX_R09',
+    BRIDGE_ALREADY_EXISTS: 'AVX_R10'
 };
 
 /**
@@ -55,7 +56,8 @@ export const AvenxErrorMessages = {
     [AvenxErrorCodes.ROUTER_GUARD_DENIED]: 'Navigation guard denied transition to route "{0}".',
     [AvenxErrorCodes.ROUTER_GUARD_ERROR]: 'Navigation guard threw an error during evaluation for route "{0}": {1}',
     [AvenxErrorCodes.TEMPLATE_RENDER_ERROR]: 'Failed to render interpolation expression "{0}". Error: {1}',
-    [AvenxErrorCodes.EVENT_HANDLER_ERROR]: 'Event handler execution failed for statement "{0}". Error: {1}'
+    [AvenxErrorCodes.EVENT_HANDLER_ERROR]: 'Event handler execution failed for statement "{0}". Error: {1}',
+    [AvenxErrorCodes.BRIDGE_ALREADY_EXISTS]: 'Bridge "{0}" is already registered. Available bridges: {1}. Suggestion: {2}'
 };
 
 /**


### PR DESCRIPTION
Adds explicit error handling for duplicate bridge registration in AvenxApp.registerBridge().

## Changes
- added a duplicate bridge name check in registerBridge()
- introduced a dedicated BRIDGE_ALREADY_EXISTS error
- throw AvenxError when attempting to register a bridge with an already used name