### PR TITLE
docs: fix quickstart CSS variable syntax

### DIFF
--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -73,12 +73,12 @@ Open `src/components/counter/counter.component.css` and define your scoped style
 
     .number {
         font-size: 1.25rem;
-        color: var(--text-dark);
+        color: @text-dark;
         margin: 1rem 0;
     }
 
     button {
-        background-color: var(--brand-color);
+        background-color: @brand-color;
         color: white;
         border: none;
         padding: 0.5rem 1rem;


### PR DESCRIPTION
Summary:
- update the quickstart `counter.component.css` snippet to use compiler-supported `@text-dark` and `@brand-color` references
- remove the unsupported native CSS custom property references from that snippet

Validation:
- `npm test` (35 passed)
- `node -e "const StyleProcessor=require('./lib/compiler/StyleProcessor'); const sp=new StyleProcessor(); sp.addVariable('brand-color','#4f46e5'); sp.addVariable('text-dark','#1f2937'); const out=sp.applyVariables('color: @text-dark; background-color: @brand-color;'); if(!out.includes('#1f2937') || !out.includes('#4f46e5') || out.includes('@brand-color') || out.includes('@text-dark')) process.exit(1); console.log(out);"`
- `rg -n "var\(--brand-color\)|var\(--text-dark\)|@brand-color|@text-dark" docs\src\content\docs\getting-started\quickstart.md`
- `git diff --check`

Closes #150