### PR TITLE
docs(routing): document in-place parameter updates in mountPage (page updates vs. re-creation)

### DIFF
--- a/docs/src/content/docs/api-reference/page.md
+++ b/docs/src/content/docs/api-reference/page.md
@@ -2,20 +2,13 @@
 title: 'AvenxPage API'
 description: 'API reference for AvenxPage, the specialized component class for views and routing.'
 ---
-
 A specialized sub-class extending `AvenxComponent`. Pages represent root layouts in router configurations.
-
 ## Key Differences from AvenxComponent
-
 - **Child Component Resolution**: Pages are configured with a registry of components. Whenever a page renders, it scans the DOM for custom element tags (e.g. `<div data-avenx-comp="Navbar">`) and instantiates them automatically.
-
 - **Props Propagation**: If a child component is declared with attributes (e.g., `<Card title="My Card" />`), `AvenxPage` extracts and feeds them to the child component as props dynamically.
-
 ## Constructor
-
 Compiled page classes receive the application bridge map and component registry.
 The compiler emits page constructors with this shape:
-
 ```javascript
 constructor(bridges, componentRegistry, props) {
   super(
@@ -29,54 +22,54 @@ constructor(bridges, componentRegistry, props) {
   );
 }
 ```
-
 This differs from a regular component constructor, which receives only
 `bridges` and `props`. The extra `componentRegistry` argument lets `AvenxPage`
 mount child components inside the page template.
-
 ## Route Parameters
-
 When a route pattern contains dynamic segments, such as `/profile/:id`, the
 router decodes the matched values and passes them into the mounted page.
-
 ```javascript
 app.initRouter({
   '/profile/:id': 'Profile',
 });
 ```
-
 For `#/profile/42?tab=settings`, the page receives:
-
 ```javascript
 this.params.id; // "42"
 this.params.query; // { tab: "settings" }
 this.state.id; // "42"
 this.state.query; // { tab: "settings" }
 ```
-
 Route parameters are copied into both `this.params` and `this.state`, so they
 can be read inside page actions or rendered directly in templates.
-
 ## Page Reuse During Navigation
-
 If navigation resolves to the same page class, Avenx reuses the active page
 instance. It updates route parameters in place instead of unmounting and
 mounting the page again. Parameters that are no longer present on the new route
 are removed from both `this.params` and `this.state`.
-
 If navigation resolves to a different page class, the current page is unmounted
 before the new page is mounted.
+:::caution
+Because the existing instance is reused, `onMount()` and `onUnmount()` do **not** run again during this kind of navigation — only `onUpdate()` fires. If your page needs to react to a changed route parameter (for example, re-fetching data for a new `:id`), do not rely on `onMount()` alone. Compare the new parameter value against the previously seen value inside `onUpdate()` instead:
 
