### PR TITLE
feat: enforce minimum supported node version for compilation

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -15,6 +15,27 @@ const findProjectRoot = loadConfig.findProjectRoot;
 
 const [, , command, ...args] = process.argv;
 
+const MIN_NODE_VERSION = [18, 0, 0];
+const current = process.versions.node
+  .split(".")
+  .map(Number);
+
+function compareVersions(current, required) {
+  for (let i = 0; i < required.length; i++) {
+    if (current[i] > required[i]) return true;
+    if (current[i] < required[i]) return false;
+  }
+  return true;
+}
+
+if (!compareVersions(current, MIN_NODE_VERSION)) {
+  console.error(
+    `Avenx requires Node.js ${MIN_NODE_VERSION.join(".")} or later.\n` +
+    `Current version: ${process.versions.node}`
+  );
+  process.exit(1);
+}
+
 /**
  * Helper to parse input names into PascalCase and kebab-case.
  * Supports camelCase, kebab-case, snake_case, and PascalCase.

--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -17,7 +17,7 @@ const [, , command, ...args] = process.argv;
 
 const MIN_NODE_VERSION = [18, 0, 0];
 const current = process.versions.node
-  .split(".")
+  .split('.')
   .map(Number);
 
 function compareVersions(current, required) {
@@ -30,7 +30,7 @@ function compareVersions(current, required) {
 
 if (!compareVersions(current, MIN_NODE_VERSION)) {
   console.error(
-    `Avenx requires Node.js ${MIN_NODE_VERSION.join(".")} or later.\n` +
+    `Avenx requires Node.js ${MIN_NODE_VERSION.join('.')} or later.\n` +
     `Current version: ${process.versions.node}`
   );
   process.exit(1);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A lightweight reactive framework with scoped CSS and custom components.",
   "type": "module",
   "main": "lib/compiler.js",
+  "engines": {
+    "node": ">=18"
+  },
   "exports": {
     ".": {
       "types": "./lib/compiler.d.ts",


### PR DESCRIPTION
## Validate Node.js version at startup

### Issue
The CLI should check the active Node.js version before running.

### Why this is needed
The project now expects Node.js >=18. Without an early check, users on older versions may hit runtime errors or confusing failures.

Closes #247

### Changes
- Added `engines.node` with `>=18` in `package.json`.
- Added a runtime version check before app startup.
- Printed a clear warning and exited when the Node.js version is incompatible.

### What it solves
- Makes the supported Node version clear.
- Gives users a cleaner error at startup.
- Helps prevent unsupported runtimes from running the app.
- Improves the install/run experience while keeping the change lightweight.

**Note:** Very old Node versions may still fail before the warning if they cannot parse the entry file.
