### PR TITLE
Git checkout  b docs/339 provide inject

### DIFF
--- a/docs/src/content/docs/core-concepts/reactivity.md
+++ b/docs/src/content/docs/core-concepts/reactivity.md
@@ -104,3 +104,71 @@ Avenx-JS automatically intercepts nested object mutations. If a state property c
 state.todos.push({ text: 'Learn Avenx', done: false }); // Reactive!
 state.user.profile.age = 35; // Reactive!
 ```
+
+## Reactivity Injection (Provide / Inject)
+
+For deeply nested component trees, passing data down through props at every level ("prop drilling") gets unwieldy. Avenx-JS offers a lighter-weight alternative to global `bridges` for this specific case: an ancestor component can `provide` values, and any descendant, no matter how deeply nested, can `inject` them directly — without the value passing through, or being known by, the components in between.
+
+Unlike bridges, provide/inject is scoped to a single component subtree rather than the whole application, and it doesn't route through the global bridge/render system, avoiding that overhead for state that's only relevant to one part of the tree.
+
+### Providing values
+
+Declare a `provide` property (or static method) on the ancestor component. It can be:
+
+- **An object**, mapping keys to values or methods
+- **A function** (instance or static) returning either form above, evaluated once per instance
+- **An array of keys**, exposing matching properties already present on the component's own `state`, `props`, methods, or bridges
+
+```javascript
+// src/pages/dashboard.page.js
+<state theme="dark" />
+
+// Object form: explicit keys and values
+provide = {
+  theme: this.state.theme,
+  setTheme: (value) => { this.state.theme = value; },
+};
+```
+
+```javascript
+// Array form: re-exposes existing state/props/methods by name
+provide = ['theme', 'setTheme'];
+```
+
+### Injecting values
+
+Descendant components declare `inject` the same way — object, function, or array of keys — and the resolved keys become directly accessible as properties on `this` (and inside template expressions):
+
+```javascript
+// src/components/theme-toggle/theme-toggle.component.js
+inject = ['theme', 'setTheme'];
+
+<button @click="setTheme(theme === 'dark' ? 'light' : 'dark')">
+  Current theme: {{ theme }}
+</button>
+```
+
+To expose a provided value under a different local name, use the object form of `inject`, mapping the local key to the key it was provided under:
+
+```javascript
+inject = {
+  currentTheme: 'theme', // accessible as `this.currentTheme` / `{{ currentTheme }}`
+};
+```
+
+### How resolution works
+
+An injected key is resolved **lazily, on every access** — it is not copied or cached at mount time. When a descendant reads an injected property, Avenx walks up the DOM tree from the component's root element to find the nearest ancestor component whose `provide` declares that key, then reads the current value from it.
+
+This has two practical implications:
+
+- **Object-form `provide` is reactive.** The object passed to `provide` is wrapped in its own reactive proxy internally. Injecting descendants read through that proxy on every access, so they automatically see updates when the provider changes a provided value — no extra wiring required.
+- **Array-form `provide` stays reactive too**, since it reads the provided key directly off the provider's live `state`/`props`/methods each time, rather than a snapshot.
+
+:::note
+Only the **nearest** ancestor providing a given key is used. If multiple ancestors in the chain provide the same key, closer ancestors take precedence.
+:::
+
+:::caution
+If no ancestor in the tree provides an injected key, the property resolves to `undefined` and a warning is logged to the console — it does not throw. Double-check ancestor/descendant `provide`/`inject` key names match if an injected value is unexpectedly `undefined`.
+:::

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -2,26 +2,17 @@
 title: 'Pages & Routing'
 description: 'Set up client-side routing, nested pages, dynamic parameters, and guards.'
 ---
-
 Avenx-JS features a built-in router designed for single-page applications. It handles hash-based navigation (e.g. `#/dashboard`), dynamic parameters, and guards.
-
 ## 1. Page Components (`.page.js`)
-
 Pages are top-level components located inside `src/pages/`. They extend `AvenxPage` instead of `AvenxComponent`, enabling them to host child components dynamically.
-
 ## 2. Configuring the Router
-
 Define routes in your `src/main.app.js` file by mapping path patterns to page names:
-
 ```javascript
 import { AvenxApp } from 'avenx-core/runtime';
-
 const app = new AvenxApp({ target: '#app' });
-
 // Registering Pages (Normally automatically registered by compiler)
 app.registerPage('Home', Home);
 app.registerPage('Profile', Profile);
-
 // Initialize router
 app.initRouter({
   '/': 'Home',
@@ -29,11 +20,8 @@ app.initRouter({
   '*': 'Home', // Fallback route
 });
 ```
-
 ## 3. Dynamic Route Parameters
-
 Route segments starting with `:` are dynamic variables. The values parsed from the URL are automatically added to the Page component's `state` object and can be read inside templates or actions:
-
 ```html
 <!-- src/pages/profile.page.js -->
 <!-- state.id will contain the value from /profile/:id -->
@@ -41,21 +29,73 @@ Route segments starting with `:` are dynamic variables. The values parsed from t
   <h1>Viewing Profile ID: {{ id }}</h1>
 </div>
 ```
