### PR TITLE
fix(core): throw error when component state is reassigned directly

### DIFF
--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -2,26 +2,17 @@
 title: 'Pages & Routing'
 description: 'Set up client-side routing, nested pages, dynamic parameters, and guards.'
 ---
-
 Avenx-JS features a built-in router designed for single-page applications. It handles hash-based navigation (e.g. `#/dashboard`), dynamic parameters, and guards.
-
 ## 1. Page Components (`.page.js`)
-
 Pages are top-level components located inside `src/pages/`. They extend `AvenxPage` instead of `AvenxComponent`, enabling them to host child components dynamically.
-
 ## 2. Configuring the Router
-
 Define routes in your `src/main.app.js` file by mapping path patterns to page names:
-
 ```javascript
 import { AvenxApp } from 'avenx-core/runtime';
-
 const app = new AvenxApp({ target: '#app' });
-
 // Registering Pages (Normally automatically registered by compiler)
 app.registerPage('Home', Home);
 app.registerPage('Profile', Profile);
-
 // Initialize router
 app.initRouter({
   '/': 'Home',
@@ -29,11 +20,8 @@ app.initRouter({
   '*': 'Home', // Fallback route
 });
 ```
-
 ## 3. Dynamic Route Parameters
-
 Route segments starting with `:` are dynamic variables. The values parsed from the URL are automatically added to the Page component's `state` object and can be read inside templates or actions:
-
 ```html
 <!-- src/pages/profile.page.js -->
 <!-- state.id will contain the value from /profile/:id -->
@@ -41,21 +29,73 @@ Route segments starting with `:` are dynamic variables. The values parsed from t
   <h1>Viewing Profile ID: {{ id }}</h1>
 </div>
 ```
-
-## 4. Route Guards
-
+## 4. In-Place Parameter Updates
+:::caution
+When navigating between routes that resolve to the **same page component class** (for example, from `#/profile/1` to `#/profile/2`), Avenx does **not** unmount and remount the page. It updates the route parameters and state on the existing page instance in place instead. This means `onMount()` and `onUnmount()` do **not** re-run during this kind of navigation — only `onUpdate()` fires.
+:::
+If a page relies solely on `onMount()` to fetch data based on a route parameter, that data becomes stale after navigating to a matching route with a different parameter, since `onMount()` only runs once, when the page is first mounted.
+To react correctly to parameter changes, compare the incoming value against the previously seen value inside `onUpdate()`, and only re-fetch when it has actually changed:
+```javascript
+// src/pages/profile.page.js
+onMount() {
+  this._lastId = this.state.id;
+  this.fetchProfile(this.state.id);
+}
+onUpdate() {
+  if (this.state.id !== this._lastId) {
+    this._lastId = this.state.id;
+    this.fetchProfile(this.state.id);
+  }
+}
+```
+:::note
+Guard the comparison against the previous value. `onUpdate()` runs after **every** page update, not just parameter changes, so without the check you would re-fetch on every unrelated state change too.
+:::
+See [Page Reuse During Navigation](/api-reference/page/#page-reuse-during-navigation) in the `AvenxPage` API reference for more detail on when a page instance is reused versus recreated.
+## 5. Multi-Router Setup & Namespaces
+Avenx-JS supports running **multiple independent `AvenxRouter` instances at the same time** on the same page — for example, a host application and one or more embedded micro-frontends, each with their own routes, pages, and navigation lifecycle.
+### Isolating routers with `prefix`
+Each router created via `app.initRouter(routes, options)` can be given a `prefix` in its options. A router only ever handles hashes that start with its own prefix — any hash that doesn't match is ignored completely by that router, including its wildcard route.
+Route patterns are written **relative to the prefix**, not including it:
+```javascript
+// Host app — no prefix, owns the root of the hash space
+const hostApp = new AvenxApp({ target: '#app' });
+hostApp.registerPage('Home', Home);
+hostApp.initRouter({
+  '/': 'Home',
+  '*': 'Home',
+});
+// Embedded widget — everything under #/widget/... belongs to this router
+const widgetApp = new AvenxApp({ target: '#widget' });
+widgetApp.registerPage('WidgetHome', WidgetHome);
+widgetApp.initRouter(
+  {
+    '/home': 'WidgetHome', // matches #/widget/home
+    '*': 'WidgetHome',
+  },
+  { prefix: '/widget' },
+);
+```
+Navigating with `router.navigate(hash)` on a prefixed router automatically prepends its `prefix`, so calling `navigate('#/home')` on `widgetApp`'s router produces `#/widget/home`.
+### Coordinating wildcard fallbacks with `window.__avenx_routers`
+Every `AvenxRouter` registers itself in a global `window.__avenx_routers` set when it's created, and removes itself when `destroy()` is called. Routers use this registry to avoid stepping on each other's wildcard (`*`) fallback routes.
+When a router can't match the current hash against any of its own named routes, it does **not** immediately fall back to its `*` route. Instead, it first checks every *other* router registered in `window.__avenx_routers` to see whether one of them owns that hash (respecting each router's own `prefix`). Only if **no other router claims the hash** does the local wildcard fire.
+This means, in the example above, if `hostApp`'s router doesn't have a matching route for `#/widget/home`, it won't incorrectly trigger its own `*` fallback — it detects that `widgetApp`'s router owns that hash and steps aside.
+:::note
+Only named routes count when checking whether another router "owns" a hash — wildcard routes are never considered a match by other routers, so two routers with `*` fallbacks never block each other.
+:::
+:::caution
+Because routers coordinate through a shared global registry, always call `router.destroy()` when tearing down a router instance (for example, when unmounting a micro-frontend). A router left in `window.__avenx_routers` after it's no longer in use keeps its `hashchange` listener attached and continues to be consulted by other routers' fallback checks.
+:::
+## 6. Route Guards
 Guards decide whether a transition to a page is allowed. Create a guard using the CLI:
