### PR TITLE
feat(core): expose parent component reference

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -34,6 +34,11 @@ export class AvenxComponent {
     props: Record<string, any>;
 
     /**
+     * The component instance that mounted this component, or null for root components.
+     */
+    readonly $parent: AvenxComponent | null;
+
+    /**
      * The active route details.
      */
     readonly $route: { hash: string; page: string; params: Record<string, any> };
@@ -534,4 +539,3 @@ export class AvenxSandbox {
         trigger(selectorOrElement: any, eventName: string, eventData?: Record<string, any>): void;
     };
 }
-

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -124,6 +124,9 @@ export class AvenxComponent {
    * @param {object} [props] - Component properties.
    */
   constructor(initialState = {}, computed = {}, bridges = {}, template = '', methods = {}, props = {}) {
+    /** @type {AvenxComponent|null} */
+    this.$parent = null;
+
     this.#template = processBindDirectives(template);
     this.#bridges = bridges;
     this.#computed = new ComputedRegistry(computed);

--- a/lib/core/runtime/AvenxPage.js
+++ b/lib/core/runtime/AvenxPage.js
@@ -104,6 +104,7 @@ export class AvenxPage extends AvenxComponent {
           }
         } else {
           const compInstance = new CompClass(this._getBridges(), props);
+          compInstance.$parent = this;
           compInstance.mount(el);
           this.#childComponents.set(el, compInstance);
         }

--- a/test/integration/child_component_lifecycle.test.js
+++ b/test/integration/child_component_lifecycle.test.js
@@ -467,6 +467,7 @@ global.Node = {
 
     // 1. Initial Page Mount
     const parentPage = new ParentPage({}, componentRegistry);
+    assert.strictEqual(parentPage.$parent, null, 'Root component should not have a parent');
     parentPage.mount(testRootElement);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -476,6 +477,7 @@ global.Node = {
 
     const firstChildInstance = lastChildInstance;
     assert.ok(firstChildInstance, 'Child instance should be cached');
+    assert.strictEqual(firstChildInstance.$parent, parentPage, 'Child should reference its parent component');
 
     // Mutate child component local state directly to verify it persists
     firstChildInstance.state.childVal = 'mutatedLocalState';


### PR DESCRIPTION
Closes #255.

A child component now gets the `AvenxPage` instance that created it through `this.$parent`. Root components keep `$parent` as `null`. The reference is assigned before mounting, so it is available to mount hooks.

I also added the public TypeScript declaration and covered both root and child behavior in the lifecycle integration test.

Tests:
- `npm test`
- `npm run lint`