### PR TITLE
feat: support custom output bundle names in config

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -53,6 +53,13 @@ class AvenxCompiler {
     this.rootDir = options.rootDir || findProjectRoot(process.cwd());
     const config = { ...loadConfig(this.rootDir), ...options };
 
+    /**
+     * The output bundle name without file extension.
+     * Defaults to "bundle" when outputName is not configured.
+     * @type {string}
+     */
+    this.outputName = config.outputName || 'bundle';
+
     // Configure logger for build-time compiler
     logger.configure({
       level: (config.logging && config.logging.level) || 'info',
@@ -112,6 +119,7 @@ class AvenxCompiler {
   build() {
     logger.info('--- Avenx-JS Compiler ---');
     const startTime = performance.now();
+
     if (!fs.existsSync(this.srcDir)) {
       logger.error(`❌ ${formatCompilerError('AVX_C02', this.srcDir)}`);
       return;
@@ -132,12 +140,20 @@ class AvenxCompiler {
 
     const pageData = this.processPages();
     bundleJs += pageData.pagesJs;
-    bundleJs += this.processMain((bridgeData.registrations || '') + '\n' + (pageData.registrations || ''));
+    bundleJs += this.processMain(
+      (bridgeData.registrations || '') + '\n' + (pageData.registrations || ''),
+    );
 
-    fs.writeFileSync(path.join(this.distDir, 'bundle.js'), bundleJs);
-    fs.writeFileSync(path.join(this.distDir, 'bundle.css'), this.styleProcessor.getGlobalStyles());
+    const jsFileName = `${this.outputName}.js`;
+    const cssFileName = `${this.outputName}.css`;
 
-    const files = ['bundle.js', 'bundle.css'];
+    fs.writeFileSync(path.join(this.distDir, jsFileName), bundleJs);
+    fs.writeFileSync(
+      path.join(this.distDir, cssFileName),
+      this.styleProcessor.getGlobalStyles(),
+    );
+
+    const files = [jsFileName, cssFileName];
 
     logger.info('\nAsset sizes:');
 
@@ -149,12 +165,17 @@ class AvenxCompiler {
       logger.info(`${file}: ${sizeKb.toFixed(2)} KB`);
 
       if (sizeKb > BUNDLE_SIZE_WARNING_THRESHOLD_KB) {
-        logger.warn(`WARNING: ${file} exceeds ${BUNDLE_SIZE_WARNING_THRESHOLD_KB} KB (${sizeKb.toFixed(2)} KB)`);
+        logger.warn(
+          `WARNING: ${file} exceeds ${BUNDLE_SIZE_WARNING_THRESHOLD_KB} KB (${sizeKb.toFixed(2)} KB)`,
+        );
       }
     });
 
     logger.info('-----------------------');
-    logger.info(`\nBuild erfolgreich: ${this.distDir}/bundle.js & ${this.distDir}/bundle.css`);
+    logger.info(
+      `\nBuild erfolgreich: ${this.distDir}/${jsFileName} & ${this.distDir}/${cssFileName}`,
+    );
+
     const endTime = performance.now();
     logger.info(`Build completed in ${Math.round(endTime - startTime)} ms`);
   }
@@ -177,19 +198,30 @@ class AvenxCompiler {
   processBridges() {
     const globalDir = path.join(this.srcDir, 'global');
     let registrations = '';
+
     if (fs.existsSync(globalDir)) {
       fs.readdirSync(globalDir).forEach((file) => {
         if (file.endsWith('.bridge.js')) {
           const name = path.basename(file, '.bridge.js');
+
           const capitalizedName =
             name
               .split(/[-_]/)
-              .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+              .map(
+                (part) =>
+                  part.charAt(0).toUpperCase() + part.slice(1),
+              )
               .join('') + 'Bridge';
 
           logger.info(`[Bridge] ${capitalizedName}`);
-          const content = fs.readFileSync(path.join(globalDir, file), 'utf-8');
+
+          const content = fs.readFileSync(
+            path.join(globalDir, file),
+            'utf-8',
+          );
+
           const match = content.match(/export\s+default\s+([\s\S]*)/);
+
           if (match) {
             const objStr = match[1].trim().replace(/;$/, '');
             registrations += `app.registerBridge('${capitalizedName}', ${objStr});\n`;
@@ -197,6 +229,7 @@ class AvenxCompiler {
         }
       });
     }
+
     return { registrations };
   }
 
@@ -212,19 +245,29 @@ class AvenxCompiler {
 
     const processFile = (dir, file) => {
       const name = path.basename(file, '.guard.js');
+
       const capitalizedName =
         name
           .split(/[-_]/)
-          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .map(
+            (part) =>
+              part.charAt(0).toUpperCase() + part.slice(1),
+          )
           .join('') + 'Guard';
 
       logger.info(`[Guard] ${capitalizedName}`);
-      const content = fs.readFileSync(path.join(dir, file), 'utf-8');
+
+      const content = fs.readFileSync(
+        path.join(dir, file),
+        'utf-8',
+      );
+
       const cleaned = content
         .replace(/^import\s+.*?;\s*$/gm, '')
         .replace(/import\s+.*?\s+from\s+['"].*?['"];?/gm, '')
         .replace(/export\s+default\s+/g, '')
         .replace(/export\s+/g, '');
+
       guardsJs += `\n${cleaned}\n`;
     };
 
@@ -235,6 +278,7 @@ class AvenxCompiler {
         }
       });
     }
+
     if (fs.existsSync(guardsDir)) {
       fs.readdirSync(guardsDir).forEach((file) => {
         if (file.endsWith('.guard.js')) {
@@ -242,6 +286,7 @@ class AvenxCompiler {
         }
       });
     }
+
     return guardsJs;
   }
 
@@ -253,25 +298,33 @@ class AvenxCompiler {
   processComponents() {
     let componentsJs = '';
     const compDir = path.join(this.srcDir, 'components');
-    const classNameMap = new Map(); // className -> [file paths]
+    const classNameMap = new Map();
 
-    // Same naming convention used elsewhere in this file (bridges/guards)
     const toClassName = (fileName) =>
       path
         .basename(fileName, '.component.js')
         .split(/[-_]/)
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .map(
+          (part) =>
+            part.charAt(0).toUpperCase() + part.slice(1),
+        )
         .join('');
 
     const scan = (dir) => {
       if (!fs.existsSync(dir)) return;
+
       fs.readdirSync(dir).forEach((file) => {
         const fullPath = path.join(dir, file);
+
         if (fs.statSync(fullPath).isDirectory()) {
           scan(fullPath);
         } else if (file.endsWith('.component.js')) {
           const className = toClassName(file);
-          if (!classNameMap.has(className)) classNameMap.set(className, []);
+
+          if (!classNameMap.has(className)) {
+            classNameMap.set(className, []);
+          }
+
           classNameMap.get(className).push(fullPath);
         }
       });
@@ -279,19 +332,28 @@ class AvenxCompiler {
 
     scan(compDir);
 
-    // Halt the build if any two files would generate the same class name
-    const duplicates = [...classNameMap.entries()].filter(([, paths]) => paths.length > 1);
+    const duplicates = [...classNameMap.entries()].filter(
+      ([, paths]) => paths.length > 1,
+    );
+
     if (duplicates.length > 0) {
       const details = duplicates
-        .map(([className, paths]) => `  "${className}":\n${paths.map((p) => `    - ${p}`).join('\n')}`)
+        .map(
+          ([className, paths]) =>
+            `  "${className}":\n${paths
+              .map((p) => `    - ${p}`)
+              .join('\n')}`,
+        )
         .join('\n');
+
       throw new Error(formatCompilerError('AVX_C03', details));
     }
 
-    // Safe to compile now — no name collisions
     classNameMap.forEach((paths) => {
       const fullPath = paths[0];
+
       logger.info(`[Compiling] ${path.basename(fullPath)}`);
+
       componentsJs += this.componentParser.parse(fullPath);
     });
 
@@ -310,17 +372,24 @@ class AvenxCompiler {
 
     const scan = (dir) => {
       if (!fs.existsSync(dir)) return;
+
       fs.readdirSync(dir).forEach((file) => {
         const fullPath = path.join(dir, file);
+
         if (fs.statSync(fullPath).isDirectory()) {
           scan(fullPath);
         } else if (file.endsWith('.page.js')) {
           logger.info(`[Compiling Page] ${file}`);
+
           const name = path
             .basename(file, '.page.js')
             .split(/[-_]/)
-            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .map(
+              (part) =>
+                part.charAt(0).toUpperCase() + part.slice(1),
+            )
             .join('');
+
           pagesJs += this.componentParser.parse(fullPath, 'page');
           registrations += `app.registerPage('${name}', ${name});\n`;
         }
@@ -328,6 +397,7 @@ class AvenxCompiler {
     };
 
     scan(pageDir);
+
     return { pagesJs, registrations };
   }
 
@@ -339,34 +409,58 @@ class AvenxCompiler {
    */
   processMain(registrations) {
     const mainFile = path.join(this.srcDir, 'main.app.js');
+
     if (fs.existsSync(mainFile)) {
       let main = fs
         .readFileSync(mainFile, 'utf-8')
-        .replace(/import\s*{\s*AvenxApp\s*}\s*from\s*['"].*?['"];?/g, '')
-        .replace(/import\s+.*?\s+from\s+['"].*?['"];?/gm, '');
+        .replace(
+          /import\s*{\s*AvenxApp\s*}\s*from\s*['"].*?['"];?/g,
+          '',
+        )
+        .replace(
+          /import\s+.*?\s+from\s+['"].*?['"];?/gm,
+          '',
+        );
 
       if (registrations) {
         let appName = 'app';
-        const appMatch = main.match(/(?:const|let|var)?\s*([\w$.]+)\s*=\s*new\s+AvenxApp\(/);
+
+        const appMatch = main.match(
+          /(?:const|let|var)?\s*([\w$.]+)\s*=\s*new\s+AvenxApp\(/,
+        );
+
         if (appMatch) {
           appName = appMatch[1].trim();
         }
 
         if (appName !== 'app') {
-          registrations = registrations.replace(/\bapp\.register/g, `${appName}.register`);
+          registrations = registrations.replace(
+            /\bapp\.register/g,
+            `${appName}.register`,
+          );
         }
 
         if (main.includes('// @avenx-inject')) {
-          main = main.replace('// @avenx-inject', registrations);
+          main = main.replace(
+            '// @avenx-inject',
+            registrations,
+          );
         } else {
-          const appDeclRegex = /((?:const|let|var)?\s*[\w$.]+\s*=\s*new\s+AvenxApp\([\s\S]*?\);?)/;
+          const appDeclRegex =
+            /((?:const|let|var)?\s*[\w$.]+\s*=\s*new\s+AvenxApp\([\s\S]*?\);?)/;
+
           if (appDeclRegex.test(main)) {
-            main = main.replace(appDeclRegex, `$1\n${registrations}`);
+            main = main.replace(
+              appDeclRegex,
+              `$1\n${registrations}`,
+            );
           }
         }
       }
+
       return `\n(function(){\n${main}\n})();`;
     }
+
     return '';
   }
 }

--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -73,8 +73,18 @@ function runTest() {
     });
 
     // Verify content of a template file
-    const settings = JSON.parse(fs.readFileSync(path.join(TEST_DIR, '.vscode/settings.json'), 'utf-8'));
-    assert.ok(settings['files.associations'], 'settings.json should have files.associations');
+    const settings = JSON.parse(
+      fs.readFileSync(
+        path.join(TEST_DIR, '.vscode/settings.json'),
+        'utf-8',
+      ),
+    );
+
+    assert.ok(
+      settings['files.associations'],
+      'settings.json should have files.associations',
+    );
+
     assert.strictEqual(
       settings['files.associations']['*.component.js'],
       'html',
@@ -84,173 +94,488 @@ function runTest() {
     console.log('✅ All init tests passed!');
 
     console.log('🧪 Testing avenx build...');
-    const buildOutput = execSync(`node ${BIN_PATH} build 2>&1`, { cwd: TEST_DIR, encoding: 'utf8' });
 
-    const bundleJsPath = path.join(TEST_DIR, 'dist/bundle.js');
-    const bundleCssPath = path.join(TEST_DIR, 'dist/bundle.css');
-    assert.ok(fs.existsSync(bundleJsPath), 'Missing bundle.js');
-    assert.ok(fs.existsSync(bundleCssPath), 'Missing bundle.css');
+    const buildOutput = execSync(
+      `node ${BIN_PATH} build 2>&1`,
+      {
+        cwd: TEST_DIR,
+        encoding: 'utf8',
+      },
+    );
 
-    const bundleContent = fs.readFileSync(bundleJsPath, 'utf-8');
-    assert.ok(bundleContent.includes('HtmlEscaper'), 'bundle.js should contain HtmlEscaper');
-    assert.ok(bundleContent.includes('SafeHtml'), 'bundle.js should contain SafeHtml');
-    assert.ok(bundleContent.includes('html'), 'bundle.js should contain html function');
+    const bundleJsPath = path.join(
+      TEST_DIR,
+      'dist/bundle.js',
+    );
 
-    assert.match(buildOutput, /Asset sizes:/, 'prints asset size');
-    assert.match(buildOutput, /bundle\.js: \d+\.\d{2} KB/, 'prints bundle.js asset size');
+    const bundleCssPath = path.join(
+      TEST_DIR,
+      'dist/bundle.css',
+    );
+
+    assert.ok(
+      fs.existsSync(bundleJsPath),
+      'Missing bundle.js',
+    );
+
+    assert.ok(
+      fs.existsSync(bundleCssPath),
+      'Missing bundle.css',
+    );
+
+    const bundleContent = fs.readFileSync(
+      bundleJsPath,
+      'utf-8',
+    );
+
+    assert.ok(
+      bundleContent.includes('HtmlEscaper'),
+      'bundle.js should contain HtmlEscaper',
+    );
+
+    assert.ok(
+      bundleContent.includes('SafeHtml'),
+      'bundle.js should contain SafeHtml',
+    );
+
+    assert.ok(
+      bundleContent.includes('html'),
+      'bundle.js should contain html function',
+    );
+
+    assert.match(
+      buildOutput,
+      /Asset sizes:/,
+      'prints asset size',
+    );
+
+    assert.match(
+      buildOutput,
+      /bundle\.js: \d+\.\d{2} KB/,
+      'prints bundle.js asset size',
+    );
 
     assert.match(
       buildOutput,
       /WARNING: bundle\.js exceeds 50 KB \(\d+\.\d{2} KB\)/,
       'warns when bundle.js exceeds threshold',
     );
-    assert.match(buildOutput, /bundle\.css: \d+\.\d{2} KB/, 'prints bundle.css size');
+
+    assert.match(
+      buildOutput,
+      /bundle\.css: \d+\.\d{2} KB/,
+      'prints bundle.css size',
+    );
+
+    console.log(
+      '🧪 Testing custom output bundle name...',
+    );
+
+    fs.writeFileSync(
+      path.join(TEST_DIR, 'avenx.config.json'),
+      JSON.stringify({ outputName: 'app' }),
+    );
+
+    const customBuildOutput = execSync(
+      `node ${BIN_PATH} build 2>&1`,
+      {
+        cwd: TEST_DIR,
+        encoding: 'utf8',
+      },
+    );
+
+    const customJsPath = path.join(
+      TEST_DIR,
+      'dist/app.js',
+    );
+
+    const customCssPath = path.join(
+      TEST_DIR,
+      'dist/app.css',
+    );
+
+    assert.ok(
+      fs.existsSync(customJsPath),
+      'Missing app.js when outputName is configured',
+    );
+
+    assert.ok(
+      fs.existsSync(customCssPath),
+      'Missing app.css when outputName is configured',
+    );
+
+    assert.match(
+      customBuildOutput,
+      /app\.js: \d+\.\d{2} KB/,
+      'prints custom app.js asset size',
+    );
+
+    assert.match(
+      customBuildOutput,
+      /app\.css: \d+\.\d{2} KB/,
+      'prints custom app.css asset size',
+    );
+
+    console.log(
+      '✅ Custom output bundle name tests passed!',
+    );
+
+    // Remove custom config so remaining tests use default bundle names
+    fs.rmSync(
+      path.join(TEST_DIR, 'avenx.config.json'),
+      { force: true },
+    );
 
     console.log('✅ All build tests passed!');
 
-    console.log('🧪 Testing avenx generate component with global template...');
-    execSync(`node ${BIN_PATH} generate component default-box`, { cwd: TEST_DIR });
+    console.log(
+      '🧪 Testing avenx generate component with global template...',
+    );
+
+    execSync(
+      `node ${BIN_PATH} generate component default-box`,
+      { cwd: TEST_DIR },
+    );
+
     const defaultBoxJs = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/default-box/default-box.component.js'),
+      path.join(
+        TEST_DIR,
+        'src/components/default-box/default-box.component.js',
+      ),
       'utf-8',
     );
-    assert.ok(defaultBoxJs.includes('DefaultBox Component'), 'Should contain default title');
 
-    const duplicateComponentResult = runCli(['generate', 'component', 'default-box']);
-    assert.strictEqual(duplicateComponentResult.status, 1, 'Duplicate component generation should fail');
+    assert.ok(
+      defaultBoxJs.includes('DefaultBox Component'),
+      'Should contain default title',
+    );
+
+    const duplicateComponentResult = runCli([
+      'generate',
+      'component',
+      'default-box',
+    ]);
+
+    assert.strictEqual(
+      duplicateComponentResult.status,
+      1,
+      'Duplicate component generation should fail',
+    );
+
     assert.match(
       duplicateComponentResult.stderr,
       /Component 'default-box' already exists/,
       'Duplicate component generation should explain the existing path',
     );
+
     assert.strictEqual(
-      fs.readFileSync(path.join(TEST_DIR, 'src/components/default-box/default-box.component.js'), 'utf-8'),
+      fs.readFileSync(
+        path.join(
+          TEST_DIR,
+          'src/components/default-box/default-box.component.js',
+        ),
+        'utf-8',
+      ),
       defaultBoxJs,
       'Duplicate component generation should not overwrite existing component files',
     );
 
-    console.log('🧪 Testing avenx generate component with camelCase name...');
-    execSync(`node ${BIN_PATH} generate component UserProfile`, { cwd: TEST_DIR });
+    console.log(
+      '🧪 Testing avenx generate component with camelCase name...',
+    );
+
+    execSync(
+      `node ${BIN_PATH} generate component UserProfile`,
+      { cwd: TEST_DIR },
+    );
+
     const userProfileJs = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/user-profile/user-profile.component.js'),
+      path.join(
+        TEST_DIR,
+        'src/components/user-profile/user-profile.component.js',
+      ),
       'utf-8',
     );
-    assert.ok(userProfileJs.includes('UserProfile Component'), 'Should replace template name with camelCase preserved');
+
+    assert.ok(
+      userProfileJs.includes('UserProfile Component'),
+      'Should replace template name with camelCase preserved',
+    );
 
     // Run build to verify compiling works and produces the correct class name
-    execSync(`node ${BIN_PATH} build`, { cwd: TEST_DIR });
-    const newBundleContent = fs.readFileSync(path.join(TEST_DIR, 'dist/bundle.js'), 'utf-8');
+    execSync(
+      `node ${BIN_PATH} build`,
+      { cwd: TEST_DIR },
+    );
+
+    const newBundleContent = fs.readFileSync(
+      path.join(TEST_DIR, 'dist/bundle.js'),
+      'utf-8',
+    );
+
     assert.ok(
-      newBundleContent.includes('class UserProfile extends AvenxComponent'),
+      newBundleContent.includes(
+        'class UserProfile extends AvenxComponent',
+      ),
       'Compiled bundle should contain correct class name for camelCase component',
     );
 
-    console.log('🧪 Testing avenx generate component with custom project-level templates...');
+    console.log(
+      '🧪 Testing avenx generate component with custom project-level templates...',
+    );
+
     // Create local templates folder
-    const localTemplatesDir = path.join(TEST_DIR, '.avenxtemplates');
-    fs.mkdirSync(localTemplatesDir, { recursive: true });
+    const localTemplatesDir = path.join(
+      TEST_DIR,
+      '.avenxtemplates',
+    );
+
+    fs.mkdirSync(localTemplatesDir, {
+      recursive: true,
+    });
 
     // Test flat custom template file
     fs.writeFileSync(
-      path.join(localTemplatesDir, 'component.js.template'),
+      path.join(
+        localTemplatesDir,
+        'component.js.template',
+      ),
       '// CUSTOM FLAT TEMPLATE\nclass {{ name }} extends AvenxComponent {}',
     );
-    fs.writeFileSync(path.join(localTemplatesDir, 'component.css.template'), '/* CUSTOM FLAT CSS */');
 
-    execSync(`node ${BIN_PATH} generate component custom-flat-box`, { cwd: TEST_DIR });
+    fs.writeFileSync(
+      path.join(
+        localTemplatesDir,
+        'component.css.template',
+      ),
+      '/* CUSTOM FLAT CSS */',
+    );
+
+    execSync(
+      `node ${BIN_PATH} generate component custom-flat-box`,
+      { cwd: TEST_DIR },
+    );
 
     const customFlatBoxJs = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/custom-flat-box/custom-flat-box.component.js'),
+      path.join(
+        TEST_DIR,
+        'src/components/custom-flat-box/custom-flat-box.component.js',
+      ),
       'utf-8',
     );
+
     const customFlatBoxCss = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/custom-flat-box/custom-flat-box.component.css'),
+      path.join(
+        TEST_DIR,
+        'src/components/custom-flat-box/custom-flat-box.component.css',
+      ),
       'utf-8',
     );
-    assert.ok(customFlatBoxJs.includes('// CUSTOM FLAT TEMPLATE'), 'Should use custom flat JS template');
+
     assert.ok(
-      customFlatBoxJs.includes('class CustomFlatBox extends AvenxComponent'),
+      customFlatBoxJs.includes(
+        '// CUSTOM FLAT TEMPLATE',
+      ),
+      'Should use custom flat JS template',
+    );
+
+    assert.ok(
+      customFlatBoxJs.includes(
+        'class CustomFlatBox extends AvenxComponent',
+      ),
       'Should replace template variables correctly',
     );
-    assert.strictEqual(customFlatBoxCss.trim(), '/* CUSTOM FLAT CSS */', 'Should use custom flat CSS template');
 
-    // Test structured custom template file (taking precedence over flat)
-    const structuredCompDir = path.join(localTemplatesDir, 'component');
-    fs.mkdirSync(structuredCompDir, { recursive: true });
+    assert.strictEqual(
+      customFlatBoxCss.trim(),
+      '/* CUSTOM FLAT CSS */',
+      'Should use custom flat CSS template',
+    );
+
+    // Test structured custom template file
+    const structuredCompDir = path.join(
+      localTemplatesDir,
+      'component',
+    );
+
+    fs.mkdirSync(structuredCompDir, {
+      recursive: true,
+    });
+
     fs.writeFileSync(
-      path.join(structuredCompDir, 'component.js.template'),
+      path.join(
+        structuredCompDir,
+        'component.js.template',
+      ),
       '// CUSTOM STRUCTURED TEMPLATE\nclass {{ name }} extends AvenxComponent {}',
     );
-    fs.writeFileSync(path.join(structuredCompDir, 'component.css.template'), '/* CUSTOM STRUCTURED CSS */');
 
-    execSync(`node ${BIN_PATH} generate component custom-struct-box`, { cwd: TEST_DIR });
+    fs.writeFileSync(
+      path.join(
+        structuredCompDir,
+        'component.css.template',
+      ),
+      '/* CUSTOM STRUCTURED CSS */',
+    );
+
+    execSync(
+      `node ${BIN_PATH} generate component custom-struct-box`,
+      { cwd: TEST_DIR },
+    );
 
     const customStructBoxJs = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/custom-struct-box/custom-struct-box.component.js'),
+      path.join(
+        TEST_DIR,
+        'src/components/custom-struct-box/custom-struct-box.component.js',
+      ),
       'utf-8',
     );
+
     const customStructBoxCss = fs.readFileSync(
-      path.join(TEST_DIR, 'src/components/custom-struct-box/custom-struct-box.component.css'),
+      path.join(
+        TEST_DIR,
+        'src/components/custom-struct-box/custom-struct-box.component.css',
+      ),
       'utf-8',
     );
+
     assert.ok(
-      customStructBoxJs.includes('// CUSTOM STRUCTURED TEMPLATE'),
+      customStructBoxJs.includes(
+        '// CUSTOM STRUCTURED TEMPLATE',
+      ),
       'Should prioritize custom structured JS template',
     );
+
     assert.ok(
-      customStructBoxJs.includes('class CustomStructBox extends AvenxComponent'),
+      customStructBoxJs.includes(
+        'class CustomStructBox extends AvenxComponent',
+      ),
       'Should replace template variables correctly',
     );
+
     assert.strictEqual(
       customStructBoxCss.trim(),
       '/* CUSTOM STRUCTURED CSS */',
       'Should prioritize custom structured CSS template',
     );
 
-    console.log('🧪 Testing avenx generate page does not overwrite partial existing files...');
-    const pageCssPath = path.join(TEST_DIR, 'src/pages/reports.page.css');
-    const pageJsPath = path.join(TEST_DIR, 'src/pages/reports.page.js');
-    fs.writeFileSync(pageCssPath, '/* keep existing page styles */');
+    console.log(
+      '🧪 Testing avenx generate page does not overwrite partial existing files...',
+    );
 
-    const duplicatePageResult = runCli(['generate', 'page', 'reports']);
-    assert.strictEqual(duplicatePageResult.status, 1, 'Page generation should fail when any target file exists');
+    const pageCssPath = path.join(
+      TEST_DIR,
+      'src/pages/reports.page.css',
+    );
+
+    const pageJsPath = path.join(
+      TEST_DIR,
+      'src/pages/reports.page.js',
+    );
+
+    fs.writeFileSync(
+      pageCssPath,
+      '/* keep existing page styles */',
+    );
+
+    const duplicatePageResult = runCli([
+      'generate',
+      'page',
+      'reports',
+    ]);
+
+    assert.strictEqual(
+      duplicatePageResult.status,
+      1,
+      'Page generation should fail when any target file exists',
+    );
+
     assert.match(
       duplicatePageResult.stderr,
       /Page 'reports' already exists/,
       'Page generation should explain which page already exists',
     );
+
     assert.strictEqual(
       fs.readFileSync(pageCssPath, 'utf-8'),
       '/* keep existing page styles */',
       'Page generation should not overwrite existing CSS when JS is missing',
     );
-    assert.ok(!fs.existsSync(pageJsPath), 'Page generation should not create JS after detecting an existing CSS file');
 
-    console.log('✅ Custom project-level templates tests passed!');
+    assert.ok(
+      !fs.existsSync(pageJsPath),
+      'Page generation should not create JS after detecting an existing CSS file',
+    );
 
-    console.log('🧪 Testing avenx generate component from a subdirectory...');
+    console.log(
+      '✅ Custom project-level templates tests passed!',
+    );
+
+    console.log(
+      '🧪 Testing avenx generate component from a subdirectory...',
+    );
+
     // Create nested directory to simulate a subdirectory
     const srcSubdir = path.join(TEST_DIR, 'src');
-    // Run CLI generate component command from the nested 'src' directory
-    execSync(`node ${BIN_PATH} generate component sub-box`, { cwd: srcSubdir });
 
-    // The files should be generated at the actual project root's components directory:
-    // TEST_DIR/src/components/sub-box/
-    const subBoxJsPath = path.join(TEST_DIR, 'src/components/sub-box/sub-box.component.js');
-    const subBoxCssPath = path.join(TEST_DIR, 'src/components/sub-box/sub-box.component.css');
-    assert.ok(fs.existsSync(subBoxJsPath), 'Missing sub-box component JS file at root components dir');
-    assert.ok(fs.existsSync(subBoxCssPath), 'Missing sub-box component CSS file at root components dir');
+    // Run CLI generate component command from nested src directory
+    execSync(
+      `node ${BIN_PATH} generate component sub-box`,
+      { cwd: srcSubdir },
+    );
 
-    // The files should NOT be written to a double nested 'src/src' directory
-    const incorrectNestedDir = path.join(TEST_DIR, 'src/src');
-    assert.ok(!fs.existsSync(incorrectNestedDir), 'Should not create double nested src/src directory');
+    const subBoxJsPath = path.join(
+      TEST_DIR,
+      'src/components/sub-box/sub-box.component.js',
+    );
 
-    // The component should also be correctly registered in src/main.app.js
-    const mainAppContent = fs.readFileSync(path.join(TEST_DIR, 'src/main.app.js'), 'utf-8');
-    assert.ok(mainAppContent.includes("import SubBox from './components/sub-box/sub-box.component.js';"), 'Component should be registered with correct relative path in main.app.js');
-    assert.ok(mainAppContent.includes("app.register('SubBox', SubBox);"), 'Component class should be registered on app');
+    const subBoxCssPath = path.join(
+      TEST_DIR,
+      'src/components/sub-box/sub-box.component.css',
+    );
 
-    console.log('✅ Subdirectory command execution tests passed!');
+    assert.ok(
+      fs.existsSync(subBoxJsPath),
+      'Missing sub-box component JS file at root components dir',
+    );
+
+    assert.ok(
+      fs.existsSync(subBoxCssPath),
+      'Missing sub-box component CSS file at root components dir',
+    );
+
+    const incorrectNestedDir = path.join(
+      TEST_DIR,
+      'src/src',
+    );
+
+    assert.ok(
+      !fs.existsSync(incorrectNestedDir),
+      'Should not create double nested src/src directory',
+    );
+
+    const mainAppContent = fs.readFileSync(
+      path.join(TEST_DIR, 'src/main.app.js'),
+      'utf-8',
+    );
+
+    assert.ok(
+      mainAppContent.includes(
+        "import SubBox from './components/sub-box/sub-box.component.js';",
+      ),
+      'Component should be registered with correct relative path in main.app.js',
+    );
+
+    assert.ok(
+      mainAppContent.includes(
+        "app.register('SubBox', SubBox);",
+      ),
+      'Component class should be registered on app',
+    );
+
+    console.log(
+      '✅ Subdirectory command execution tests passed!',
+    );
   } catch (error) {
     console.error('❌ Test failed!');
     console.error(error);


### PR DESCRIPTION
## Description

Adds support for custom output bundle names through the `outputName` configuration option.

Previously, the compiler always generated `bundle.js` and `bundle.css` inside the configured `distDir`. This change allows users to customize the generated filenames by setting `outputName` in `avenx.config.json`.

For example:

outputName: "app"

will generate:

- app.js
- app.css

If `outputName` is not specified, the compiler continues to use `bundle.js` and `bundle.css` as the default output filenames, preserving existing behavior.

## Changes Made

- Added support for reading `outputName` from the compiler configuration.
- Added `bundle` as the default fallback when `outputName` is unspecified.
- Updated JavaScript and CSS output file generation to use the configured output name.
- Updated asset size logging to display custom output filenames.
- Updated the build success message to display the generated filenames.
- Added system test coverage for custom output names.
- Preserved existing tests verifying the default `bundle.js` and `bundle.css` behavior.

## Testing

Added tests to verify that:

- `outputName: "app"` generates `app.js` and `app.css`.
- Omitting `outputName` continues to generate `bundle.js` and `bundle.css`.
- Asset size logging correctly displays custom output filenames.

Closes #251