### PR TITLE
fix(router): ignore secondary hash anchors during route matching

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -62,7 +62,7 @@ export class AvenxRouter {
                 }
                 const Guard = guards[index];
                 const instance = typeof Guard === 'function' ? new Guard() : Guard;
-                
+
                 Promise.resolve(instance.canActivate(to, from))
                     .then(result => {
                         if (result === false || typeof result === 'string') {
@@ -86,18 +86,26 @@ export class AvenxRouter {
      * @private
      */
     #handleRoute() {
-        const hash = window.location.hash || '#/';
+        let hash = window.location.hash || '#/';
+
+        // Strip any secondary anchor (e.g. #/profile#details)
+        const secondHashIndex = hash.indexOf('#', 1);
+
+        if (secondHashIndex !== -1) {
+            hash = hash.substring(0, secondHashIndex);
+        }
+
         if (this.hashToIgnore === hash) {
             this.hashToIgnore = null;
             return;
         }
-        
+
         let matchedRoute = null;
         let params = {};
-        
+
         for (const [routePattern, routeDef] of Object.entries(this.routes)) {
             if (routePattern === '*') continue;
-            
+
             const paramNames = [];
             const regexStr = routePattern
                 .replace(/[.+^${}()|[\]\\]/g, '\\$&')
@@ -106,10 +114,10 @@ export class AvenxRouter {
                     return '([^/]+)';
                 });
             const regex = new RegExp(`^${regexStr}$`);
-            
+
             const [pathPart, queryPart] = hash.split('?');
             const match = pathPart.match(regex);
-            
+
             if (match) {
                 matchedRoute = { pattern: routePattern, definition: routeDef };
                 paramNames.forEach((name, idx) => {
@@ -122,24 +130,24 @@ export class AvenxRouter {
                 break;
             }
         }
-        
+
         // Fallback to '*' if no route matched
         if (!matchedRoute && this.routes['*']) {
             matchedRoute = { pattern: '*', definition: this.routes['*'] };
         }
-        
+
         if (!matchedRoute) {
             console.warn(`[AvenxRouter] No route defined for hash: ${hash}`);
             return;
         }
-        
+
         const def = matchedRoute.definition;
         const pageName = typeof def === 'string' ? def : def.page;
         const guards = typeof def === 'object' ? (def.guards || []) : [];
-        
+
         const to = { hash, page: pageName, params };
         const from = this.currentRoute;
-        
+
         this.#runGuards(guards, to, from).then(result => {
             if (result === false) {
                 console.warn(formatMessage(AvenxErrorCodes.ROUTER_GUARD_DENIED, to.hash));

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -161,7 +161,52 @@ const { AvenxPage } = require('../../lib/core/runtime/AvenxPage');
         assert.strictEqual(window.location.hash, '#/', 'Hash should be redirected to redirect target');
         assert.strictEqual(mountedPageName, 'TestPage');
 
-        // 5. Duplicate page registration should warn
+        // Reset tracking
+        mountedPageName = null;
+        mountedParams = null;
+        guardCalled = false;
+
+        // 5. Secondary anchor should be ignored
+        allowTransition = true;
+        redirectTarget = null;
+
+        window.location.hash = '#/user/42#details';
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        assert.strictEqual(
+            mountedPageName,
+            'TestPage',
+            'Route should match even with secondary anchor'
+        );
+        assert.strictEqual(
+            mountedParams.userId,
+            '42',
+            'Should parse params while ignoring secondary anchor'
+        );
+
+        // Reset tracking
+        mountedPageName = null;
+        mountedParams = null;
+
+        // 6. Secondary anchor after query should be ignored
+        window.location.hash = '#/user/42?ref=test#specs';
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        assert.strictEqual(
+            mountedPageName,
+            'TestPage',
+            'Route with query and secondary anchor should match'
+        );
+        assert.strictEqual(
+            mountedParams.userId,
+            '42'
+        );
+        assert.deepStrictEqual(
+            mountedParams.query,
+            { ref: 'test' }
+        );
+
+        // 7. Duplicate page registration should warn
         const originalWarn = console.warn;
         let warningMessage = '';
 


### PR DESCRIPTION
**Summary**

Fixes router matching when the URL hash contains a secondary anchor (for example, `#/profile#details` or `#/user/42?ref=test#specs`).

Before matching routes, the router now strips everything after the second #, allowing route matching to work correctly while preserving support for in-page anchors.

**Changes**

- Strip any secondary hash fragment before route matching.
- Preserve existing route parameter and query parsing behavior.
- Add integration tests covering:
- `#/user/42#details`
- `#/user/42?ref=test#specs`

**Testing**

Verified locally:

`node test/integration/router.test.js`
`npm test`

**Result:**

All router-related tests pass.
The remaining` test/system/cli.test.js` failure is an existing Windows path issue unrelated to this change.

Closes #84