### PR TITLE
docs: fix scoped css attribute syntax

### DIFF
--- a/docs/src/content/docs/core-concepts/styling.md
+++ b/docs/src/content/docs/core-concepts/styling.md
@@ -23,7 +23,7 @@ CSS rules defined inside `<@css>` use named blocks without dot prefixes. The com
 </@css>
 ```
 
-<div @css="card">
+<div @css card>
     <!-- Component Content -->
 </div>
 


### PR DESCRIPTION
## Summary
- update the Scoped & Global CSS docs to use the compiler-supported @css blockName syntax
- remove the quoted @css="..." form from the example

## Validation
- Checked docs/src/content/docs/core-concepts/styling.md for @css= occurrences

Fixes #270