### PR TITLE
fix(router): handle malformed URI route parameters

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -121,7 +121,17 @@ export class AvenxRouter {
             if (match) {
                 matchedRoute = { pattern: routePattern, definition: routeDef };
                 paramNames.forEach((name, idx) => {
-                    params[name] = decodeURIComponent(match[idx + 1]);
+                    const value = match[idx + 1];
+
+                    try {
+                        params[name] = decodeURIComponent(value);
+                    } catch {
+                        console.warn(
+                            `[AvenxRouter] Failed to decode route parameter "${name}": ${value}`
+                        );
+
+                        params[name] = value;
+                    }
                 });
                 if (queryPart) {
                     const queryParams = new URLSearchParams(queryPart);

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -220,7 +220,27 @@ const { AvenxPage } = require('../../lib/core/runtime/AvenxPage');
             'Route containing a literal * should match correctly'
         );
 
-        // 8. Duplicate page registration should warn
+        // Reset tracking
+        mountedPageName = null;
+        mountedParams = null;
+
+        // 8. Malformed URI parameters should not crash routing
+        window.location.hash = '#/user/%E0%A4%A';
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        assert.strictEqual(
+            mountedPageName,
+            'TestPage',
+            'Router should still mount the page when URI decoding fails'
+        );
+
+        assert.strictEqual(
+            mountedParams.userId,
+            '%E0%A4%A',
+            'Router should fall back to the raw parameter value'
+        );
+
+        // 9. Duplicate page registration should warn
         const originalWarn = console.warn;
         let warningMessage = '';
 


### PR DESCRIPTION
## Summary

Fixes router crashes when route parameters contain malformed URI sequences (for example `#/user/%E0%A4%A`).

The router now safely handles `decodeURIComponent` failures by catching `URIError`, logging a warning, and falling back to the raw parameter value instead of crashing.

## Changes

- Wrap `decodeURIComponent` in a `try...catch`
- Fall back to the original parameter when decoding fails
- Add an integration test covering malformed URI parameters

## Testing

Verified locally:

```bash
node test/integration/router.test.js
npm test
```

All router-related tests pass. The remaining `test/system/cli.test.js` failure is the existing Windows path issue unrelated to this change.

Closes #76