### PR TITLE
feat(cli): output build execution duration

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,6 +6,7 @@ const findProjectRoot = loadConfig.findProjectRoot;
 import StyleProcessor from './compiler/StyleProcessor.js';
 import ComponentParser from './compiler/ComponentParser.js';
 import { logger } from './core/runtime/AvenxLogger.js';
+import { performance } from 'perf_hooks';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -110,7 +111,7 @@ class AvenxCompiler {
    */
   build() {
     logger.info('--- Avenx-JS Compiler ---');
-
+    const startTime = performance.now();
     if (!fs.existsSync(this.srcDir)) {
       logger.error(`❌ ${formatCompilerError('AVX_C02', this.srcDir)}`);
       return;
@@ -154,6 +155,8 @@ class AvenxCompiler {
 
     logger.info('-----------------------');
     logger.info(`\nBuild erfolgreich: ${this.distDir}/bundle.js & ${this.distDir}/bundle.css`);
+    const endTime = performance.now();
+    logger.info(`Build completed in ${Math.round(endTime - startTime)} ms`);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR adds execution duration logging for compilation builds.

### Changes
- Added `performance.now()` timing in the compiler.
- Logs the total build duration after a successful compilation.
- Keeps the implementation minimal and consistent with the existing CLI logging.

### Testing

- Verified the project builds successfully.
- Confirmed the CLI outputs:

```text
Build completed in X ms
```


Fixes #256