### PR TITLE
docs: document compiler lifecycle and limitations

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -1,7 +1,8 @@
 ---
+
 title: 'AvenxRouter & Guard API'
 description: 'API documentation for routing hooks, guards, navigation, and page lifecycle management.'
----
+------------------------------------------------------------------------------------------------------
 
 Classes responsible for navigation controls and route access authorization.
 
@@ -11,13 +12,13 @@ Created by calling `AvenxApp.initRouter()`.
 
 ### Methods
 
-- `navigate(hash)`: Programs a transition to another hash path.
+* `navigate(hash)`: Programs a transition to another hash path.
 
-```javascript
+```javascript id="8axpof"
 router.navigate('#/dashboard');
 ```
 
-- `destroy()`: Removes routing event listeners from the window.
+* `destroy()`: Removes routing event listeners from the window.
 
 <hr />
 
@@ -35,3 +36,41 @@ Called before navigating to a route.
 | `from` | `hash, page, params` | Current route details (or null if initial load). |
 
 **Returns:** `boolean` (true to allow, false to deny) or `string` (a redirect hash like `'#/login'`).
+
+## Compilation Lifecycle & Limits
+
+The Avenx compiler processes `.guard.js` files before including them in the compiled application. During compilation, ES module imports declared in guard files are stripped from the generated output.
+
+As a result, guard logic that depends directly on imported utilities or other imported declarations may cause runtime `ReferenceError` exceptions after compilation.
+
+For example, avoid relying on ES module imports directly inside a guard file:
+
+```javascript id="o83wbg"
+import { isAuthenticated } from './auth-utils.js';
+
+export default class AuthGuard extends AvenxGuard {
+  canActivate(to, from) {
+    return isAuthenticated();
+  }
+}
+```
+
+In this example, the `import` declaration may be removed during compilation, leaving `isAuthenticated` unavailable when the guard executes.
+
+Instead, move reusable logic into external utility files and expose it through supported application patterns. Utilities that are intentionally available globally can be referenced through properties on the `window` object:
+
+```javascript id="kiz3p7"
+export default class AuthGuard extends AvenxGuard {
+  canActivate(to, from) {
+    return window.AppUtils.isAuthenticated();
+  }
+}
+```
+
+When writing `.guard.js` files:
+
+* Do not rely on ES module imports being preserved in the compiled output.
+* Move reusable helper logic into external utility files.
+* Reference intentionally global utilities through properties on `window`.
+
+Understanding these compilation limits helps prevent missing imports and runtime `ReferenceError` exceptions caused by declarations being removed from the compiled output.

--- a/docs/src/content/docs/core-concepts/bridges.md
+++ b/docs/src/content/docs/core-concepts/bridges.md
@@ -93,3 +93,69 @@ export default {
 ```
 
 Plain object bridges provide a simpler alternative for small amounts of shared state and business logic. For consistency with the CLI-generated structure and Avenx's object-oriented model, the class-based `AvenxBridge` pattern is recommended as the primary approach.
+
+## Compilation Lifecycle & Limits
+
+The Avenx compiler processes `.bridge.js` files by extracting the bridge definition beginning at `export default`. Declarations placed before `export default`, such as local variables, constants, and helper functions, are not preserved in the compiled output.
+
+As a result, bridge code that depends on declarations defined above `export default` may cause runtime `ReferenceError` exceptions after compilation.
+
+For example, avoid defining local utilities before the bridge export:
+
+```javascript
+const defaultRole = 'visitor';
+
+function createGuestUser() {
+  return {
+    name: 'Guest',
+    role: defaultRole,
+  };
+}
+
+export default class AuthBridge extends AvenxBridge {
+  constructor() {
+    super();
+    this.user = createGuestUser();
+  }
+}
+```
+
+In this example, `defaultRole` and `createGuestUser` are declared before `export default` and may be removed during compilation, leaving the bridge with references to declarations that no longer exist.
+
+Instead, keep helper methods inside the exported bridge class when the logic belongs specifically to that bridge:
+
+```javascript
+export default class AuthBridge extends AvenxBridge {
+  constructor() {
+    super();
+    this.user = this.createGuestUser();
+  }
+
+  createGuestUser() {
+    return {
+      name: 'Guest',
+      role: 'visitor',
+    };
+  }
+}
+```
+
+For reusable utilities shared across multiple parts of an application, move the logic into external utility files and expose it through supported application patterns. Utilities that are intentionally available globally can also be referenced through properties on the `window` object.
+
+```javascript
+export default class AuthBridge extends AvenxBridge {
+  constructor() {
+    super();
+    this.user = window.AppUtils.createGuestUser();
+  }
+}
+```
+
+When writing `.bridge.js` files:
+
+* Do not rely on variables, constants, or helper functions declared before `export default`.
+* Keep bridge-specific helper methods inside the exported bridge class.
+* Move reusable logic into external utility files.
+* Reference intentionally global utilities through properties on `window`.
+
+Understanding these compilation limits helps prevent missing declarations and runtime `ReferenceError` exceptions caused by helper code being removed from the compiled output.

