### PR TITLE
fix(router): escape literal asterisks in route patterns

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -108,7 +108,7 @@ export class AvenxRouter {
 
             const paramNames = [];
             const regexStr = routePattern
-                .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+                .replace(/[.*+^${}()|[\]\\]/g, '\\$&')
                 .replace(/:([a-zA-Z0-9_$]+)/g, (_, name) => {
                     paramNames.push(name);
                     return '([^/]+)';

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -98,6 +98,7 @@ const { AvenxPage } = require('../../lib/core/runtime/AvenxPage');
 
         app.initRouter({
             '#/': 'TestPage',
+            '#/items*': 'TestPage',
             '#/user/:userId': {
                 page: 'TestPage',
                 guards: [MockGuard]
@@ -206,7 +207,20 @@ const { AvenxPage } = require('../../lib/core/runtime/AvenxPage');
             { ref: 'test' }
         );
 
-        // 7. Duplicate page registration should warn
+        // 7. Literal asterisk route should match correctly
+        mountedPageName = null;
+        mountedParams = null;
+
+        window.location.hash = '#/items*';
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        assert.strictEqual(
+            mountedPageName,
+            'TestPage',
+            'Route containing a literal * should match correctly'
+        );
+
+        // 8. Duplicate page registration should warn
         const originalWarn = console.warn;
         let warningMessage = '';
 


### PR DESCRIPTION
## Summary

Escapes literal `*` characters when compiling route patterns into regular expressions.

Previously, route patterns such as `#/items*` were interpreted by the RegExp engine as quantifiers instead of literal characters, causing unexpected route matching behavior.

## Changes

- Escape `*` while building the route matching regex.
- Add integration tests covering literal `*` route patterns.
- Preserve existing parameter and query parsing behavior.

## Testing

Verified locally:

- `node test/integration/router.test.js`
- `npm test` (all router-related tests pass; the existing `test/system/cli.test.js` Windows path failure is unrelated to this change)

Closes #77