### PR TITLE
docs: fix html escaper example output

### DIFF
--- a/docs/src/content/docs/api-reference/utils.md
+++ b/docs/src/content/docs/api-reference/utils.md
@@ -28,5 +28,5 @@ Internal utility class providing character replacement mappings to prevent code 
 ```javascript
 const escaper = new HtmlEscaper();
 escaper.escape('<h1>Text</h1>');
-// Returns: <h1>Text</h1>
+// Returns: &lt;h1&gt;Text&lt;/h1&gt;
 ```


### PR DESCRIPTION
## Summary
- correct the HtmlEscaper.escape() example output to show escaped HTML entities
- keep the API reference example aligned with the utility's XSS-prevention behavior

## Validation
- Checked docs/src/content/docs/api-reference/utils.md for the updated Returns line

Fixes #268