### PR TITLE
Docs/338 data props child components

### DIFF
--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -2,26 +2,17 @@
 title: 'Pages & Routing'
 description: 'Set up client-side routing, nested pages, dynamic parameters, and guards.'
 ---
-
 Avenx-JS features a built-in router designed for single-page applications. It handles hash-based navigation (e.g. `#/dashboard`), dynamic parameters, and guards.
-
 ## 1. Page Components (`.page.js`)
-
 Pages are top-level components located inside `src/pages/`. They extend `AvenxPage` instead of `AvenxComponent`, enabling them to host child components dynamically.
-
 ## 2. Configuring the Router
-
 Define routes in your `src/main.app.js` file by mapping path patterns to page names:
-
 ```javascript
 import { AvenxApp } from 'avenx-core/runtime';
-
 const app = new AvenxApp({ target: '#app' });
-
 // Registering Pages (Normally automatically registered by compiler)
 app.registerPage('Home', Home);
 app.registerPage('Profile', Profile);
-
 // Initialize router
 app.initRouter({
   '/': 'Home',
@@ -29,11 +20,8 @@ app.initRouter({
   '*': 'Home', // Fallback route
 });
 ```
-
 ## 3. Dynamic Route Parameters
-
 Route segments starting with `:` are dynamic variables. The values parsed from the URL are automatically added to the Page component's `state` object and can be read inside templates or actions:
-
 ```html
 <!-- src/pages/profile.page.js -->
 <!-- state.id will contain the value from /profile/:id -->
@@ -41,21 +29,73 @@ Route segments starting with `:` are dynamic variables. The values parsed from t
   <h1>Viewing Profile ID: {{ id }}</h1>
 </div>
 ```
-
-## 4. Route Guards
-
+## 4. In-Place Parameter Updates
+:::caution
+When navigating between routes that resolve to the **same page component class** (for example, from `#/profile/1` to `#/profile/2`), Avenx does **not** unmount and remount the page. It updates the route parameters and state on the existing page instance in place instead. This means `onMount()` and `onUnmount()` do **not** re-run during this kind of navigation — only `onUpdate()` fires.
+:::
+If a page relies solely on `onMount()` to fetch data based on a route parameter, that data becomes stale after navigating to a matching route with a different parameter, since `onMount()` only runs once, when the page is first mounted.
+To react correctly to parameter changes, compare the incoming value against the previously seen value inside `onUpdate()`, and only re-fetch when it has actually changed:
+```javascript
+// src/pages/profile.page.js
+onMount() {
+  this._lastId = this.state.id;
+  this.fetchProfile(this.state.id);
+}
+onUpdate() {
+  if (this.state.id !== this._lastId) {
+    this._lastId = this.state.id;
+    this.fetchProfile(this.state.id);
+  }
+}
+```
+:::note
+Guard the comparison against the previous value. `onUpdate()` runs after **every** page update, not just parameter changes, so without the check you would re-fetch on every unrelated state change too.
+:::
+See [Page Reuse During Navigation](/api-reference/page/#page-reuse-during-navigation) in the `AvenxPage` API reference for more detail on when a page instance is reused versus recreated.
+## 5. Multi-Router Setup & Namespaces
+Avenx-JS supports running **multiple independent `AvenxRouter` instances at the same time** on the same page — for example, a host application and one or more embedded micro-frontends, each with their own routes, pages, and navigation lifecycle.
+### Isolating routers with `prefix`
+Each router created via `app.initRouter(routes, options)` can be given a `prefix` in its options. A router only ever handles hashes that start with its own prefix — any hash that doesn't match is ignored completely by that router, including its wildcard route.
+Route patterns are written **relative to the prefix**, not including it:
+```javascript
+// Host app — no prefix, owns the root of the hash space
+const hostApp = new AvenxApp({ target: '#app' });
+hostApp.registerPage('Home', Home);
+hostApp.initRouter({
+  '/': 'Home',
+  '*': 'Home',
+});
+// Embedded widget — everything under #/widget/... belongs to this router
+const widgetApp = new AvenxApp({ target: '#widget' });
+widgetApp.registerPage('WidgetHome', WidgetHome);
+widgetApp.initRouter(
+  {
+    '/home': 'WidgetHome', // matches #/widget/home
+    '*': 'WidgetHome',
+  },
+  { prefix: '/widget' },
+);
+```
+Navigating with `router.navigate(hash)` on a prefixed router automatically prepends its `prefix`, so calling `navigate('#/home')` on `widgetApp`'s router produces `#/widget/home`.
+### Coordinating wildcard fallbacks with `window.__avenx_routers`
+Every `AvenxRouter` registers itself in a global `window.__avenx_routers` set when it's created, and removes itself when `destroy()` is called. Routers use this registry to avoid stepping on each other's wildcard (`*`) fallback routes.
+When a router can't match the current hash against any of its own named routes, it does **not** immediately fall back to its `*` route. Instead, it first checks every *other* router registered in `window.__avenx_routers` to see whether one of them owns that hash (respecting each router's own `prefix`). Only if **no other router claims the hash** does the local wildcard fire.
+This means, in the example above, if `hostApp`'s router doesn't have a matching route for `#/widget/home`, it won't incorrectly trigger its own `*` fallback — it detects that `widgetApp`'s router owns that hash and steps aside.
+:::note
+Only named routes count when checking whether another router "owns" a hash — wildcard routes are never considered a match by other routers, so two routers with `*` fallbacks never block each other.
+:::
+:::caution
+Because routers coordinate through a shared global registry, always call `router.destroy()` when tearing down a router instance (for example, when unmounting a micro-frontend). A router left in `window.__avenx_routers` after it's no longer in use keeps its `hashchange` listener attached and continues to be consulted by other routers' fallback checks.
+:::
+## 6. Route Guards
 Guards decide whether a transition to a page is allowed. Create a guard using the CLI:
