### PR TITLE
Add compile-time check for duplicate component names (#210)

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,6 +7,9 @@ const ComponentParser = require('./compiler/ComponentParser');
 const AvenxCompilerErrors = {
   AVX_C01: 'Could not create dist directory at "{0}".',
   AVX_C02: '"src" directory not found at "{0}". Run "avenx init" to scaffold a project.',
+  AVX_C03:
+    'Duplicate component name(s) detected. These files compile to the same class name:\n{0}\n' +
+    'Fix by renaming or moving one of the files (e.g. "card.component.js" -> "profile-card.component.js").',
 };
 
 /**
@@ -94,13 +97,19 @@ class AvenxCompiler {
       return;
     }
 
-    // Reset style processor to avoid accumulating styles across multiple builds (watch mode)
     this.styleProcessor.reset();
 
     let bundleJs = this.getRuntime();
     const bridgeData = this.processBridges();
     bundleJs += this.processGuards();
-    bundleJs += this.processComponents();
+
+    try {
+      bundleJs += this.processComponents();
+    } catch (err) {
+      console.error(`❌ ${err.message}`);
+      return; // halt build — do not write dist files
+    }
+
     const pageData = this.processPages();
     bundleJs += pageData.pagesJs;
     bundleJs += this.processMain((bridgeData.registrations || '') + '\n' + (pageData.registrations || ''));
@@ -230,6 +239,15 @@ class AvenxCompiler {
   processComponents() {
     let componentsJs = '';
     const compDir = path.join(this.srcDir, 'components');
+    const classNameMap = new Map(); // className -> [file paths]
+
+    // Same naming convention used elsewhere in this file (bridges/guards)
+    const toClassName = (fileName) =>
+      path
+        .basename(fileName, '.component.js')
+        .split(/[-_]/)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join('');
 
     const scan = (dir) => {
       if (!fs.existsSync(dir)) return;
@@ -238,13 +256,34 @@ class AvenxCompiler {
         if (fs.statSync(fullPath).isDirectory()) {
           scan(fullPath);
         } else if (file.endsWith('.component.js')) {
-          console.log(`[Compiling] ${file}`);
-          componentsJs += this.componentParser.parse(fullPath);
+          const className = toClassName(file);
+          if (!classNameMap.has(className)) classNameMap.set(className, []);
+          classNameMap.get(className).push(fullPath);
         }
       });
     };
 
     scan(compDir);
+
+    // Halt the build if any two files would generate the same class name
+    const duplicates = [...classNameMap.entries()].filter(([, paths]) => paths.length > 1);
+    if (duplicates.length > 0) {
+      const details = duplicates
+        .map(
+          ([className, paths]) =>
+            `  "${className}":\n${paths.map((p) => `    - ${p}`).join('\n')}`
+        )
+        .join('\n');
+      throw new Error(formatCompilerError('AVX_C03', details));
+    }
+
+    // Safe to compile now — no name collisions
+    classNameMap.forEach((paths) => {
+      const fullPath = paths[0];
+      console.log(`[Compiling] ${path.basename(fullPath)}`);
+      componentsJs += this.componentParser.parse(fullPath);
+    });
+
     return componentsJs;
   }
 

--- a/test/unit/duplicateComponentNames.test.js
+++ b/test/unit/duplicateComponentNames.test.js
@@ -1,0 +1,88 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const AvenxCompiler = require('../../lib/compiler');
+
+try {
+    console.log('🧪 Testing AvenxCompiler duplicate component name detection...');
+
+    const tempDir = path.join(__dirname, 'temp_compiler_duplicate_test_src');
+    const compDir = path.join(tempDir, 'components');
+    const sharedDir = path.join(compDir, 'shared');
+
+    const cleanUp = () => {
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    };
+
+    cleanUp(); // in case a previous failed run left files behind
+
+    const compiler = new AvenxCompiler();
+    compiler.srcDir = tempDir; // override srcDir for testing
+
+    // --- Case 1: duplicate class names in different directories should throw ---
+    console.log('  Testing: duplicate component names across directories throws AVX_C03');
+
+    const cardTemplate = `
+    <state title="Card" />
+    <div @css root>{{ title }}</div>
+    <@css>
+        root { padding: 8px; }
+    </@css>
+    `;
+
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(path.join(compDir, 'card.component.js'), cardTemplate);
+    fs.writeFileSync(path.join(sharedDir, 'card.component.js'), cardTemplate);
+
+    assert.throws(
+        () => compiler.processComponents(),
+        (err) => {
+            assert.ok(err instanceof Error, 'Should throw an Error instance');
+            assert.ok(err.message.includes('AVX_C03'), 'Error should reference code AVX_C03');
+            assert.ok(err.message.includes('Card'), 'Error should mention the conflicting class name "Card"');
+            assert.ok(
+                err.message.includes(path.join(compDir, 'card.component.js')),
+                'Error should list the first conflicting file path'
+            );
+            assert.ok(
+                err.message.includes(path.join(sharedDir, 'card.component.js')),
+                'Error should list the second conflicting file path'
+            );
+            return true;
+        },
+        'processComponents() should throw when two files compile to the same class name'
+    );
+
+    // Clean up case 1 files before the next case
+    fs.rmSync(compDir, { recursive: true, force: true });
+
+    // --- Case 2: uniquely-named components should compile without throwing ---
+    console.log('  Testing: unique component names compile without throwing');
+
+    const profileCardTemplate = `
+    <state title="Profile Card" />
+    <div @css root>{{ title }}</div>
+    <@css>
+        root { padding: 12px; }
+    </@css>
+    `;
+
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(path.join(compDir, 'card.component.js'), cardTemplate);
+    fs.writeFileSync(path.join(sharedDir, 'profile-card.component.js'), profileCardTemplate);
+
+    assert.doesNotThrow(() => {
+        const result = compiler.processComponents();
+        assert.ok(typeof result === 'string', 'processComponents() should return a string when names are unique');
+    }, 'processComponents() should not throw when all component class names are unique');
+
+    cleanUp();
+
+    console.log('  ✅ AvenxCompiler duplicate component name tests passed!');
+} catch (error) {
+    console.error('❌ AvenxCompiler duplicate component name tests failed!');
+    console.error(error);
+    process.exit(1);
+}


### PR DESCRIPTION
Closes #210

## Problem
Two component files with the same base filename (in different
directories) compile to the same class name, causing a runtime
collision when the bundle is generated.

## Fix
- processComponents() now does a two-pass scan: first it maps
  className -> [file paths], then checks for any name with more
  than one file before compiling anything.
- If a collision is found, it throws a new AVX_C03 error listing
  every conflicting file path and suggesting a rename.
- build() catches this and halts before writing dist files, so no
  partial/broken bundle is produced.

## Testing
Added test/unit/duplicateComponentNames.test.js covering both the
duplicate-name failure case and the unique-name success case.
Ran the full suite locally: 37/37 passing, no regressions.