### PR TITLE
feat(cli): print build asset size report

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -5,6 +5,8 @@ const StyleProcessor = require('./compiler/StyleProcessor');
 const ComponentParser = require('./compiler/ComponentParser');
 const { logger } = require('./core/runtime/AvenxLogger');
 
+const BUNDLE_SIZE_WARNING_THRESHOLD_KB = 50;
+
 const AvenxCompilerErrors = {
   AVX_C01: 'Could not create dist directory at "{0}".',
   AVX_C02: '"src" directory not found at "{0}". Run "avenx init" to scaffold a project.',
@@ -128,6 +130,22 @@ class AvenxCompiler {
 
     fs.writeFileSync(path.join(this.distDir, 'bundle.js'), bundleJs);
     fs.writeFileSync(path.join(this.distDir, 'bundle.css'), this.styleProcessor.getGlobalStyles());
+
+    const files = ['bundle.js', 'bundle.css'];
+
+    logger.info('\nAsset sizes:');
+
+    files.forEach((file) => {
+      const filePath = path.join(this.distDir, file);
+      const bytes = fs.statSync(filePath).size;
+      const sizeKb = bytes / 1024;
+
+      logger.info(`${file}: ${sizeKb.toFixed(2)} KB`);
+
+      if (sizeKb > BUNDLE_SIZE_WARNING_THRESHOLD_KB) {
+        logger.warn(`WARNING: ${file} exceeds ${BUNDLE_SIZE_WARNING_THRESHOLD_KB} KB (${sizeKb.toFixed(2)} KB)`);
+      }
+    });
 
     logger.info('-----------------------');
     logger.info(`\nBuild erfolgreich: ${this.distDir}/bundle.js & ${this.distDir}/bundle.css`);

--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -67,7 +67,7 @@ function runTest() {
     console.log('✅ All init tests passed!');
 
     console.log('🧪 Testing avenx build...');
-    execSync(`node ${BIN_PATH} build`, { cwd: TEST_DIR });
+    const buildOutput = execSync(`node ${BIN_PATH} build 2>&1`, { cwd: TEST_DIR, encoding: 'utf8' });
 
     const bundleJsPath = path.join(TEST_DIR, 'dist/bundle.js');
     const bundleCssPath = path.join(TEST_DIR, 'dist/bundle.css');
@@ -78,6 +78,16 @@ function runTest() {
     assert.ok(bundleContent.includes('class HtmlEscaper'), 'bundle.js should contain HtmlEscaper');
     assert.ok(bundleContent.includes('class SafeHtml'), 'bundle.js should contain SafeHtml');
     assert.ok(bundleContent.includes('function html('), 'bundle.js should contain html function');
+
+    assert.match(buildOutput, /Asset sizes:/, 'prints asset size');
+    assert.match(buildOutput, /bundle\.js: \d+\.\d{2} KB/, 'prints bundle.js asset size');
+
+    assert.match(
+      buildOutput,
+      /WARNING: bundle\.js exceeds 50 KB \(\d+\.\d{2} KB\)/,
+      'warns when bundle.js exceeds threshold',
+    );
+    assert.match(buildOutput, /bundle\.css: \d+\.\d{2} KB/, 'prints bundle.css size');
 
     console.log('✅ All build tests passed!');
 


### PR DESCRIPTION
Closes #215

# Summary
Adds an asset size report to `avenx build` so compiled output is no longer silent about bundle sizes.

## Changes
- Prints `bundle.js` and `bundle.css` sizes in KB after compilation.
- Warns when a compiled bundle exceeds a threshold.
- Adds system test coverage for size output and warning output.

## Notes
I chose a 50 KB threshold based on the attributes set in `scripts/size-check.js` and `.github/workflows/size-check.yml`. This can be adjusted.
