### PR TITLE
fix(cli): use correct runtime package name

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -95,7 +95,7 @@ class AvenxCLI {
         // Create initial main.app.js
         const mainAppPath = path.join(this.baseDir, 'src/main.app.js');
         if (!fs.existsSync(mainAppPath)) {
-            fs.writeFileSync(mainAppPath, "import { AvenxApp } from 'avenx-js/runtime';\n\nconst app = new AvenxApp({ target: '#app' });\n");
+            fs.writeFileSync(mainAppPath, "import { AvenxApp } from 'avenx-core/runtime';\n\nconst app = new AvenxApp({ target: '#app' });\n");
             console.log('  Created: src/main.app.js');
         }
 


### PR DESCRIPTION
Summary

Updated the scaffolded main.app.js template to use the correct runtime package name.

Changes

- Replaced 'avenx-js/runtime' with 'avenx-core/runtime' in the initProject() template.
- Ensures newly generated projects reference the package name defined in package.json.

Testing

Verified that:

- The generated src/main.app.js now imports from 'avenx-core/runtime'.
- The scaffolded project no longer references the incorrect package name.

Closes #68