### PR TITLE
fix(events): cleanup root event listeners on unmount

### DIFF
--- a/lib/core/events/bindEvents.js
+++ b/lib/core/events/bindEvents.js
@@ -3,8 +3,8 @@
  */
 export class EventBinder {
     /**
-     * Stores bound events to avoid duplicate bindings.
-     * @type {WeakMap<Element, Set<string>>}
+     * Stores bound events and handlers.
+     * @type {WeakMap<Element, Map<string, Function>>}
      * @private
      */
     #boundEvents = new WeakMap();
@@ -29,15 +29,45 @@ export class EventBinder {
                 if (attr.name.startsWith('@')) {
                     const eventName = attr.name.substring(1);
                     const signature = `${eventName}:${attr.value}`;
-                    const existing = this.#boundEvents.get(el) || new Set();
+                    const existing = this.#boundEvents.get(el) || new Map();
 
                     if (!existing.has(signature)) {
-                        el.addEventListener(eventName, event => dispatcher.execute(attr.value, event));
-                        existing.add(signature);
+                        const handler = event => dispatcher.execute(attr.value, event);
+
+                        el.addEventListener(eventName, handler);
+
+                        existing.set(signature, handler);
                         this.#boundEvents.set(el, existing);
                     }
                 }
             });
+        });
+    }
+
+    /**
+     * Removes all tracked event listeners under a root element.
+     * @param {Element|DocumentFragment} root
+     */
+    unbind(root) {
+        if (!root) return;
+
+        const elements = [root];
+
+        if (typeof root.querySelectorAll === 'function') {
+            elements.push(...root.querySelectorAll('*'));
+        }
+
+        elements.forEach(el => {
+            const existing = this.#boundEvents.get(el);
+
+            if (!existing) return;
+
+            existing.forEach((handler, signature) => {
+                const eventName = signature.split(':')[0];
+                el.removeEventListener(eventName, handler);
+            });
+
+            this.#boundEvents.delete(el);
         });
     }
 }

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -185,12 +185,16 @@ export class AvenxComponent {
      * Unmounts the component and triggers cleanup.
      */
     unmount() {
+        this.#eventBinder.unbind(this.#element);
+
         if (this.#methods.onUnmount) {
             this.#methods.onUnmount();
         }
+
         if (this.#element) {
             this.#element.innerHTML = '';
         }
+
         this.#isMounted = false;
     }
 

--- a/test/unit/eventBinder.test.js
+++ b/test/unit/eventBinder.test.js
@@ -20,6 +20,11 @@ try {
             addEventListener(event, callback) {
                 listeners[event] = callback;
             },
+            removeEventListener(event, callback) {
+                if (listeners[event] === callback) {
+                    delete listeners[event];
+                }
+            },
             querySelectorAll(selector) {
                 if (selector === '*') {
                     const result = [];
@@ -69,7 +74,7 @@ try {
     // 2. Descendant elements also have event listeners
     const childEl = createMockElement('BUTTON', { '@input': 'handleInput' });
     const rootWithChild = createMockElement('DIV', { '@click': 'parentClick' }, [childEl]);
-    
+
     binder.bind(rootWithChild, dispatcher);
 
     // Trigger parent
@@ -90,6 +95,26 @@ try {
     executedSource = null;
     childEl.trigger('input', { type: 'input' });
     assert.strictEqual(executedSource, 'handleInput');
+
+    // 4. unbind removes event listeners
+    const unbindEl = createMockElement('BUTTON', { '@click': 'cleanupHandler' });
+
+    const binder3 = new EventBinder();
+    binder3.bind(unbindEl, dispatcher);
+
+    executedSource = null;
+    unbindEl.trigger('click', { type: 'click' });
+    assert.strictEqual(executedSource, 'cleanupHandler');
+
+    binder3.unbind(unbindEl);
+
+    executedSource = null;
+    unbindEl.trigger('click', { type: 'click' });
+    assert.strictEqual(
+        executedSource,
+        null,
+        'Event listener should be removed after unbind()'
+    );
 
     console.log('  ✅ EventBinder tests passed!');
 } catch (error) {


### PR DESCRIPTION
## Summary

Fixes a memory leak where event listeners attached to the component root element were not removed during unmount.

## Changes

- Store event handler references in EventBinder.
- Add EventBinder.unbind() to remove tracked listeners.
- Call unbind() during component unmount cleanup.
- Add unit tests covering listener removal behavior.

## Testing

Verified that:

- Existing event binding behavior remains unchanged.
- Event listeners are removed after unbind().
- EventBinder unit tests pass successfully.

Closes #66