### PR TITLE
Add viewport meta tag to default HTML template

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -515,8 +515,9 @@ class AvenxCLI {
     return `<!DOCTYPE html>
 <html>
 <head>
-    <title>My Avenx App</title>
-    <link rel="stylesheet" href="dist/bundle.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Avenx App</title>
+  <link rel="stylesheet" href="dist/bundle.css">
 </head>
 <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary

Adds the viewport meta tag to the default HTML template generated by the Avenx CLI.

## Why

This ensures generated applications render correctly on mobile devices and improves responsive behavior.

Closes #65