### PR TITLE
docs: fixed jsdoc example for logger in AvenxLogger.js

### DIFF
--- a/lib/core/runtime/AvenxLogger.js
+++ b/lib/core/runtime/AvenxLogger.js
@@ -70,19 +70,21 @@ export const consoleTransport = {
  * });
  * @example
  * // 2. Usage inside component methods:
+ * import { logger } from 'avenx-core/runtime';
+ *
  * export default {
  *   name: 'TargetSyncComponent',
  *   methods: {
  *     async syncDatabase(targets) {
- *       this.logger.info('Starting celestial synchronization...', { count: targets.length });
+ *       logger.info('Starting celestial synchronization...', { count: targets.length });
  *       try {
  *         if (!targets || targets.length === 0) {
- *           this.logger.warn('Sync skipped: list is empty.');
+ *           logger.warn('Sync skipped: list is empty.');
  *           return;
  *         }
- *         this.logger.debug('Processing batch.', { sampleId: targets[0].id });
+ *         logger.debug('Processing batch.', { sampleId: targets[0].id });
  *       } catch (error) {
- *         this.logger.error('Database sync failed.', { error: error.message });
+ *         logger.error('Database sync failed.', { error: error.message });
  *       }
  *     }
  *   }


### PR DESCRIPTION
Fix for #306 

- Modified `@example` section in `lib/core/runtime/AvenxLogger.js` and replaced `this.logger.info(...)` with `logger.info(...)`.
- Added `import` statement for the global `logger` in the example code.