### PR TITLE
docs: document AvenxComponent setProps

### DIFF
--- a/docs/src/content/docs/api-reference/component.md
+++ b/docs/src/content/docs/api-reference/component.md
@@ -61,6 +61,24 @@ const btn = new ButtonComponent();
 btn.mount('#button-container');
 ```
 
+### `setProps(newProps)`
+
+Updates the component's reactive `props` to match `newProps`. New or changed properties are applied, and properties omitted from `newProps` are removed. These reactive changes trigger the update scheduler, which queues a DOM patch with the component's updated props.
+
+| Param      | Type     | Description                              |
+| ---------- | -------- | ---------------------------------------- |
+| `newProps` | `object` | The complete set of props to apply.      |
+
+```javascript
+const btn = new ButtonComponent();
+btn.mount('#button-container');
+
+btn.setProps({
+  label: 'Saving...',
+  disabled: true,
+});
+```
+
 ### `unmount()`
 
 Cleans up event listeners and empties the mounted container.


### PR DESCRIPTION
## Summary

Documents the public `AvenxComponent.setProps(newProps)` method in the Component API reference.

This update:

- Adds the method signature and parameter description
- Explains how `setProps()` updates reactive props
- Documents the removal of props omitted from `newProps`
- Explains how prop changes trigger the update scheduler and queue a DOM patch
- Includes a basic component instance usage example

## Testing

- Verified the documentation against the runtime implementation
- Ran `git diff --check` successfully
- Documentation-only change; no runtime behavior was modified

Closes #308