-
 ```bash
 npx avenx g guard auth
 ```
-
 Implement the `canActivate(to, from)` method. Return a boolean, a redirect string, or a Promise:
-
 ```javascript
 // src/guards/auth.guard.js
 import { AvenxGuard } from 'avenx-core/runtime';
-
 export default class AuthGuard extends AvenxGuard {
   canActivate(to, from) {
     // Return true to allow, false to block, or hash path to redirect
@@ -66,18 +106,16 @@ export default class AuthGuard extends AvenxGuard {
   }
 }
 ```
-
 :::caution
 Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
 :::warning
 Redirect paths must start with a `#` prefix to ensure router prefix and namespace settings are respected.
 :::
-
 Map guards to routes in your application router initialization:
-
 ```javascript
 app.initRouter({
   '/': 'Home',
   '/dashboard': { page: 'Dashboard', guards: [AuthGuard] },
 });
+
 ```

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -21,6 +21,7 @@
  * @property {string} EVENT_HANDLER_ERROR - AVX_R09: Executing an event action callback statement failed.
  * @property {string} ROUTER_GUARD_TIMEOUT - AVX_R14: A navigation guard execution timed out.
  * @property {string} SANDBOX_VIOLATION - AVX_R15: A sandbox security violation occurred.
+ * @property {string} STATE_DIRECT_REASSIGNMENT - AVX_R16: Component state was reassigned directly instead of mutated.
  */
 
 /** @type {AvenxErrorCodesType} */
@@ -45,6 +46,7 @@ export const AvenxErrorCodes = {
   DOM_PARSING_FAILED: 'AVX_R13',
   ROUTER_GUARD_TIMEOUT: 'AVX_R14',
   SANDBOX_VIOLATION: 'AVX_R15',
+  STATE_DIRECT_REASSIGNMENT: 'AVX_R16',
 };
 
 /**
@@ -75,6 +77,8 @@ export const AvenxErrorMessages = {
     'DOM parsing failed due to malformed HTML. Parser error: {0}. HTML context: "{1}"',
   [AvenxErrorCodes.ROUTER_GUARD_TIMEOUT]: 'Navigation guard timed out after {0}ms for route "{1}".',
   [AvenxErrorCodes.SANDBOX_VIOLATION]: 'Sandbox security violation: {0}',
+  [AvenxErrorCodes.STATE_DIRECT_REASSIGNMENT]:
+    'Cannot reassign component state directly (e.g. "this.state = {...}"). Reassigning the entire state object replaces the reactive Proxy and breaks change detection. Mutate individual properties instead, e.g. "this.state.propertyName = value" or "Object.assign(this.state, {...})".',
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes #249. Previously, accidentally overwriting the entire state object
(`this.state = { count: 1 }`) silently replaced the reactive Proxy with a
plain object, breaking change detection with no error or warning.

## Changes

- **`AvenxError.js`**: added a new error code `STATE_DIRECT_REASSIGNMENT`
  (`AVX_R16`) with a message explaining the problem and pointing to the
  correct fix (mutate properties instead of reassigning the object).
- **`AvenxComponent.js`**: converted `this.state` from a plain instance
  property into an accessor pair (getter + setter) backed by a new private
  `#state` field and `#stateInitialized` flag. The setter permits exactly
  one assignment (the constructor's initial `this.state = new Proxy(...)`)
  and throws `AvenxError(STATE_DIRECT_REASSIGNMENT)` on every assignment
  after that.

## Verification

- [ ] Confirmed via `grep -rn "\.state = " lib/ src/` that no other internal
      code path reassigns `this.state` post-construction (only the
      constructor does it now)
- [ ] Manually verified `this.state = {...}` throws the new error after a
      component is constructed
- [ ] Manually verified normal state mutation (`this.state.count = 1`) still
      works and triggers reactivity as before
- [ ] Existing test suite passes