-
-## 4. Route Guards
-
+## 4. In-Place Parameter Updates
+:::caution
+When navigating between routes that resolve to the **same page component class** (for example, from `#/profile/1` to `#/profile/2`), Avenx does **not** unmount and remount the page. It updates the route parameters and state on the existing page instance in place instead. This means `onMount()` and `onUnmount()` do **not** re-run during this kind of navigation — only `onUpdate()` fires.
+:::
+If a page relies solely on `onMount()` to fetch data based on a route parameter, that data becomes stale after navigating to a matching route with a different parameter, since `onMount()` only runs once, when the page is first mounted.
+To react correctly to parameter changes, compare the incoming value against the previously seen value inside `onUpdate()`, and only re-fetch when it has actually changed:
+```javascript
+// src/pages/profile.page.js
+onMount() {
+  this._lastId = this.state.id;
+  this.fetchProfile(this.state.id);
+}
+onUpdate() {
+  if (this.state.id !== this._lastId) {
+    this._lastId = this.state.id;
+    this.fetchProfile(this.state.id);
+  }
+}
+```
+:::note
+Guard the comparison against the previous value. `onUpdate()` runs after **every** page update, not just parameter changes, so without the check you would re-fetch on every unrelated state change too.
+:::
+See [Page Reuse During Navigation](/api-reference/page/#page-reuse-during-navigation) in the `AvenxPage` API reference for more detail on when a page instance is reused versus recreated.
+## 5. Multi-Router Setup & Namespaces
+Avenx-JS supports running **multiple independent `AvenxRouter` instances at the same time** on the same page — for example, a host application and one or more embedded micro-frontends, each with their own routes, pages, and navigation lifecycle.
+### Isolating routers with `prefix`
+Each router created via `app.initRouter(routes, options)` can be given a `prefix` in its options. A router only ever handles hashes that start with its own prefix — any hash that doesn't match is ignored completely by that router, including its wildcard route.
+Route patterns are written **relative to the prefix**, not including it:
+```javascript
+// Host app — no prefix, owns the root of the hash space
+const hostApp = new AvenxApp({ target: '#app' });
+hostApp.registerPage('Home', Home);
+hostApp.initRouter({
+  '/': 'Home',
+  '*': 'Home',
+});
+// Embedded widget — everything under #/widget/... belongs to this router
+const widgetApp = new AvenxApp({ target: '#widget' });
+widgetApp.registerPage('WidgetHome', WidgetHome);
+widgetApp.initRouter(
+  {
+    '/home': 'WidgetHome', // matches #/widget/home
+    '*': 'WidgetHome',
+  },
+  { prefix: '/widget' },
+);
+```
+Navigating with `router.navigate(hash)` on a prefixed router automatically prepends its `prefix`, so calling `navigate('#/home')` on `widgetApp`'s router produces `#/widget/home`.
+### Coordinating wildcard fallbacks with `window.__avenx_routers`
+Every `AvenxRouter` registers itself in a global `window.__avenx_routers` set when it's created, and removes itself when `destroy()` is called. Routers use this registry to avoid stepping on each other's wildcard (`*`) fallback routes.
+When a router can't match the current hash against any of its own named routes, it does **not** immediately fall back to its `*` route. Instead, it first checks every *other* router registered in `window.__avenx_routers` to see whether one of them owns that hash (respecting each router's own `prefix`). Only if **no other router claims the hash** does the local wildcard fire.
+This means, in the example above, if `hostApp`'s router doesn't have a matching route for `#/widget/home`, it won't incorrectly trigger its own `*` fallback — it detects that `widgetApp`'s router owns that hash and steps aside.
+:::note
+Only named routes count when checking whether another router "owns" a hash — wildcard routes are never considered a match by other routers, so two routers with `*` fallbacks never block each other.
+:::
+:::caution
+Because routers coordinate through a shared global registry, always call `router.destroy()` when tearing down a router instance (for example, when unmounting a micro-frontend). A router left in `window.__avenx_routers` after it's no longer in use keeps its `hashchange` listener attached and continues to be consulted by other routers' fallback checks.
+:::
+## 6. Route Guards
 Guards decide whether a transition to a page is allowed. Create a guard using the CLI:
-
 ```bash
 npx avenx g guard auth
 ```
-
 Implement the `canActivate(to, from)` method. Return a boolean, a redirect string, or a Promise:
-
 ```javascript
 // src/guards/auth.guard.js
 import { AvenxGuard } from 'avenx-core/runtime';
-
 export default class AuthGuard extends AvenxGuard {
   canActivate(to, from) {
     // Return true to allow, false to block, or hash path to redirect
@@ -66,18 +106,16 @@ export default class AuthGuard extends AvenxGuard {
   }
 }
 ```
-
 :::caution
 Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
 :::warning
 Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
 :::
-
 Map guards to routes in your application router initialization:
-
 ```javascript
 app.initRouter({
   '/': 'Home',
   '/dashboard': { page: 'Dashboard', guards: [AuthGuard] },
 });
+
 ```


### PR DESCRIPTION
## Summary
Documents the previously-undocumented `provide`/`inject` state injection API
on `AvenxComponent`, which lets an ancestor component expose values that any
descendant in its subtree can read directly, without prop drilling or the
overhead of a global bridge.

Closes #339

## Changes
- Added a "Reactivity Injection (Provide / Inject)" section to
  `docs/src/content/docs/core-concepts/reactivity.md`, after "Nested Reactivity"
- Documents all three declaration forms for both `provide` and `inject`
  (object, function, array of keys)
- Step-by-step example: a page provides `theme`/`setTheme`, a nested
  `theme-toggle` component injects and uses them
- Explains the reactive mapping: object-form provide is proxy-wrapped;
  array-form reads live off the provider's own state/props/methods; both
  resolve lazily on every access rather than being cached at mount
- Notes nearest-ancestor precedence and the silent-`undefined`-plus-warning
  behavior when no provider exists for a key

## Notes for reviewers
Written directly from `AvenxComponent`'s `__initProvide`/`__initInjection`/
`#findAncestorProviding` implementation, so the mechanics should be accurate
as of this version. Worth double-checking the "object vs. array reactivity"
distinction reads clearly to someone who hasn't seen the source — it's a
subtle but important difference for anyone relying on this for reactive UI.