### PR TITLE
docs: fix AvenxBridge import path in Shared State & Bridges documenta…

### DIFF
--- a/docs/src/content/docs/core-concepts/bridges.md
+++ b/docs/src/content/docs/core-concepts/bridges.md
@@ -18,7 +18,7 @@ This creates a file in `src/global/auth.bridge.js`. The generated bridge uses th
 
 ```javascript
 // src/global/auth.bridge.js
-import { AvenxBridge } from 'avenx';
+import { AvenxBridge } from 'avenx-core/runtime';
 
 export default class AuthBridge extends AvenxBridge {
   constructor() {


### PR DESCRIPTION
## Description

This PR fixes the incorrect import path in the Shared State & Bridges documentation.

### Changes

Updated the import statement from:

```js
import { AvenxBridge } from 'avenx';
```

to

```js
import { AvenxBridge } from 'avenx-core/runtime';
```

Closes #269