### PR TITLE
docs: add configuration guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
 						{ label: 'Installation', slug: 'getting-started/install' },
 						{ label: 'Quick Start Tutorial', slug: 'getting-started/quickstart' },
 						{ label: 'Project Structure', slug: 'getting-started/structure' },
+						{ label: 'Configuration', slug: 'getting-started/configuration' },
 					],
 				},
 				{

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -1,0 +1,46 @@
+---
+title: 'Configuration'
+description: 'Configure Avenx-JS project paths, template overrides, and the local development server.'
+---
+
+Avenx-JS reads optional project settings from `avenx.config.json` in the project root. When the file is missing, the CLI uses the default values below.
+
+```json
+{
+  "srcDir": "src",
+  "distDir": "dist",
+  "templatesDir": ".avenxtemplates",
+  "server": {
+    "port": 3000,
+    "host": "localhost"
+  }
+}
+```
+
+## Options
+
+| Option | Type | Default | Rules |
+| ------ | ---- | ------- | ----- |
+| `srcDir` | `string` | `"src"` | Non-empty relative path to application source files. |
+| `distDir` | `string` | `"dist"` | Non-empty relative path where compiled output is written. |
+| `templatesDir` | `string` | `".avenxtemplates"` | Non-empty relative path for local generator template overrides. |
+| `server.port` | `number` | `3000` | Valid TCP port from `0` to `65535`. |
+| `server.host` | `string` | `"localhost"` | Non-empty host name or address for the local dev server. |
+
+Path options must be relative paths. Absolute paths are rejected during configuration loading.
+
+## Example
+
+```json
+{
+  "srcDir": "app",
+  "distDir": "public/build",
+  "templatesDir": ".avenxtemplates",
+  "server": {
+    "port": 5173,
+    "host": "0.0.0.0"
+  }
+}
+```
+
+The configuration is merged with the defaults, so you can override only the settings your project needs.


### PR DESCRIPTION
## Summary
- add a Getting Started page for avenx.config.json
- document defaults, types, and validation rules for srcDir, distDir, templatesDir, server.port, and server.host
- register the page in the Starlight sidebar

## Validation
- node --check docs/astro.config.mjs
- checked the new guide includes all required config keys and constraints

Fixes #271