### PR TITLE
Add component name parameter to validateTemplate

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -270,7 +270,7 @@ class ${name} extends AvenxComponent {
     template = this.styleProcessor.process(template, desBlocks, name);
     template = this.processBindDirectives(template);
     if (filePath && state && computed && methods) {
-      this.validateTemplate(template, state, computed, methods, filePath);
+      this.validateTemplate(template, state, computed, methods, filePath, name);
     }
     template = this.processForLoops(template);
     template = this.processTransitionTags(template);
@@ -288,9 +288,14 @@ class ${name} extends AvenxComponent {
    * @param {object} computed - The extracted computed keys.
    * @param {object} methods - The extracted method keys.
    * @param {string} filePath - The component file path.
+   * @param {string} [name] - The component name, used for warning messages.
    * @private
    */
-  validateTemplate(template, state, computed, methods, filePath) {
+  validateTemplate(template, state, computed, methods, filePath, name) {
+    if (!template || template.trim() === '') {
+      logger.warn(`[Avenx Warning] Component "${name}" has an empty template.`);
+    }
+
     const declared = new Set([...Object.keys(state), ...Object.keys(computed), ...Object.keys(methods)]);
 
     const bridges = this.findBridgeNames(filePath);


### PR DESCRIPTION
fix(compiler): warn on empty component templates

  Add a check in ComponentParser.validateTemplate to detect when a
  component's template is empty (either an empty <template> tag or
  one omitted entirely). Logs:
  [Avenx Warning] Component "Name" has an empty template.

  Compilation still succeeds; this is a warning only, matching the
  existing validation warning pattern for undeclared identifiers.

  Closes #250