### PR TITLE
fix: prevent double-wrapping reactive proxies

### DIFF
--- a/lib/core/reactive/createState.js
+++ b/lib/core/reactive/createState.js
@@ -1,4 +1,4 @@
-import { ProxyHandlerFactory } from './proxyHandler.js';
+import { ProxyHandlerFactory, IS_REACTIVE_PROXY } from './proxyHandler.js';
 
 /**
  * Factory for creating reactive state objects.
@@ -19,6 +19,9 @@ export class StateFactory {
    * @returns {Proxy} The reactive state proxy.
    */
   create(initialState = {}, options = {}) {
+    if (initialState && initialState[IS_REACTIVE_PROXY]) {
+      return initialState;
+    }
     const handlerFactory = new this.handlerFactoryClass(options);
     return new Proxy(initialState, handlerFactory.create());
   }

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -7,6 +7,7 @@
 import { track, trigger, parentMap, AvenxWatcher } from './watcher.js';
 
 export const RAW_SYMBOL = Symbol('raw');
+export const IS_REACTIVE_PROXY = Symbol("avenx.reactive.proxy");
 
 const mutatingArrayMethods = new Set([
   'push',
@@ -142,6 +143,9 @@ export class ProxyHandlerFactory {
    * @returns {any}
    */
   get(target, key, receiver) {
+    if (key === IS_REACTIVE_PROXY) {
+      return true;
+    }
     if (key === RAW_SYMBOL) {
       return target;
     }
@@ -220,11 +224,17 @@ export class ProxyHandlerFactory {
    * @private
    */
   getOrCreateProxy(val) {
+    if (val && val[IS_REACTIVE_PROXY]) {
+      return val;
+    }
     if (this.proxyCache.has(val)) {
       return this.proxyCache.get(val);
     }
     const handler = {
       get: (target, key, receiver) => {
+        if (key === IS_REACTIVE_PROXY) {
+          return true;
+        }
         if (key === RAW_SYMBOL) {
           return target;
         }

--- a/test/unit/reactivity.test.js
+++ b/test/unit/reactivity.test.js
@@ -293,6 +293,33 @@ function testBuiltinsAreNotProxied() {
   console.log('  ✅ Built-ins are not proxied tests passed!');
 }
 
+/**
+ * Verifies that assigning a reactive proxy to another state property doesn't create a double proxy layer.
+ */
+function testDoubleWrappingPrevention() {
+  console.log('🧪 Testing prevention of double wrapping for reactive proxies...');
+  
+  let changeCount = 0;
+  const state = new StateFactory().create({
+    child1: { a: 1 },
+    child2: { b: 2 }
+  }, {
+    onChange: () => changeCount++
+  });
+
+  state.child1 = state.child2;
+  
+  assert.strictEqual(state.child1, state.child2, 'The proxies should be identical (no double wrapping)');
+  
+  changeCount = 0;
+  
+  state.child1.b = 3;
+  assert.strictEqual(changeCount, 1, 'Mutating the assigned proxy should trigger only 1 update, not 2');
+  assert.strictEqual(state.child2.b, 3, 'Mutation should reflect in the original proxy');
+
+  console.log('  ✅ Double wrapping prevention tests passed!');
+}
+
 (async () => {
   try {
     testIsReactiveTarget();
@@ -303,6 +330,7 @@ function testBuiltinsAreNotProxied() {
     testSymbolKeysDoNotTriggerUpdates();
     await testBridgeDeepReactivity();
     testBuiltinsAreNotProxied();
+    testDoubleWrappingPrevention();
     console.log('✅ All reactivity tests passed!');
   } catch (error) {
     console.error('❌ Reactivity tests failed!');


### PR DESCRIPTION
## Summary

This PR fixes a reactivity issue where assigning an already reactive proxy to another state property caused the value to be wrapped in an additional Proxy layer.

## Changes

- Added an internal `IS_REACTIVE_PROXY` symbol marker.
- Updated proxy `get` traps to expose the marker.
- Updated proxy creation logic to return existing reactive proxies directly.
- Added regression coverage for assigning one reactive proxy to another state property.
- Verified that mutations trigger updates only once.

## Test
node test/unit/reactivity.test.js successful.