### PR TITLE
docs(logger): fix JSDoc example to use static logger import (#306)

### DIFF
--- a/lib/core/runtime/AvenxLogger.js
+++ b/lib/core/runtime/AvenxLogger.js
@@ -70,19 +70,23 @@ export const consoleTransport = {
  * });
  * @example
  * // 2. Usage inside component methods:
+ * // Import the shared logger from the runtime entry point — component
+ * // instances do not expose `this.logger`.
+ * import { logger } from 'avenx-core/runtime';
+ *
  * export default {
  *   name: 'TargetSyncComponent',
  *   methods: {
  *     async syncDatabase(targets) {
- *       this.logger.info('Starting celestial synchronization...', { count: targets.length });
+ *       logger.info('Starting celestial synchronization...', { count: targets.length });
  *       try {
  *         if (!targets || targets.length === 0) {
- *           this.logger.warn('Sync skipped: list is empty.');
+ *           logger.warn('Sync skipped: list is empty.');
  *           return;
  *         }
- *         this.logger.debug('Processing batch.', { sampleId: targets[0].id });
+ *         logger.debug('Processing batch.', { sampleId: targets[0].id });
  *       } catch (error) {
- *         this.logger.error('Database sync failed.', { error: error.message });
+ *         logger.error('Database sync failed.', { error: error.message });
  *       }
  *     }
  *   }


### PR DESCRIPTION
Closes #306.

## Problem
The component-usage `@example` in `lib/core/runtime/AvenxLogger.js` shows `this.logger.info(...)` / `this.logger.warn(...)`. But `AvenxComponent` instances don't expose a `logger` on `this`, so following the example throws a `TypeError`.

## Fix
Update the `@example` to import the shared `logger` from `avenx-core/runtime` and call it directly. This matches:
- how `logger` is actually consumed in the codebase (`lib/compiler.js`, `lib/config.js`),
- the public export (`logger` is re-exported from `avenx-core/runtime` via `lib/core/index.js`),
- the project's own README import convention (`import { ... } from 'avenx-core/runtime'`).

## Acceptance criteria
- ✅ `this.logger.*` → `logger.*` in the `@example`
- ✅ Import statement for the global `logger` shown in the example

## Testing
`npx eslint lib/core/runtime/AvenxLogger.js` → passes (exit 0). Documentation-only change (JSDoc comment); no runtime impact.