### PR TITLE
fix(cli): prevent generated file overwrites

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -66,6 +66,35 @@ class AvenxCLI {
   }
 
   /**
+   * Reports a CLI error and marks the process as failed.
+   * @param {string} message
+   */
+  fail(message) {
+    console.error(`\x1b[31m❌ Error: ${message}\x1b[0m`);
+    process.exitCode = 1;
+  }
+
+  /**
+   * Stops generation if any target path already exists.
+   * @param {string} type
+   * @param {string} name
+   * @param {string[]} targetPaths
+   * @returns {boolean}
+   */
+  abortIfGeneratedPathExists(type, name, targetPaths) {
+    const existingPath = targetPaths.find((targetPath) => fs.existsSync(targetPath));
+    if (!existingPath) {
+      return false;
+    }
+
+    this.fail(
+      `${type} '${name}' already exists at ${path.relative(this.baseDir, existingPath)}. ` +
+        'Remove the existing file or choose a different name.',
+    );
+    return true;
+  }
+
+  /**
    * Executes a given CLI command with provided arguments.
    * @param {string} command - The command to run (e.g., 'init', 'generate', 'build', 'serve', 'help').
    * @param {string[]} args - Additional arguments for the command.
@@ -178,7 +207,7 @@ class AvenxCLI {
    */
   generateBridge(name) {
     if (!name) {
-      console.error('❌ Error: Please provide a bridge name (e.g., avenx g bridge auth)');
+      this.fail('Please provide a bridge name (e.g., avenx g bridge auth)');
       return;
     }
 
@@ -192,8 +221,7 @@ class AvenxCLI {
 
     const bridgePath = path.join(globalDir, `${lowerName}.bridge.js`);
 
-    if (fs.existsSync(bridgePath)) {
-      console.error(`❌ Error: Bridge '${lowerName}' already exists.`);
+    if (this.abortIfGeneratedPathExists('Bridge', lowerName, [bridgePath])) {
       return;
     }
 
@@ -211,7 +239,7 @@ class AvenxCLI {
    */
   generateGuard(name) {
     if (!name) {
-      console.error('❌ Error: Please provide a guard name (e.g., avenx g guard auth)');
+      this.fail('Please provide a guard name (e.g., avenx g guard auth)');
       return;
     }
 
@@ -225,8 +253,7 @@ class AvenxCLI {
 
     const guardPath = path.join(guardDir, `${lowerName}.guard.js`);
 
-    if (fs.existsSync(guardPath)) {
-      console.error(`❌ Error: Guard '${lowerName}' already exists.`);
+    if (this.abortIfGeneratedPathExists('Guard', lowerName, [guardPath])) {
       return;
     }
 
@@ -244,7 +271,7 @@ class AvenxCLI {
    */
   generatePage(name) {
     if (!name) {
-      console.error('❌ Error: Please provide a page name (e.g., avenx g page home)');
+      this.fail('Please provide a page name (e.g., avenx g page home)');
       return;
     }
 
@@ -258,8 +285,7 @@ class AvenxCLI {
     const jsPath = path.join(pageDir, `${lowerName}.page.js`);
     const cssPath = path.join(pageDir, `${lowerName}.page.css`);
 
-    if (fs.existsSync(jsPath)) {
-      console.error(`❌ Error: Page '${lowerName}' already exists.`);
+    if (this.abortIfGeneratedPathExists('Page', lowerName, [jsPath, cssPath])) {
       return;
     }
 
@@ -279,7 +305,7 @@ class AvenxCLI {
    */
   generateComponent(name) {
     if (!name) {
-      console.error('❌ Error: Please provide a component name (e.g., avenx g my-component)');
+      this.fail('Please provide a component name (e.g., avenx g my-component)');
       return;
     }
 
@@ -287,8 +313,7 @@ class AvenxCLI {
 
     const compDir = path.join(this.baseDir, 'src/components', lowerName);
 
-    if (fs.existsSync(compDir)) {
-      console.error(`❌ Error: Component '${lowerName}' already exists.`);
+    if (this.abortIfGeneratedPathExists('Component', lowerName, [compDir])) {
       return;
     }
 
@@ -572,4 +597,3 @@ if (command === '-v' || command === '--version') {
   const cli = new AvenxCLI();
   cli.run(command, args);
 }
-

--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -1,10 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 const TEST_DIR = path.join(__dirname, 'test-project');
 const BIN_PATH = path.join(__dirname, '../../bin/avenx.js');
+
+/**
+ *
+ * @param {string[]} args
+ * @returns {import('child_process').SpawnSyncReturns<string>}
+ */
+function runCli(args) {
+  return spawnSync(process.execPath, [BIN_PATH, ...args], {
+    cwd: TEST_DIR,
+    encoding: 'utf8',
+  });
+}
 
 /**
  *
@@ -99,6 +111,19 @@ function runTest() {
     );
     assert.ok(defaultBoxJs.includes('DefaultBox Component'), 'Should contain default title');
 
+    const duplicateComponentResult = runCli(['generate', 'component', 'default-box']);
+    assert.strictEqual(duplicateComponentResult.status, 1, 'Duplicate component generation should fail');
+    assert.match(
+      duplicateComponentResult.stderr,
+      /Component 'default-box' already exists/,
+      'Duplicate component generation should explain the existing path',
+    );
+    assert.strictEqual(
+      fs.readFileSync(path.join(TEST_DIR, 'src/components/default-box/default-box.component.js'), 'utf-8'),
+      defaultBoxJs,
+      'Duplicate component generation should not overwrite existing component files',
+    );
+
     console.log('🧪 Testing avenx generate component with camelCase name...');
     execSync(`node ${BIN_PATH} generate component UserProfile`, { cwd: TEST_DIR });
     const userProfileJs = fs.readFileSync(
@@ -176,6 +201,25 @@ function runTest() {
       '/* CUSTOM STRUCTURED CSS */',
       'Should prioritize custom structured CSS template',
     );
+
+    console.log('🧪 Testing avenx generate page does not overwrite partial existing files...');
+    const pageCssPath = path.join(TEST_DIR, 'src/pages/reports.page.css');
+    const pageJsPath = path.join(TEST_DIR, 'src/pages/reports.page.js');
+    fs.writeFileSync(pageCssPath, '/* keep existing page styles */');
+
+    const duplicatePageResult = runCli(['generate', 'page', 'reports']);
+    assert.strictEqual(duplicatePageResult.status, 1, 'Page generation should fail when any target file exists');
+    assert.match(
+      duplicatePageResult.stderr,
+      /Page 'reports' already exists/,
+      'Page generation should explain which page already exists',
+    );
+    assert.strictEqual(
+      fs.readFileSync(pageCssPath, 'utf-8'),
+      '/* keep existing page styles */',
+      'Page generation should not overwrite existing CSS when JS is missing',
+    );
+    assert.ok(!fs.existsSync(pageJsPath), 'Page generation should not create JS after detecting an existing CSS file');
 
     console.log('✅ Custom project-level templates tests passed!');
   } catch (error) {


### PR DESCRIPTION
## Summary

- add a shared generated-path guard for CLI scaffolds
- fail duplicate or partial scaffold generation with exit code 1 before writing files
- cover duplicate component and partial page CSS cases in the system CLI test

## Why

`avenx generate page reports` could overwrite `src/pages/reports.page.css` when that CSS file already existed but the matching JS file did not. Duplicate component generation also reported an error while still exiting successfully.

Fixes #242.

## Validation

- `npm run test:system` — passed
- `npm test` — passed
- `npm run lint` — passed

## Notes

`npm test` emits existing `MODULE_TYPELESS_PACKAGE_JSON` warnings in several unrelated tests.