### PR TITLE
docs: address data-ax-bind limitations (#225) and reactive lifecycle guide (#224)

### DIFF
--- a/docs/src/content/docs/core-concepts/reactivity.md
+++ b/docs/src/content/docs/core-concepts/reactivity.md
@@ -1,7 +1,8 @@
 ---
+
 title: 'Reactive State'
 description: 'Deep dive into the Proxy-based reactive state and transparent dependency tracking in Avenx-JS.'
----
+-------------------------------------------------------------------------------------------------------------
 
 Avenx-JS implements a **transparent reactivity system** powered by JavaScript ES6 `Proxy`. There are no state setter functions or hooks required to update the user interface.
 
@@ -20,10 +21,82 @@ To maximize browser performance, state updates are batched together. If you chan
 
 ```javascript
 <action name="updateUser">
-  state.name = "John"; // Queued state.age = 30; // Queued (deduplicated) state.role = "admin"; // Queued (deduplicated)
+  state.name = "John"; // Queued
+  state.age = 30; // Queued (deduplicated)
+  state.role = "admin"; // Queued (deduplicated)
+
   // The DOM will render only ONCE at the end of the microtask queue.
 </action>
 ```
+
+## Lifecycle & Rendering Flow
+
+When reactive state changes, Avenx-JS processes the update through a scheduled rendering cycle. Updates are batched using the scheduler queue so that multiple state mutations can be processed efficiently within a single microtask.
+
+The update lifecycle follows this sequence:
+
+1. **State Mutation** - A value in the reactive `state` object is changed.
+2. **Proxy Interception** - The reactive Proxy intercepts the mutation and requests an update.
+3. **Scheduler Job Queue** - The component's update job is added to the scheduler queue. Multiple updates to the same component can be deduplicated and batched together.
+4. **Microtask Flush** - The scheduler processes the queued update jobs during the next microtask.
+5. **DOM Patch** - The component template is rendered and the DOM is patched with the updated values.
+6. **Slot Re-fill** - Component slots are re-filled with their updated content.
+7. **`onUpdate` Execution** - The component's `onUpdate` lifecycle callback runs after the update has completed.
+
+In summary:
+
+```text
+State Mutation
+    ↓
+Proxy Interception
+    ↓
+Scheduler Job Queue
+    ↓
+Microtask Flush
+    ↓
+DOM Patch
+    ↓
+Slot Re-fill
+    ↓
+onUpdate Execution
+```
+
+Because updates are queued and processed asynchronously, multiple synchronous state mutations can be grouped into a single rendering cycle instead of causing repeated DOM updates.
+
+### Troubleshooting `AVX_R11`
+
+The `AVX_R11` (`STATE_MUTATION_IN_UPDATE`) error occurs when state is mutated synchronously while Avenx-JS is already processing an update.
+
+This can happen when state is modified from code that runs as part of rendering, such as a computed property or template expression. Updating state during this phase can schedule another update before the current update has finished, potentially creating an infinite rendering loop.
+
+For example, avoid mutating state while computing a value:
+
+```javascript
+get displayName() {
+  state.name = state.name.trim(); // Avoid: mutates state during an update
+  return state.name;
+}
+```
+
+Instead, computed getters should derive and return values without modifying state:
+
+```javascript
+get displayName() {
+  return state.name.trim();
+}
+```
+
+If a state mutation must happen after the current update cycle has completed, defer it using `setTimeout`:
+
+```javascript
+setTimeout(() => {
+  state.name = state.name.trim();
+}, 0);
+```
+
+Deferring the mutation allows the current rendering cycle to finish before another state update is scheduled.
+
+When troubleshooting `AVX_R11`, check for state mutations inside computed getters, template expressions, or other code that executes during rendering. Prefer deriving values without side effects, and defer necessary state changes until after the current update cycle.
 
 ## Nested Reactivity
 

--- a/docs/src/content/docs/core-concepts/templates.md
+++ b/docs/src/content/docs/core-concepts/templates.md
@@ -1,19 +1,20 @@
 ---
+
 title: 'Templates & Slots'
 description: 'How slots, data-bindings, loops, and conditional templates work in Avenx-JS.'
----
+-------------------------------------------------------------------------------------------
 
 Avenx-JS provides a clean HTML-based template engine that supports text interpolation, HTML transclusion, two-way bindings, and loops.
 
 ## 1. Interpolation & HTML Escaping
 
-- **Escaped Text (`{{ expression }}`)**: Values are automatically passed through an HTML escaper to prevent Cross-Site Scripting (XSS).
+* **Escaped Text (`{{ expression }}`)**: Values are automatically passed through an HTML escaper to prevent Cross-Site Scripting (XSS).
 
 ```html
 <p>Hello {{ state.username }}</p>
 ```
 
-- **Raw HTML (`{{{ expression }}}`)**: Allows inserting unescaped HTML. Use this with caution.
+* **Raw HTML (`{{{ expression }}}`)**: Allows inserting unescaped HTML. Use this with caution.
 
 ```html
 <div>{{{ state.rawHtml }}}</div>
@@ -26,6 +27,20 @@ Form inputs (input, textarea, select) support two-way bindings via `data-ax-bind
 ```html
 <input type="text" data-ax-bind="state.username" />
 ```
+
+> **Warning:** `data-ax-bind` does not currently handle the boolean `checked` state of checkbox and radio inputs. Since the directive binds to the input's `value` and listens for `input` events, using it with checkboxes or radio buttons will not correctly update their checked state.
+
+For checkbox inputs, bind the `checked` attribute manually and listen for the `change` event:
+
+```html
+<input
+  type="checkbox"
+  checked="{{ state.checked }}"
+  @change="state.checked = event.target.checked"
+/>
+```
+
+This ensures that the checkbox's checked state is rendered from `state.checked` and that the state is updated whenever the checkbox changes.
 
 ## 3. Loops (`<@for>`)
 


### PR DESCRIPTION
## Summary

This PR addresses issues #225 and #224 by improving the Avenx-JS documentation for form bindings and the reactive update lifecycle.

## Changes for #225

* Documents the current `data-ax-bind` limitations for checkbox and radio inputs.
* Explains why binding to `value` and listening for `input` events does not correctly handle the boolean `checked` state.
* Adds an example showing how to manually bind checkbox state using the `checked` attribute and the `change` event.

## Changes for #224

* Adds a new "Lifecycle & Rendering Flow" section to the reactive state documentation.
* Documents the complete update sequence: State Mutation → Proxy Interception → Scheduler Job Queue → Microtask Flush → DOM Patch → Slot Re-fill → `onUpdate` execution.
* Explains the cause of the `AVX_R11` (`STATE_MUTATION_IN_UPDATE`) error.
* Adds troubleshooting guidance for preventing repeated or infinite update loops.
* Includes examples showing how to use computed getters without state mutations and how to defer necessary state updates using `setTimeout`.

Closes #225.
Closes #224.