+```javascript
+onUpdate() {
+  if (this.state.id !== this._lastId) {
+    this._lastId = this.state.id;
+    this.fetchProfile(this.state.id);
+  }
+}
+```
+
+See [In-Place Parameter Updates](/core-concepts/routing/#4-in-place-parameter-updates) in the Pages & Routing guide for the full pattern.
+:::
 ## Lifecycle
-
 Pages use the same lifecycle hooks as components:
-
 | Hook          | When it runs                                                                  |
 | ------------- | ----------------------------------------------------------------------------- |
 | `onMount()`   | After the page is first mounted into the application target.                  |
 | `onUpdate()`  | After page state changes, including route parameter updates on a reused page. |
 | `onUnmount()` | Before the page is removed, including cleanup of child components.            |
-
 `AvenxPage.update()` first updates the page itself and then mounts or updates
 child components found in the rendered template. `AvenxPage.unmount()` unmounts
 all child components before delegating to the base component cleanup.

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -2,26 +2,17 @@
 title: 'Pages & Routing'
 description: 'Set up client-side routing, nested pages, dynamic parameters, and guards.'
 ---
-
 Avenx-JS features a built-in router designed for single-page applications. It handles hash-based navigation (e.g. `#/dashboard`), dynamic parameters, and guards.
-
 ## 1. Page Components (`.page.js`)
-
 Pages are top-level components located inside `src/pages/`. They extend `AvenxPage` instead of `AvenxComponent`, enabling them to host child components dynamically.
-
 ## 2. Configuring the Router
-
 Define routes in your `src/main.app.js` file by mapping path patterns to page names:
-
 ```javascript
 import { AvenxApp } from 'avenx-core/runtime';
-
 const app = new AvenxApp({ target: '#app' });
-
 // Registering Pages (Normally automatically registered by compiler)
 app.registerPage('Home', Home);
 app.registerPage('Profile', Profile);
-
 // Initialize router
 app.initRouter({
   '/': 'Home',
@@ -29,11 +20,8 @@ app.initRouter({
   '*': 'Home', // Fallback route
 });
 ```
-
 ## 3. Dynamic Route Parameters
-
 Route segments starting with `:` are dynamic variables. The values parsed from the URL are automatically added to the Page component's `state` object and can be read inside templates or actions:
-
 ```html
 <!-- src/pages/profile.page.js -->
 <!-- state.id will contain the value from /profile/:id -->
@@ -41,21 +29,38 @@ Route segments starting with `:` are dynamic variables. The values parsed from t
   <h1>Viewing Profile ID: {{ id }}</h1>
 </div>
 ```
-
-## 4. Route Guards
-
+## 4. In-Place Parameter Updates
+:::caution
+When navigating between routes that resolve to the **same page component class** (for example, from `#/profile/1` to `#/profile/2`), Avenx does **not** unmount and remount the page. It updates the route parameters and state on the existing page instance in place instead. This means `onMount()` and `onUnmount()` do **not** re-run during this kind of navigation — only `onUpdate()` fires.
+:::
+If a page relies solely on `onMount()` to fetch data based on a route parameter, that data becomes stale after navigating to a matching route with a different parameter, since `onMount()` only runs once, when the page is first mounted.
+To react correctly to parameter changes, compare the incoming value against the previously seen value inside `onUpdate()`, and only re-fetch when it has actually changed:
+```javascript
+// src/pages/profile.page.js
+onMount() {
+  this._lastId = this.state.id;
+  this.fetchProfile(this.state.id);
+}
+onUpdate() {
+  if (this.state.id !== this._lastId) {
+    this._lastId = this.state.id;
+    this.fetchProfile(this.state.id);
+  }
+}
+```
+:::note
+Guard the comparison against the previous value. `onUpdate()` runs after **every** page update, not just parameter changes, so without the check you would re-fetch on every unrelated state change too.
+:::
+See [Page Reuse During Navigation](/api-reference/page/#page-reuse-during-navigation) in the `AvenxPage` API reference for more detail on when a page instance is reused versus recreated.
+## 5. Route Guards
 Guards decide whether a transition to a page is allowed. Create a guard using the CLI:
-
 ```bash
 npx avenx g guard auth
 ```
-
 Implement the `canActivate(to, from)` method. Return a boolean, a redirect string, or a Promise:
-
 ```javascript
 // src/guards/auth.guard.js
 import { AvenxGuard } from 'avenx-core/runtime';
-
 export default class AuthGuard extends AvenxGuard {
   canActivate(to, from) {
     // Return true to allow, false to block, or hash path to redirect
@@ -66,18 +71,16 @@ export default class AuthGuard extends AvenxGuard {
   }
 }
 ```
-
 :::caution
 Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
 :::warning
 Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
 :::
-
 Map guards to routes in your application router initialization:
-
 ```javascript
 app.initRouter({
   '/': 'Home',
   '/dashboard': { page: 'Dashboard', guards: [AuthGuard] },
 });
+
 ```


### PR DESCRIPTION
## Summary
Documents that navigating between routes resolving to the same page class
(e.g. `#/profile/1` → `#/profile/2`) updates the page's route params/state
in place rather than unmounting/remounting — so `onMount`/`onUnmount` do not
re-run — and shows the correct pattern for reacting to parameter changes.

Closes #341

## Changes
- `routing.md`: added a new "4. In-Place Parameter Updates" section (existing
  "Route Guards" section renumbered 4→5) with a caution callout and a full
  `onMount`/`onUpdate` code example
- `page.md`: added a caution callout at the end of the existing "Page Reuse
  During Navigation" section, with a condensed version of the same example,
  cross-linked to the routing guide

## Notes for reviewers
The issue suggests documenting `this.watch(...)` as a way to observe param
changes reactively. I could not find a `watch()` method documented anywhere
in the Component/Page/Reactivity API docs — only `onUpdate()`, computed
getters, and direct state mutation are documented — so I've written the
example using the confirmed `onUpdate()` + previous-value-comparison
pattern instead. If `watch()` does exist in the runtime source, happy to
swap the examples to use it, since it'd likely be the cleaner recommended
API. Could someone confirm before merging?