--- a/docs/src/content/docs/core-concepts/components.md
+++ b/docs/src/content/docs/core-concepts/components.md
@@ -1,7 +1,8 @@
 ---
+
 title: 'Component Structure'
 description: 'Understand how Avenx Single File Components are structured with template, script, and style tags.'
----
+----------------------------------------------------------------------------------------------------------------
 
 In Avenx-JS, a component is defined by two companion files in the same directory: `<name>.component.js` (logic and template) and `<name>.component.css` (styles).
 
@@ -9,11 +10,11 @@ In Avenx-JS, a component is defined by two companion files in the same directory
 
 The component file contains configuration tags at the top and the HTML template at the bottom. The configuration tags are parsed at compile-time and stripped out before outputting class declarations.
 
-- `<state key="val" />` - Declares the component's reactive local properties. Attributes are coerced to their corresponding JS types (numbers, booleans, arrays, or objects).
+* `<state key="val" />` - Declares the component's reactive local properties. Attributes are coerced to their corresponding JS types (numbers, booleans, arrays, or objects).
 
-- `<computed name="computedName" value="expression" />` - Defines computed getters. The value attribute accepts stringified JS expressions.
+* `<computed name="computedName" value="expression" />` - Defines computed getters. The value attribute accepts stringified JS expressions.
 
-- `<action name="methodName"> ... </action>` - Defines actions (methods) that have access to the component's state, computed attributes, and bridges in their execution scope.
+* `<action name="methodName"> ... </action>` - Defines actions (methods) that have access to the component's state, computed attributes, and bridges in their execution scope.
 
 ```html
 <!-- src/components/greet/greet.component.js -->
@@ -28,3 +29,49 @@ The component file contains configuration tags at the top and the HTML template 
   <button @click="login()">Log In</button>
 </div>
 ```
+
+## Compilation Lifecycle & Limits
+
+The Avenx compiler processes `.component.js` files by scanning for supported configuration tags and template content. During compilation, only `<state>`, `<computed>`, `<action>`, and template content are preserved and transformed into the generated component output.
+
+Standard JavaScript declarations written outside these supported tags, such as ES module imports, local variables, constants, and helper functions, are not preserved by the compiler. Code that depends on these declarations may therefore cause runtime `ReferenceError` exceptions after compilation.
+
+For example, avoid declaring imports or helper functions directly in a component file:
+
+```javascript
+import { formatName } from './utils.js';
+
+const defaultName = 'Guest';
+
+function getDisplayName(name) {
+  return formatName(name);
+}
+
+<state username="Guest" />
+
+<action name="updateName">
+  state.username = getDisplayName(defaultName);
+</action>
+```
+
+In this example, the `import`, `defaultName`, and `getDisplayName` declarations are outside the supported component tags and may be removed during compilation.
+
+Instead, keep component logic inside supported tags or move reusable utilities into external files that can be accessed through supported application patterns.
+
+For utilities that are intentionally exposed globally, reference them through the `window` object:
+
+```html
+<action name="updateName">
+  state.username = window.AppUtils.formatName(state.username);
+</action>
+```
+
+When writing `.component.js` files:
+
+* Keep reactive state declarations inside `<state>` tags.
+* Keep computed values inside `<computed>` tags.
+* Keep component methods and state mutations inside `<action>` tags.
+* Move reusable helper logic into external utility files.
+* Reference intentionally global utilities through properties on `window`.
+
+Understanding these compilation limits helps prevent missing imports, undefined helpers, and runtime `ReferenceError` exceptions caused by code being removed from the compiled output.


### PR DESCRIPTION
Update the documentation to explain Avenx compiler behavior and limitations across components, bridges, and router guards.

This change adds a "Compilation Lifecycle & Limits" section to the relevant documentation files and explains which declarations may be removed during compilation.

The documentation now warns developers about variables, helper functions, constants, and imports that may not be preserved in `.component.js`, `.bridge.js`, and `.guard.js` files.

It also provides examples of unsupported patterns and documents recommended workarounds, including keeping logic within supported component tags, defining bridge-specific helper methods inside exported bridge classes, moving reusable logic into external utility files, and referencing intentionally global utilities through the `window` object.

These changes help developers avoid runtime `ReferenceError` exceptions caused by declarations being removed from the compiled output.

Addresses #222.
