### PR TITLE
Document 'mount' method in app API reference

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -51,3 +51,12 @@ Registers a global reactive state bridge. The bridge will be initialized and exp
 ```javascript
 app.registerBridge('AuthBridge', { isLoggedIn: false });
 ```
+
+### `mount(name, targetSelector)`
+
+Mounts the initialized application onto the specified DOM element, triggering the component lifecycle and bootstrapping the template rendering.
+
+```javascript
+app.mount('#app');
+```
+


### PR DESCRIPTION
Added documentation for the 'mount' method in the API reference, including:
- Method signature: `mount(name, targetSelector)`
- Description of the lifecycle and bootstrapping behavior
- Usage example (`app.mount('#app')`)