### PR TITLE
docs: standardize route guard redirect examples on hash prefix

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -57,7 +57,11 @@ This lifecycle method is executed prior to entering a route.
 * **Return Values:** The method can return a `boolean`, a `string` (redirect path), or a `Promise` resolving to either:
   * `true`: Allows the navigation to proceed.
   * `false`: Cancels the navigation.
-  * `string`: Redirects the user to the specified path/hash (e.g., `'/login'`).
+  * `string`: Redirects the user to the specified path/hash (e.g., `'#/login'`).
+
+:::caution
+Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
+:::
 
 #### Sample Guard Implementation
 
@@ -70,7 +74,7 @@ export class AuthGuard extends AvenxGuard {
     
     if (!isAuthenticated) {
       // Redirect unauthenticated users to the login hash
-      return '/login'; 
+      return '#/login'; 
     }
     
     return true; // Allow navigation

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -67,6 +67,10 @@ export default class AuthGuard extends AvenxGuard {
 }
 ```
 
+:::caution
+Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
+:::
+
 Map guards to routes in your application router initialization:
 
 ```javascript


### PR DESCRIPTION
Closes #309.

The two docs pages disagreed on how redirect paths should look: router-guard.md had `return '/login'` while routing.md had `return '#/login'`. Only the hash version actually works right with `prefix`/namespace resolution in `AvenxRouter.navigate`, so I made router-guard.md match routing.md and added a quick caution callout to both pages so people don't get bitten by this again.

Docs only change, no code touched.