### PR TITLE
docs: document the Sanitizer utility class

### DIFF
--- a/docs/src/content/docs/api-reference/utils.md
+++ b/docs/src/content/docs/api-reference/utils.md
@@ -30,3 +30,46 @@ const escaper = new HtmlEscaper();
 escaper.escape('<h1>Text</h1>');
 // Returns: &lt;h1&gt;Text&lt;/h1&gt;
 ```
+
+## 4. `Sanitizer`
+
+A utility class used to escape and clean up templates and dynamic HTML tags by stripping dangerous elements/attributes while preserving safe markup.
+
+### Constructor
+
+```javascript
+import { Sanitizer } from 'avenx-core/runtime';
+
+const sanitizer = new Sanitizer(config);
+```
+
+- **`config`** *(optional)*: An object to customize the allowed HTML tags and attributes.
+  - **`allowedTags`** *(string[])*: Custom array of allowed tag names. Defaults to a standard safe set of elements (e.g., `div`, `span`, `p`, `a`, `img`, etc.).
+  - **`allowedAttributes`** *(Record<string, string[]>)*: Custom mapping of tag names to allowed attribute arrays. Use `*` to specify attributes allowed globally on all elements.
+
+### Methods
+
+#### `sanitize(html)`
+
+Sanitizes an input string containing HTML by filtering it against the allowed tags and attributes configuration. Dangerous elements (like `<script>`, `<style>`, `<iframe>`, etc.) and unsafe URL protocols (like `javascript:`, `data:` except for safe image data) are stripped.
+
+- **Parameters:**
+  - `html` *(any)*: The raw content to sanitize (coerced to a string).
+- **Returns:**
+  - `string`: The sanitized, safe HTML string.
+
+### Example
+
+```javascript
+import { Sanitizer } from 'avenx-core/runtime';
+
+const sanitizer = new Sanitizer();
+
+// Dangerous tags like <script> are stripped, and unsafe protocols on attributes are removed
+const dirtyHtml = '<div>Hello <script>alert("xss")</script> <a href="javascript:alert(1)">World</a></div>';
+const cleanHtml = sanitizer.sanitize(dirtyHtml);
+
+console.log(cleanHtml);
+// Output: <div>Hello  <a>World</a></div>
+```
+


### PR DESCRIPTION
Adds a new section to the Utility Functions API reference guide (docs/src/content/docs/api-reference/utils.md) documenting the Sanitizer class.