### PR TITLE
feat(reactivity): add nextTick API to Component and Page

### DIFF
--- a/lib/core/reactive/scheduler.js
+++ b/lib/core/reactive/scheduler.js
@@ -1,9 +1,7 @@
 const queue = new Set();
 let isPending = false;
 let isFlushing = false;
-
 import { logger } from '../runtime/AvenxLogger.js';
-
 /**
  * Queues a job (update callback) to be executed in the next microtask.
  * Deduplicates multiple calls to the same job.
@@ -18,7 +16,6 @@ export function queueJob(job) {
     }
   }
 }
-
 /**
  * Flushes all queued jobs in a loop until the queue is completely empty.
  */
@@ -40,4 +37,21 @@ function flushJobs() {
   } finally {
     isFlushing = false;
   }
+}
+
+/**
+ * Executes a callback (or resolves a Promise) after all currently queued
+ * jobs in the scheduler queue have finished flushing.
+ * @param {Function} [callback] - Optional callback to invoke after the flush.
+ * @returns {Promise<void>|void} A promise resolving after the flush, if no callback was given.
+ */
+export function nextTick(callback) {
+  if (callback) {
+    queueJob(callback);
+    return;
+  }
+
+  return new Promise((resolve) => {
+    queueJob(resolve);
+  });
 }

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -9,7 +9,7 @@ import { LifecycleManager } from './lifecycle.js';
 import { ListManager } from '../renderer/listManager.js';
 import { AvenxError, AvenxErrorCodes, formatMessage } from './AvenxError.js';
 import { logger } from './AvenxLogger.js';
-import { queueJob } from '../reactive/scheduler.js';
+import { queueJob, nextTick as schedulerNextTick } from '../reactive/scheduler.js';
 
 import { AvenxWatcher } from '../reactive/watcher.js';
 import { ProxyHandlerFactory } from '../reactive/proxyHandler.js';
@@ -330,6 +330,16 @@ export class AvenxComponent {
     } finally {
       this.#isUpdating = false;
     }
+  }
+
+  /**
+   * Executes a callback (or resolves a Promise) after the current reactive
+   * update cycle has finished flushing pending DOM updates.
+   * @param {Function} [callback] - Optional callback to run after the flush.
+   * @returns {Promise<void>|void} A promise resolving after the flush, if no callback was given.
+   */
+  nextTick(callback) {
+    return schedulerNextTick(callback);
   }
 
   /**


### PR DESCRIPTION
feat(reactivity): add nextTick API to Component and Page

Add a nextTick(callback) export to the job scheduler that runs a
callback (or resolves a returned Promise if no callback is given)
after the current queue of pending jobs has flushed.

Expose this as an instance method, AvenxComponent.prototype.nextTick,
so developers can run code or read updated DOM state immediately
after a reactive update cycle completes. AvenxPage inherits this
automatically since it extends AvenxComponent.

Closes #236