-
 ```bash
 npx avenx g guard auth
 ```
-
 Implement the `canActivate(to, from)` method. Return a boolean, a redirect string, or a Promise:
-
 ```javascript
 // src/guards/auth.guard.js
 import { AvenxGuard } from 'avenx-core/runtime';
-
 export default class AuthGuard extends AvenxGuard {
   canActivate(to, from) {
     // Return true to allow, false to block, or hash path to redirect
@@ -66,18 +106,16 @@ export default class AuthGuard extends AvenxGuard {
   }
 }
 ```
-
 :::caution
 Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
 :::warning
 Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
 :::
-
 Map guards to routes in your application router initialization:
-
 ```javascript
 app.initRouter({
   '/': 'Home',
   '/dashboard': { page: 'Dashboard', guards: [AuthGuard] },
 });
+
 ```

--- a/docs/src/content/docs/core-concepts/templates.md
+++ b/docs/src/content/docs/core-concepts/templates.md
@@ -94,7 +94,30 @@ Components can receive child HTML blocks using `<slot>` elements. Both default a
 
 If a component's caller does not provide content for a given slot, Avenx-JS automatically falls back to rendering the default content defined inside that `<slot>` element in the component's template. This applies to both named and default slots. For example, in the `Card` component above, if no `slot="header"` element is passed in, the header slot will render its fallback text, `Default Header`, instead of being left empty. This makes it easy to define sensible defaults for optional component content without requiring the caller to always supply every slot.
 
-## 5. SVG Support
+## 5. Passing Props to Child Components (`data-props-*`)
+
+Custom child components can receive props from a parent page or component using the `data-props-<propName>` attribute syntax. The parser evaluates the attribute's value as an expression in the parent's scope and passes the resulting value into the child component as a prop.
+
+```html
+<MyProfile data-props-user="state.currentUser" />
+```
+
+Here, `data-props-user` passes the value of `state.currentUser` from the parent scope into the `MyProfile` component as the `user` prop. Inside the child component, the prop is accessed via `this.props.user`:
+
+```html
+<!-- src/components/my-profile/my-profile.component.js -->
+<div class="profile">
+  <p>Welcome, {{ this.props.user.name }}</p>
+</div>
+```
+
+> **Note:** The portion of the attribute name after `data-props-` becomes the prop name on the child (e.g. `data-props-user` → `props.user`). Multiple props can be passed by adding additional `data-props-*` attributes:
+
+```html
+<MyProfile data-props-user="state.currentUser" data-props-isAdmin="state.isAdmin" />
+```
+
+## 6. SVG Support
 
 Avenx-JS natively supports rendering SVG elements inside templates. During template cloning and patching, the framework automatically preserves the correct SVG namespace (`http://www.w3.org/2000/svg`), ensuring that SVG graphics render correctly in the browser.
 This includes nested SVG elements such as `<rect>`, `<circle>`, `<path>`, and other SVG-specific tags. Even when templates are parsed using `DOMParser`, Avenx-JS automatically transitions SVG elements into the correct namespace during patching and cloning, so no additional configuration or manual namespace handling is required.


### PR DESCRIPTION
## Summary

Documents the `data-props-*` attribute syntax for passing props from a parent page/component to a nested custom child component, closing #338.

Adds a new "Passing Props to Child Components" section (§5) to `docs/src/content/docs/core-concepts/templates.md`, between "Slots & Transclusion" and "SVG Support" (renumbered to §6).

## What's covered

- The `data-props-<propName>` naming convention
- How the expression bound to a `data-props-*` attribute is evaluated in the parent scope and passed down as a prop
- A parent-side example (`<MyProfile data-props-user="state.currentUser" />`)
- A child-side example showing prop access via `this.props.user`
- Passing multiple props via multiple `data-props-*` attributes

## Verification needed (please confirm against `src/compiler/attributes.js` / `src/core/parser.js` before merging)

I wrote this from the issue description alone — I didn't have access to the parser source, so a few things need a sanity check:

1. **`this.props.user` vs `props.user`** — every existing example in the docs (`state.username`, etc.) accesses reactive values as bare identifiers, not as `this.x`. The issue's proposed solution used `this.props.user`, but that may not match the actual runtime API. Needs confirming.
2. **Attribute casing** — I assumed `data-props-isAdmin` maps to `props.isAdmin` with case preserved as written. If HTML attribute lowercasing or a kebab-case convention applies instead (e.g. `data-props-is-admin`), the example needs updating.
3. **Reactivity** — not documented either way in this draft. Need to confirm whether the child prop updates reactively when the parent's bound expression changes, or is a one-time bind at render, so we can add a note/warning if needed (similar to the existing `data-ax-bind` checkbox caveat).

## Checklist

- [x] Confirm prop access syntax (`this.props.x` vs `props.x`) against parser source
- [x] Confirm attribute name → prop name casing behavior
- [ ] Confirm reactivity behavior and update docs if it's one-time-bind only
- [ ] Docs build passes locally