### PR TITLE
docs: document nested style selector scoping rules

### DIFF
--- a/docs/src/content/docs/core-concepts/styling.md
+++ b/docs/src/content/docs/core-concepts/styling.md
@@ -23,9 +23,11 @@ CSS rules defined inside `<@css>` use named blocks without dot prefixes. The com
 </@css>
 ```
 
+```html
 <div @css card>
     <!-- Component Content -->
 </div>
+```
 
 ## 2. Global CSS & Custom Variables (`<@global>`)
 
@@ -49,3 +51,145 @@ Declare global styles or design token variables using the `<@global>` block. Use
     }
 </@css>
 ```
+
+## 3. Scoping Limitations and Nesting Rules
+
+The `StyleProcessor` scopes selectors declared inside `<@css>` blocks by prepending the generated component hash to nested selectors that do not contain the nesting reference character `&`.
+
+Because of this scoping behavior, descendant selectors must use `&` explicitly. Writing a nested selector without `&` does not produce a descendant selector.
+
+### Nested Selectors Without `&`
+
+Consider the following scoped style:
+
+```css
+<@css>
+    card {
+        h1 {
+            color: red;
+        }
+    }
+</@css>
+```
+
+The nested `h1` selector does not contain `&`, so the compiler prepends the generated scope class directly to the selector. Conceptually, the result is:
+
+```css
+.generated-hashh1 {
+    color: red;
+}
+```
+
+There is no space between the generated scope class and `h1`. As a result, this selector does not target an `h1` element that is a descendant of the scoped `card` block.
+
+### Descendant Selectors With `&`
+
+To target an element inside the scoped block, use the `&` nesting reference character:
+
+```css
+<@css>
+    card {
+        & h1 {
+            color: red;
+        }
+    }
+</@css>
+```
+
+The `&` refers to the generated scoped selector. Conceptually, this compiles to:
+
+```css
+.generated-hash h1 {
+    color: red;
+}
+```
+
+The space creates a descendant selector, so the rule correctly targets `h1` elements inside the scoped block.
+
+For example:
+
+```html
+<div @css card>
+    <h1>Card title</h1>
+</div>
+```
+
+> **Note:** When targeting child or descendant elements inside a scoped CSS block, always use `&` followed by the required selector.
+
+### Parent Selectors and Pseudo-classes
+
+The `&` character can also be used to reference the scoped parent selector when applying pseudo-classes or other selector modifiers.
+
+For example:
+
+```css
+<@css>
+    card {
+        &:hover {
+            border-color: #6366f1;
+        }
+
+        &:focus {
+            outline: 2px solid #6366f1;
+        }
+    }
+</@css>
+```
+
+Conceptually, these selectors compile to:
+
+```css
+.generated-hash:hover {
+    border-color: #6366f1;
+}
+
+.generated-hash:focus {
+    outline: 2px solid #6366f1;
+}
+```
+
+Use `&:hover`, `&:focus`, and similar patterns when the selector should apply directly to the scoped parent element.
+
+### Nesting At-rules
+
+Nesting at-rules such as `@media` and `@container` are resolved while preserving the scoped selector rules inside them.
+
+For example:
+
+```css
+<@css>
+    card {
+        @media (max-width: 768px) {
+            & h1 {
+                font-size: 1.5rem;
+            }
+        }
+    }
+</@css>
+```
+
+The descendant selector continues to require `&` because it targets an element inside the scoped block.
+
+The same rule applies when using container queries:
+
+```css
+<@css>
+    card {
+        @container (min-width: 500px) {
+            & .content {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+    }
+</@css>
+```
+
+In both cases, the at-rule is resolved while the nested selector remains scoped to the component.
+
+When writing nested scoped styles, remember:
+
+- Use `& h1`, `& .child`, or similar selectors to target descendants.
+- Use `&:hover`, `&:focus`, and similar selectors to target states of the scoped parent.
+- Continue using `&` for descendant selectors nested inside `@media` and `@container` rules.
+- A nested selector without `&` is scoped by directly prepending the generated hash and does not create a descendant selector.


### PR DESCRIPTION
Add documentation for nested selector scoping behavior in StyleProcessor.

Explain the difference between selectors with and without the & nesting reference, provide descendant selector examples, and document parent pseudo-selectors and nested at-rules such as @media and @container.

Closes #291