### PR TITLE
Updated sanitize.js by adding warnSanitizedTag() and warnSanitizedAttribute()

### DIFF
--- a/lib/core/security/sanitize.js
+++ b/lib/core/security/sanitize.js
@@ -1,4 +1,18 @@
 /**
+ * Logs a warning whenever elements have their content stripped.
+*/
+function warnSanitizedTag(value) {
+  console.warn(`[Avenx Security warning] Sanitized tag "<${value}>" when stripping content.`);
+}
+
+/**
+ * Logs a warning whenever an attribute has its content stripped.
+*/
+function warnSanitizedAttribute(value) {
+  console.warn(`[Avenx Security warning] Sanitized attribute "${value}" when stripping content.`);
+}
+
+/**
  * Safe allowed tags by default.
  */
 const DEFAULT_ALLOWED_TAGS = new Set([
@@ -225,7 +239,13 @@ export class Sanitizer {
       return this._sanitizeNode(doc.body);
     } else {
       // Fallback if no DOM parsing environment is available: strip all HTML tags
-      return htmlString.replace(/<\/?[^>]+(>|$)/g, '');
+      return htmlString.replace(/<\/?[^>]+(>|$)/g, (match) => {
+        const tagMatch = match.match(/<\/?([a-zA-Z0-9:-]+)/);
+        if (tagMatch) {
+          warnSanitizedTag(tagMatch[1].toLowerCase());
+        }
+        return '';
+      });
     }
   }
 
@@ -274,6 +294,8 @@ export class Sanitizer {
                 }
               }
               result += ` ${lowerAttrName}="${escapeAttrValue(attrValue)}"`;
+            } else{
+              warnSanitizedAttribute(lowerAttrName);
             }
           }
 
@@ -287,6 +309,8 @@ export class Sanitizer {
           }
         } else {
           // Tag is not allowed.
+          warnSanitizedTag(tagName);
+
           // If the tag content should be stripped completely, do not process children.
           if (!STRIP_CONTENT_TAGS.has(tagName)) {
             // Keep children but discard the tag


### PR DESCRIPTION
In the lib/core/security/sanitizer.js, I have 
refactored: the split warnSanitized into specific tag and attribute helpers

- Split warnSanitized into warnSanitizedTag and warnSanitizedAttribute
- Updated JSDoc comments for consistency

Closes #317