### PR TITLE
docs: add JSDoc annotations and usage examples for AvenxLogger API #293

### DIFF
--- a/lib/core/runtime/AvenxLogger.js
+++ b/lib/core/runtime/AvenxLogger.js
@@ -51,8 +51,63 @@ export const consoleTransport = {
 };
 
 /**
- * Central logger class for Avenx-JS framework.
+ * @typedef {Object} LoggingConfig
+ * @property {('trace'|'debug'|'info'|'warn'|'error'|'fatal')} [level='info'] - The minimum severity level to output.
+ * @property {boolean} [silent=false] - Global silence setting. If true, suppresses all logging.
+ * @property {Function} [formatter=defaultFormatter] - Custom formatting callback function. Receives (level, args).
+ * @property {Array<Object|Function>} [transports=[consoleTransport]] - Collection of transport targets.
  */
+
+/**
+ * Central logger class for Avenx-JS framework.
+ * 
+ * @example
+ * // 1. Basic initialization during application setup:
+ * const app = new AvenxApp({
+ *   logging: {
+ *     level: 'debug',
+ *     silent: false
+ *   }
+ * });
+ * 
+ * @example
+ * // 2. Usage inside component methods:
+ * export default {
+ *   name: 'TargetSyncComponent',
+ *   methods: {
+ *     async syncDatabase(targets) {
+ *       this.logger.info('Starting celestial synchronization...', { count: targets.length });
+ *       try {
+ *         if (!targets || targets.length === 0) {
+ *           this.logger.warn('Sync skipped: list is empty.');
+ *           return;
+ *         }
+ *         this.logger.debug('Processing batch.', { sampleId: targets[0].id });
+ *       } catch (error) {
+ *         this.logger.error('Database sync failed.', { error: error.message });
+ *       }
+ *     }
+ *   }
+ * };
+ * 
+ * @example
+ * // 3. Registering a Custom Formatter:
+ * const customFormatter = (level, args) => {
+ *   return [`[MY-APP] [${level.toUpperCase()}]:`, ...args];
+ * };
+ * const loggerWithFormatter = new AvenxLogger({ formatter: customFormatter });
+ * 
+ * @example
+ * // 4. Registering a Custom Transport:
+ * const fileTransport = {
+ *   log(level, formattedArgs, rawArgs) {
+ *     // Append custom streaming/file logic here
+ *     fs.appendFileSync('./app.log', formattedArgs.join(' ') + '\n');
+ *   }
+ * };
+ * const loggerWithTransport = new AvenxLogger({ transports: [fileTransport] });
+ */
+
 export class AvenxLogger {
   /**
    * Creates an instance of AvenxLogger.


### PR DESCRIPTION
## Description
This PR resolves #293 by adding comprehensive JSDoc api-reference documentation to the built-in `AvenxLogger` utility layer located at `lib/core/runtime/AvenxLogger.js`. 

## Changes Made
* **Configuration Specification:** Introduced a clear `@typedef {Object} LoggingConfig` block detailing all available core configuration options (`level`, `silent`, `formatter`, and `transports`).
* **Component Usage Architecture:** Included detailed inline `@example` structures showcasing how to invoke log statements across different contexts inside standard component lifecycle methods.
* **Extensibility Examples:** Embedded code architecture blocks illustrating how developers can write and register custom log message formatters and downstream pipeline transports (e.g., local file streaming).

## Testing Checklist
1. [x] Inspected modified source file to confirm structural JSDoc tag properties match standard parser requirements.
2. [x] Validated that all parameters on exposed methods (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) map cleanly to incoming contextual payloads without breaking baseline types.