### PR TITLE
fix(cli): handle EADDRINUSE gracefully in dev server (#64)

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -509,6 +509,18 @@ class AvenxCLI {
       });
     });
 
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        console.error(
+          `\n❌ Port ${port} is already in use.\n` +
+            `   Stop the process using that port, or start the dev server on a different one.\n`,
+        );
+        process.exit(1);
+      }
+      // Re-throw anything unexpected so it is not silently swallowed.
+      throw err;
+    });
+
     server.listen(port, () => {
       const url = `http://localhost:${port}`;
       console.log(`\n🚀 Dev-Server running at ${url}`);


### PR DESCRIPTION
Closes #64.

## Problem
The dev server started by `avenx serve` binds the port via `server.listen(port)` with no error handler. If the port (default 3000) is already in use, the CLI crashes with a raw `EADDRINUSE` stack trace.

## Fix
Attach an `'error'` handler to the server before `listen()`. On `EADDRINUSE`, print a clear, actionable message and `exit(1)`; any other error is re-thrown unchanged so it isn't silently swallowed.

## Acceptance criteria
- ✅ `'error'` listener attached to the server instance in `serveProject`
- ✅ Checks for `EADDRINUSE`, logs a user-friendly message
- ✅ Exits gracefully instead of crashing with a raw stack trace

## Testing
- `npx eslint bin/avenx.js` → passes (exit 0).
- Verified at runtime: occupied a port, attempted a second `listen()` on it, and confirmed the `error` handler fires with `err.code === 'EADDRINUSE'` (graceful) instead of an uncaught crash.