### PR TITLE
feat(component): introduce data-ax-ref for DOM element referencing

### DIFF
--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -128,6 +128,9 @@ export class AvenxComponent {
     /** @type {AvenxComponent|null} */
     this.$parent = null;
 
+    /** @type {Record<string, Element>} */
+    this.$refs = {};
+
     this.#template = processBindDirectives(template);
     this.#bridges = bridges;
     this.#computed = new ComputedRegistry(computed);
@@ -322,6 +325,8 @@ export class AvenxComponent {
       this.#listManager.process(this.#element, this.#createScope(), this.state);
       this.#eventBinder.bind(this.#element, this.#eventExecutor);
 
+      this.#collectRefs();
+
       if (this.#isMounted && this.#element?.dispatchEvent) {
         this.#element.dispatchEvent(new CustomEvent('avenx:update'));
       }
@@ -422,11 +427,6 @@ export class AvenxComponent {
   }
 
   /**
-   * Fills <slot> elements with transcluded child nodes.
-   * Supports both static and dynamically rendered slot names.
-   * @private
-   */
-  /**
    * Retrieves default children of a slot by parsing the rendered template.
    * @param {string|null} name - The name of the slot.
    * @returns {Node[]} Cloned child nodes.
@@ -514,6 +514,38 @@ export class AvenxComponent {
       }
 
       return true;
+    });
+  }
+
+  /**
+   * Collects elements marked with data-ax-ref that belong to this component.
+   * Elements inside nested component boundaries are excluded.
+   * @private
+   */
+  #collectRefs() {
+    this.$refs = {};
+
+    if (!this.#element) return;
+
+    const refElements = this.#element.querySelectorAll('[data-ax-ref]');
+    const root = this.#element;
+
+    Array.from(refElements).forEach((element) => {
+      let current = element;
+
+      while (current && current !== root) {
+        if (current.hasAttribute && current.hasAttribute('data-avenx-comp')) {
+          return;
+        }
+
+        current = current.parentNode;
+      }
+
+      const refName = element.getAttribute('data-ax-ref');
+
+      if (refName && refName.trim()) {
+        this.$refs[refName.trim()] = element;
+      }
     });
   }
 
@@ -635,6 +667,8 @@ export class AvenxComponent {
     if (this._propsHandler) {
       this._propsHandler.teardown();
     }
+
+    this.$refs = {};
 
     if (this.#element) {
       delete this.#element.__avenx_comp_instance;

--- a/test/helpers/dom-mock.js
+++ b/test/helpers/dom-mock.js
@@ -13,7 +13,7 @@ class MockDOMElement {
   constructor(tagName, namespaceURI = 'http://www.w3.org/1999/xhtml') {
     this.tagName = tagName.toUpperCase();
     this.nodeName = tagName.toUpperCase();
-    this.nodeType = 1; // Element Node
+    this.nodeType = 1;
     this.namespaceURI = namespaceURI;
     this.childNodes = [];
     this._attrs = {};
@@ -67,32 +67,18 @@ class MockDOMElement {
       },
     };
 
-    // Verhaltensaufzeichnung (Interaction Logging)
     this.recordedCalls = [];
   }
 
-  /**
-   *
-   * @param name
-   * @param value
-   */
   setAttribute(name, value) {
     this._attrs[name] = String(value);
     this.attributes = Object.entries(this._attrs).map(([k, v]) => ({ name: k, value: v }));
   }
 
-  /**
-   *
-   * @param name
-   */
   getAttribute(name) {
     return this._attrs[name] !== undefined ? this._attrs[name] : null;
   }
 
-  /**
-   *
-   * @param name
-   */
   hasAttribute(name) {
     return this._attrs[name] !== undefined;
   }
@@ -105,29 +91,17 @@ class MockDOMElement {
     this.setAttribute('class', val);
   }
 
-  /**
-   *
-   * @param name
-   */
   removeAttribute(name) {
     delete this._attrs[name];
     this.attributes = Object.entries(this._attrs).map(([k, v]) => ({ name: k, value: v }));
   }
 
-  /**
-   *
-   * @param child
-   */
   appendChild(child) {
     child.parentNode = this;
     this.childNodes.push(child);
     return child;
   }
 
-  /**
-   *
-   * @param child
-   */
   removeChild(child) {
     const idx = this.childNodes.indexOf(child);
     if (idx !== -1) {
@@ -137,11 +111,6 @@ class MockDOMElement {
     }
   }
 
-  /**
-   *
-   * @param newChild
-   * @param oldChild
-   */
   replaceChild(newChild, oldChild) {
     const idx = this.childNodes.indexOf(oldChild);
     if (idx !== -1) {
@@ -152,11 +121,6 @@ class MockDOMElement {
     }
   }
 
-  /**
-   *
-   * @param newChild
-   * @param referenceChild
-   */
   insertBefore(newChild, referenceChild) {
     newChild.parentNode = this;
     const idx = this.childNodes.indexOf(referenceChild);
@@ -168,10 +132,6 @@ class MockDOMElement {
     return newChild;
   }
 
-  /**
-   *
-   * @param deep
-   */
   cloneNode(deep) {
     const copy = new MockDOMElement(this.tagName, this.namespaceURI);
     copy.value = this.value;
@@ -182,6 +142,7 @@ class MockDOMElement {
     copy.style.animationDuration = this.style.animationDuration;
     copy.style.transitionDelay = this.style.transitionDelay;
     copy.style.animationDelay = this.style.animationDelay;
+
     if (deep) {
       this.childNodes.forEach((child) => {
         if (child.nodeType === 1) {
@@ -191,84 +152,79 @@ class MockDOMElement {
         }
       });
     }
+
     return copy;
   }
 
   /**
+   * Queries descendant elements.
    *
-   * @param selector
+   * Supports:
+   * - universal selector (*)
+   * - tag selectors
+   * - attribute presence selectors ([attribute])
+   *
+   * @param {string} selector
+   * @returns {MockDOMElement[]}
    */
   querySelectorAll(selector) {
     const results = [];
     const lowerSel = selector.toLowerCase();
+    const attributeMatch = selector.match(/^\[([^\]]+)\]$/);
+
     const traverse = (node) => {
       node.childNodes.forEach((child) => {
         if (child.nodeType === 1) {
-          if (selector === '*' || child.tagName.toLowerCase() === lowerSel) {
+          const matchesSelector =
+            selector === '*' ||
+            child.tagName.toLowerCase() === lowerSel ||
+            (attributeMatch && child.hasAttribute(attributeMatch[1]));
+
+          if (matchesSelector) {
             results.push(child);
           }
+
           traverse(child);
         }
       });
     };
+
     traverse(this);
     return results;
   }
 
-  /**
-   *
-   * @param event
-   * @param callback
-   */
   addEventListener(event, callback) {
-    // Protokolliert den Aufruf für spätere Assertions
     this.recordedCalls.push({ method: 'addEventListener', event, callback });
   }
 
-  /**
-   *
-   * @param event
-   * @param callback
-   */
   removeEventListener(event, callback) {
-    // Protokolliert den Aufruf für spätere Assertions
     this.recordedCalls.push({ method: 'removeEventListener', event, callback });
   }
 
-  /**
-   *
-   * @param event
-   */
   dispatchEvent(event) {
     this.recordedCalls.push({ method: 'dispatchEvent', event });
   }
 
-  // Verifikations-Methoden zur Verhaltensprüfung (Behavior Verification)
-  /**
-   *
-   * @param event
-   */
   assertListenerWasAdded(event) {
-    const found = this.recordedCalls.some((call) => call.method === 'addEventListener' && call.event === event);
+    const found = this.recordedCalls.some(
+      (call) => call.method === 'addEventListener' && call.event === event,
+    );
+
     assert.ok(found, `Erwartung fehlgeschlagen: addEventListener wurde nicht für "${event}" aufgerufen.`);
   }
 
-  /**
-   *
-   * @param event
-   */
   assertListenerWasRemoved(event) {
-    const found = this.recordedCalls.some((call) => call.method === 'removeEventListener' && call.event === event);
+    const found = this.recordedCalls.some(
+      (call) => call.method === 'removeEventListener' && call.event === event,
+    );
+
     assert.ok(found, `Erwartung fehlgeschlagen: removeEventListener wurde nicht für "${event}" aufgerufen.`);
   }
 }
 
-// 2. Hilfsfunktionen zum Registrieren und Zurücksetzen der globalen Variablen
-/**
- *
- */
 function setupDOMMock() {
   global.Node = { ELEMENT_NODE: 1, TEXT_NODE: 3 };
+
   global.document = {
     querySelector: () => new MockDOMElement('div'),
     createElement: (tag) => new MockDOMElement(tag),
@@ -276,6 +232,7 @@ function setupDOMMock() {
   };
 
   global.window = global.window || {};
+
   global.window.getComputedStyle = (el) => {
     return (
       el.style || {
@@ -286,21 +243,18 @@ function setupDOMMock() {
       }
     );
   };
+
   global.requestAnimationFrame = (cb) => {
     return setTimeout(() => cb(Date.now()), 0);
   };
 
   global.DOMParser = class {
-    /**
-     *
-     * @param htmlString
-     */
     parseFromString(htmlString) {
       const body = new MockDOMElement('body');
 
-      // Einfacher HTML Regex Parser
       const tagRegex = /<([a-z0-9-]+)([^>]*?)>([\s\S]*?)<\/\1>/gi;
       let match;
+
       while ((match = tagRegex.exec(htmlString)) !== null) {
         const tagName = match[1];
         const attrsStr = match[2];
@@ -310,6 +264,7 @@ function setupDOMMock() {
 
         const attrRegex = /([\w@:-]+)(?:=(?:"([^"]*)"|'([^']*)'))?/g;
         let attrMatch;
+
         while ((attrMatch = attrRegex.exec(attrsStr)) !== null) {
           const attrName = attrMatch[1];
           const attrValue = attrMatch[2] || attrMatch[3] || '';
@@ -323,6 +278,7 @@ function setupDOMMock() {
             textContent: content,
             parentNode: element,
           };
+
           element.childNodes.push(textNode);
         }
 
@@ -334,9 +290,6 @@ function setupDOMMock() {
   };
 }
 
-/**
- *
- */
 function teardownDOMMock() {
   delete global.Node;
   delete global.document;

--- a/test/unit/componentRefs.test.js
+++ b/test/unit/componentRefs.test.js
@@ -1,0 +1,144 @@
+import assert from 'assert';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+import { MockDOMElement, setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ * Tests that elements marked with data-ax-ref are exposed through $refs.
+ */
+function testComponentRefCollection() {
+  console.log('🧪 Testing data-ax-ref collection...');
+
+  setupDOMMock();
+
+  try {
+    const component = new AvenxComponent();
+
+    const root = new MockDOMElement('div');
+    const input = new MockDOMElement('input');
+
+    input.setAttribute('data-ax-ref', 'myInput');
+
+    component.__setMountTarget(root);
+
+    root.appendChild(input);
+
+    component.runUpdate();
+
+    assert.strictEqual(
+      component.$refs.myInput,
+      input,
+      '$refs.myInput should point to the referenced DOM element.',
+    );
+
+    console.log('  ✅ data-ax-ref element is available through $refs.');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+/**
+ * Tests that refs are scoped to the current component boundary.
+ */
+function testComponentRefScoping() {
+  console.log('🧪 Testing data-ax-ref component scoping...');
+
+  setupDOMMock();
+
+  try {
+    const component = new AvenxComponent();
+
+    const root = new MockDOMElement('div');
+
+    const parentInput = new MockDOMElement('input');
+    parentInput.setAttribute('data-ax-ref', 'parentInput');
+
+    const childComponent = new MockDOMElement('div');
+    childComponent.setAttribute('data-avenx-comp', 'child-component');
+
+    const childInput = new MockDOMElement('input');
+    childInput.setAttribute('data-ax-ref', 'childInput');
+
+    childComponent.appendChild(childInput);
+
+    component.__setMountTarget(root);
+
+    root.appendChild(parentInput);
+    root.appendChild(childComponent);
+
+    component.runUpdate();
+
+    assert.strictEqual(
+      component.$refs.parentInput,
+      parentInput,
+      'The parent component should collect its own ref.',
+    );
+
+    assert.strictEqual(
+      component.$refs.childInput,
+      undefined,
+      'The parent component should not collect refs inside nested components.',
+    );
+
+    console.log('  ✅ Refs remain scoped to the current component boundary.');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+/**
+ * Tests that refs are cleared when the component is unmounted.
+ */
+function testComponentRefCleanup() {
+  console.log('🧪 Testing data-ax-ref cleanup...');
+
+  setupDOMMock();
+
+  try {
+    const component = new AvenxComponent();
+
+    const root = new MockDOMElement('div');
+    const input = new MockDOMElement('input');
+
+    input.setAttribute('data-ax-ref', 'myInput');
+
+    component.__setMountTarget(root);
+
+    root.appendChild(input);
+
+    component.runUpdate();
+
+    assert.strictEqual(
+      component.$refs.myInput,
+      input,
+      '$refs.myInput should exist before unmount.',
+    );
+
+    component.unmount();
+
+    assert.deepStrictEqual(
+      component.$refs,
+      {},
+      '$refs should be cleared after component unmount.',
+    );
+
+    console.log('  ✅ $refs are cleared after unmount.');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+function runTests() {
+  try {
+    testComponentRefCollection();
+    testComponentRefScoping();
+    testComponentRefCleanup();
+
+    console.log('✅ All component ref tests passed successfully!');
+  } catch (error) {
+    console.error('❌ Component ref tests failed!');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+runTests();


### PR DESCRIPTION
## Description
Closes #238 — Introduce data-ax-ref for DOM Element Referencing
This PR introduces support for `data-ax-ref`, providing a component-scoped way to directly access DOM elements through `this.$refs`.

Previously, developers had to use global DOM queries such as `document.querySelector()` to access elements inside components. These queries are not scoped to a specific component instance and can cause conflicts when multiple components contain similar elements.

With this change, developers can mark elements using `data-ax-ref` and access the corresponding DOM element directly through the component's `$refs` mapping.

## Example

A DOM element can be referenced in a component template using:

```html
<input data-ax-ref="myInput">

After the component is rendered, the element can be accessed using:

this.$refs.myInput
Changes Made
Added a $refs mapping to AvenxComponent.
Added support for collecting elements marked with data-ax-ref.
Collects refs after the component DOM has been rendered and updated.
Maps each ref name directly to its corresponding DOM element.
Scopes ref collection to the current component root.
Excludes refs that belong to nested component boundaries.
Refreshes $refs during component updates to keep references synchronized with the rendered DOM.
Clears $refs when the component is unmounted to prevent stale DOM references.
Updated the DOM test mock to support attribute selectors.
Added unit tests covering ref collection, component scoping, and cleanup behavior.
Component Scoping

Ref collection is performed relative to the current component root instead of using global DOM queries.

This ensures that refs belonging to nested components are not accidentally collected by their parent component, maintaining proper component isolation.

Testing

Unit tests were added to verify that:

Elements marked with data-ax-ref are correctly collected.
this.$refs.myInput points to the corresponding DOM element.
Ref collection is scoped to the current component boundary.
Refs inside nested components are excluded from the parent component.
$refs is cleared when the component is unmounted.
Benefits

This feature improves the developer experience by providing a convenient and component-scoped API for accessing DOM elements.

It removes the need for global document.querySelector() calls while maintaining proper component isolation and lifecycle cleanup.

Related Issue

Closes #238 — Introduce data-ax-ref for DOM Element Referencing