### PR TITLE
feat(cli): scaffold .gitignore during project initialization

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -165,7 +165,16 @@ class AvenxCLI {
       );
       console.log('  Created: src/main.app.js');
     }
+    // Create initial .gitignore
+    const gitignorePath = path.join(this.baseDir, '.gitignore');
 
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(
+        gitignorePath,
+        'node_modules/\ndist/\n.DS_Store\n',
+      );
+      console.log('  Created: .gitignore');
+    }
     console.log('✅ Project initialized successfully!');
   }
 


### PR DESCRIPTION
## Summary

This PR adds automatic `.gitignore` generation during `avenx init`.

### Changes
- Creates a `.gitignore` file if one does not already exist.
- Adds the following default entries:
  - `node_modules/`
  - `dist/`
  - `.DS_Store`

### Testing
- Ran `avenx init` in a fresh directory.
- Verified that `.gitignore` is created automatically with the expected contents.
- Verified that an existing `.gitignore` is not overwritten.
Closes #30