### PR TITLE
docs: standardize guard redirect paths to use hash prefix (#/login)

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -57,7 +57,7 @@ This lifecycle method is executed prior to entering a route.
 * **Return Values:** The method can return a `boolean`, a `string` (redirect path), or a `Promise` resolving to either:
   * `true`: Allows the navigation to proceed.
   * `false`: Cancels the navigation.
-  * `string`: Redirects the user to the specified path/hash (e.g., `'/login'`).
+  * `string`: Redirects the user to the specified path/hash (e.g., `'#/login'`).
 
 #### Sample Guard Implementation
 
@@ -70,9 +70,14 @@ export class AuthGuard extends AvenxGuard {
     
     if (!isAuthenticated) {
       // Redirect unauthenticated users to the login hash
-      return '/login'; 
+      return '#/login'; 
     }
     
     return true; // Allow navigation
   }
 }
+```
+
+:::warning
+Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
+:::

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -67,6 +67,10 @@ export default class AuthGuard extends AvenxGuard {
 }
 ```
 
+:::warning
+Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
+:::
+
 Map guards to routes in your application router initialization:
 
 ```javascript


### PR DESCRIPTION
Fix for #309 

The route guard documentation contained conflicting redirect examples - `routing.md` showed `#/login` while `router-guard.md` showed `/login`. Returning a path without the `#` prefix bypasses configured router prefixes, leading to broken navigation in apps served with custom prefixes.

Changes:
- Updated `router-guard.md` to use `#/login` in the sample guard and description
- Added warning box to both `routing.md` and `router-guard.md` explaining that redirect paths must start with `#` to respect prefix/namespace settings