### PR TITLE
Docs/154 component nesting constraints

### DIFF
--- a/docs/src/content/docs/core-concepts/components.md
+++ b/docs/src/content/docs/core-concepts/components.md
@@ -35,8 +35,10 @@ Every attribute passed to `<state>` starts as a plain HTML attribute string. Bef
 - `count="42"` is resolved as a `number` → `42`
 - `tags='["work", "urgent"]'` is resolved as an `array`, parsed as JSON → `["work", "urgent"]`
 - `user='{"name": "John"}'` is resolved as an `object`, parsed as JSON → `{ name: "John" }`
-  Strings, booleans, and numbers are coerced automatically and require no special quoting. Arrays and objects are different: the parser attempts to parse the attribute's contents as **JSON**. If parsing fails, the parser cannot safely guess your intent, and the value falls back to a raw string instead of throwing, which often shows up later as a confusing error when your template or actions try to use it as an array or object.
-  Because array and object values are parsed as JSON, they must follow strict JSON syntax, most importantly, **object keys and string values must use double quotes**, not single quotes or unquoted identifiers. Since the attribute itself has to be wrapped in quotes too, wrap the **attribute** in single quotes and use **double quotes** for the JSON inside it:
+
+Strings, booleans, and numbers are coerced automatically and require no special quoting. Arrays and objects are different: the parser attempts to parse the attribute's contents as **JSON**. If parsing fails, the parser cannot safely guess your intent, and the value falls back to a raw string instead of throwing, which often shows up later as a confusing error when your template or actions try to use it as an array or object.
+
+Because array and object values are parsed as JSON, they must follow strict JSON syntax, most importantly, **object keys and string values must use double quotes**, not single quotes or unquoted identifiers. Since the attribute itself has to be wrapped in quotes too, wrap the **attribute** in single quotes and use **double quotes** for the JSON inside it:
 
 ```html
 <state user='{"name": "John", "role": "admin"}' /> <state tags='["work", "urgent", "backend"]' />
@@ -55,10 +57,92 @@ When declaring array or object state:
 - Avoid trailing commas, they are invalid in JSON even though they are valid in JavaScript.
 - If a `<state>` value behaves like a string instead of an array or object, check that it is valid JSON first.
 
+## Component Nesting Restrictions
+
+> **Important:** Custom components can currently only be resolved, instantiated, and mounted when they are declared directly inside an Avenx Page template (`.page.js`).
+
+Standard Avenx components (`.component.js`) do not support mounting child components inside their own templates. Child component registration and mounting are handled at the `AvenxPage` level and are not available to the base `AvenxComponent` class.
+
+For example, placing a custom component inside a Page template is supported:
+
+```html
+<!-- src/pages/home/home.page.js -->
+<div class="home-page">
+  <Navbar />
+  <Card />
+</div>
+```
+
+In this case, the Page runtime can resolve and mount the `Navbar` and `Card` components.
+
+However, nesting one custom component inside another standard component is currently not supported:
+
+```html
+<!-- src/components/card/card.component.js -->
+<div class="card">
+  <Navbar />
+  <p>Card content</p>
+</div>
+```
+
+Although the compiler may parse the custom `<Navbar />` tag, the base `AvenxComponent` runtime does not resolve and mount it as a child component.
+
+### Symptom
+
+When a custom component tag is placed inside a standard `.component.js` template, the application may render an empty element or placeholder in the DOM instead of mounting the expected child component.
+
+For example:
+
+```html
+<div class="card">
+  <Navbar />
+</div>
+```
+
+may result in the child component area appearing as an empty `div` in the rendered DOM.
+
+This behavior occurs because child component mounting is handled by `AvenxPage`, while standard `AvenxComponent` instances do not currently provide child component registration or mounting functionality.
+
+### Recommended Component Design
+
+Until nested components are supported by the component runtime:
+
+- Declare custom component instances directly inside `.page.js` templates.
+- Use Pages as the composition layer for combining multiple components.
+- Keep `.component.js` templates focused on their own markup, state, computed values, and actions.
+- Avoid placing custom component tags inside standard component templates.
+- Move sibling components to the containing Page when multiple components need to appear together.
+
+Instead of nesting components like this:
+
+```html
+<!-- Not currently supported -->
+<!-- src/components/dashboard/dashboard.component.js -->
+<div class="dashboard">
+  <Navbar />
+  <Stats />
+</div>
+```
+
+compose them directly in the Page template:
+
+```html
+<!-- Recommended -->
+<!-- src/pages/dashboard/dashboard.page.js -->
+<div class="dashboard">
+  <Navbar />
+  <Stats />
+</div>
+```
+
+This structure ensures that each custom component can be correctly resolved, instantiated, and mounted by the Page runtime.
+
 ## Compilation Lifecycle & Limits
 
 The Avenx compiler processes `.component.js` files by scanning for supported configuration tags and template content. During compilation, only `<state>`, `<computed>`, `<action>`, and template content are preserved and transformed into the generated component output.
+
 Standard JavaScript declarations written outside these supported tags, such as ES module imports, local variables, constants, and helper functions, are not preserved by the compiler. Code that depends on these declarations may therefore cause runtime `ReferenceError` exceptions after compilation.
+
 For example, avoid declaring imports or helper functions directly in a component file:
 
 ```javascript
@@ -74,7 +158,9 @@ function getDisplayName(name) {
 ```
 
 In this example, the `import`, `defaultName`, and `getDisplayName` declarations are outside the supported component tags and may be removed during compilation.
+
 Instead, keep component logic inside supported tags or move reusable utilities into external files that can be accessed through supported application patterns.
+
 For utilities that are intentionally exposed globally, reference them through the `window` object:
 
 ```html
@@ -88,4 +174,5 @@ When writing `.component.js` files:
 - Keep component methods and state mutations inside `<action>` tags.
 - Move reusable helper logic into external utility files.
 - Reference intentionally global utilities through properties on `window`.
-  Understanding these compilation limits helps prevent missing imports, undefined helpers, and runtime `ReferenceError` exceptions caused by code being removed from the compiled output.
+
+Understanding these compilation limits helps prevent missing imports, undefined helpers, and runtime `ReferenceError` exceptions caused by code being removed from the compiled output.

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -17,12 +17,6 @@ import { ProxyHandlerFactory } from '../reactive/proxyHandler.js';
 
 let currentMicrotaskPromise = null;
 
-/**
- * Processes data-ax-bind attributes on input, textarea, and select elements.
- * Converts data-ax-bind="expr" to value="{{ expr }}" and event listener.
- * @param {string} template - The template string.
- * @returns {string} The processed template.
- */
 function processBindDirectives(template) {
   if (typeof template !== 'string') return template;
   const tagRegex = /<(input|textarea|select)\b([^>]*?)>/gi;
@@ -51,82 +45,56 @@ function processBindDirectives(template) {
   });
 }
 
-/**
- * Base class for all Avenx components.
- * Manages state, reactivity, rendering, and lifecycle.
- */
 export class AvenxComponent {
-  /** @type {Element|null} @private */
   #element = null;
 
-  /** @type {string} @private */
   #template = '';
 
-  /** @type {object} @private */
   #methods = {};
 
-  /** @type {object} @private */
   #bridges = {};
 
-  /** @type {ComputedRegistry} @private */
   #computed;
 
-  /** @type {TemplateRenderer} @private */
   #renderer;
 
-  /** @type {DomPatcher} @private */
   #patcher;
 
-  /** @type {ListManager} @private */
   #listManager;
 
-  /** @type {EventBinder} @private */
   #eventBinder;
 
-  /** @type {EventExecutor} @private */
   #eventExecutor;
 
-  /** @type {DynamicEvaluator} @private */
   #evaluator;
 
-  /** @type {LifecycleManager} @private */
   #lifecycle;
 
-  /** @type {boolean} @private */
   #isMounted = false;
 
-  /** @type {boolean} @private */
   #isUpdating = false;
 
-  /** @type {Set<string>} @private */
   #evaluating = new Set();
 
-  /** @type {object | null} @private */
   #transcludedGroups = null;
 
-  /** @type {boolean} @private */
   #updateQueued = false;
 
-  /** @type {Function} @private */
   #updateJob = () => {
     this.#updateQueued = false;
     this.update();
   };
 
-  /** @type {Promise|null} @private */
   #lastUpdatedPromise = null;
 
-  /**
-   * @param {object} [initialState] - The initial state of the component.
-   * @param {object} [computed] - Computed properties definitions.
-   * @param {object} [bridges] - External bridges accessible to the component.
-   * @param {string} [template] - The HTML template string.
-   * @param {object} [methods] - Component methods.
-   * @param {object} [props] - Component properties.
-   */
   constructor(initialState = {}, computed = {}, bridges = {}, template = '', methods = {}, props = {}) {
-    /** @type {AvenxComponent|null} */
     this.$parent = null;
+
+    /**
+     * DOM elements registered with data-ax-ref, scoped to this component.
+     * @type {Record<string, Element>}
+     */
+    this.$refs = {};
 
     this.#template = processBindDirectives(template);
     this.#bridges = bridges;
@@ -138,7 +106,6 @@ export class AvenxComponent {
     this.#lifecycle = new LifecycleManager();
     this.#listManager = new ListManager(this.#evaluator, this.#renderer, this.#eventBinder);
 
-    /** @type {AvenxWatcher[]} @private */
     this._watchers = [];
 
     this._stateHandler = new ProxyHandlerFactory({
@@ -191,45 +158,37 @@ export class AvenxComponent {
     this.#eventExecutor = new EventExecutor((source, event) => this.#runEventHandler(source, event));
   }
 
-  /**
-   * Programmatically registers a watcher on a reactive expression/function.
-   * @param {function(): any} getter - Evaluation function returning the value to watch.
-   * @param {function(any, any): void} callback - Triggered when the value changes.
-   * @param {object} [options] - Config options.
-   * @returns {AvenxWatcher}
-   */
   watch(getter, callback, options = {}) {
     const watcher = new AvenxWatcher(getter, callback, options);
     this._watchers.push(watcher);
     return watcher;
   }
 
-  /**
-   * Creates a scope object for expression evaluation.
-   * @param {object} [methods] - Methods to include in the scope.
-   * @param {object} [extras] - Additional variables to include.
-   * @returns {object} The combined scope.
-   * @private
-   */
   #createScope(methods = this.#methods, extras = {}) {
     const injected = {};
+
     const injectOption =
       this.inject ||
       (typeof this.constructor.inject === 'function' ? this.constructor.inject() : this.constructor.inject);
+
     if (injectOption) {
       const resolvedOption = typeof injectOption === 'function' ? injectOption.call(this) : injectOption;
+
       let keys = [];
+
       if (Array.isArray(resolvedOption)) {
         keys = resolvedOption;
       } else if (resolvedOption && typeof resolvedOption === 'object') {
         keys = Object.keys(resolvedOption);
       }
+
       for (const key of keys) {
         if (key in this) {
           injected[key] = this[key];
         }
       }
     }
+
     return {
       state: this.state,
       ...this.state,
@@ -242,23 +201,10 @@ export class AvenxComponent {
     };
   }
 
-  /**
-   * Resolves an expression within the template.
-   * @param {string} expression - The expression to evaluate.
-   * @returns {any} The result of the evaluation.
-   * @private
-   */
   #resolveTemplateExpression(expression) {
     return this.#evaluator.evaluateExpression(expression, this.#createScope(), this.state);
   }
 
-  /**
-   * Runs an event handler.
-   * @param {string} source - The source code of the handler.
-   * @param {Event} event - The event object.
-   * @returns {any} The result of the execution.
-   * @private
-   */
   #runEventHandler(source, event) {
     try {
       return this.#evaluator.executeStatement(source, this.#createScope(this.#methods, { event }), this.state);
@@ -268,17 +214,10 @@ export class AvenxComponent {
     }
   }
 
-  /**
-   * Renders the component template with current state.
-   * @returns {string} The rendered HTML string.
-   */
   render() {
     return this.#renderer.render(this.#template, (expression) => this.#resolveTemplateExpression(expression));
   }
 
-  /**
-   * Triggers a synchronous DOM patch update and registers event/list bindings.
-   */
   update() {
     if (!this.renderWatcher) {
       this.renderWatcher = new AvenxWatcher(
@@ -291,9 +230,6 @@ export class AvenxComponent {
     this.renderWatcher.evaluate();
   }
 
-  /**
-   * Performs the actual update/render of the component.
-   */
   runUpdate() {
     if (!currentMicrotaskPromise) {
       currentMicrotaskPromise = Promise.resolve();
@@ -314,13 +250,18 @@ export class AvenxComponent {
     this.#isUpdating = true;
 
     try {
-      this.#patcher.patch(this.#element, this.render(), (expression) => this.#resolveTemplateExpression(expression));
+      this.#patcher.patch(
+        this.#element,
+        this.render(),
+        (expression) => this.#resolveTemplateExpression(expression),
+      );
 
-      // Fill slots with transcluded content.
       this.#fillSlots();
 
       this.#listManager.process(this.#element, this.#createScope(), this.state);
       this.#eventBinder.bind(this.#element, this.#eventExecutor);
+
+      this.#collectRefs();
 
       if (this.#isMounted && this.#element?.dispatchEvent) {
         this.#element.dispatchEvent(new CustomEvent('avenx:update'));
@@ -334,7 +275,14 @@ export class AvenxComponent {
             throw error;
           }
 
-          logger.error(formatMessage(AvenxErrorCodes.LIFECYCLE_HOOK_ERROR, this.constructor.name, 'onUpdate', error));
+          logger.error(
+            formatMessage(
+              AvenxErrorCodes.LIFECYCLE_HOOK_ERROR,
+              this.constructor.name,
+              'onUpdate',
+              error,
+            ),
+          );
         }
       }
     } finally {
@@ -342,19 +290,10 @@ export class AvenxComponent {
     }
   }
 
-  /**
-   * Executes a callback (or resolves a Promise) after the current reactive
-   * update cycle has finished flushing pending DOM updates.
-   * @param {Function} [callback] - Optional callback to run after the flush.
-   * @returns {Promise<void>|void} A promise resolving after the flush, if no callback was given.
-   */
   nextTick(callback) {
     return schedulerNextTick(callback);
   }
 
-  /**
-   * Schedules an update to run asynchronously in a microtask.
-   */
   scheduleUpdate() {
     if (this.#isUpdating) {
       throw new AvenxError(AvenxErrorCodes.STATE_MUTATION_IN_UPDATE);
@@ -370,11 +309,6 @@ export class AvenxComponent {
     queueJob(this.#updateJob);
   }
 
-  /**
-   * Internal method to set the mount target.
-   * @param {Element} target - The target element.
-   * @private
-   */
   __setMountTarget(target) {
     this.#element = target;
 
@@ -408,30 +342,11 @@ export class AvenxComponent {
     }
   }
 
-  /**
-   * Resolves the current name of a slot element.
-   * Dynamic slot names are evaluated during template rendering, so the
-   * rendered name attribute contains the value used for transclusion.
-   * @param {Element} slotEl - The slot element.
-   * @returns {string|null} The resolved slot name.
-   * @private
-   */
   #resolveSlotName(slotEl) {
     const name = slotEl.getAttribute('name');
     return name && name.trim() ? name.trim() : null;
   }
 
-  /**
-   * Fills <slot> elements with transcluded child nodes.
-   * Supports both static and dynamically rendered slot names.
-   * @private
-   */
-  /**
-   * Retrieves default children of a slot by parsing the rendered template.
-   * @param {string|null} name - The name of the slot.
-   * @returns {Node[]} Cloned child nodes.
-   * @private
-   */
   #getDefaultSlotChildren(name) {
     try {
       const parser = new DOMParser();
@@ -449,14 +364,10 @@ export class AvenxComponent {
     } catch (e) {
       logger.warn('[AvenxComponent] Failed to restore default slot content', e);
     }
+
     return [];
   }
 
-  /**
-   * Fills <slot> elements with transcluded child nodes.
-   * Supports both static and dynamically rendered slot names.
-   * @private
-   */
   #fillSlots() {
     if (!this.#element || !this.#transcludedGroups) return;
 
@@ -465,11 +376,19 @@ export class AvenxComponent {
     slots.forEach((slotEl) => {
       const name = this.#resolveSlotName(slotEl);
 
-      const nodes = name ? this.#transcludedGroups.named[name] || [] : this.#transcludedGroups.default || [];
+      const nodes = name
+        ? this.#transcludedGroups.named[name] || []
+        : this.#transcludedGroups.default || [];
 
       const hasContent = nodes.some((node) => {
-        if (node.nodeType === 1 && node.nodeName !== '!--' && node.nodeName !== '#comment') return true;
-        if (node.nodeType === 3 && node.textContent.trim().length > 0) return true;
+        if (node.nodeType === 1 && node.nodeName !== '!--' && node.nodeName !== '#comment') {
+          return true;
+        }
+
+        if (node.nodeType === 3 && node.textContent.trim().length > 0) {
+          return true;
+        }
+
         return false;
       });
 
@@ -484,6 +403,7 @@ export class AvenxComponent {
       } else {
         slotEl.removeAttribute('data-avenx-transcluded');
         slotEl.innerHTML = '';
+
         this.#getDefaultSlotChildren(name).forEach((child) => {
           slotEl.appendChild(child);
         });
@@ -491,11 +411,6 @@ export class AvenxComponent {
     });
   }
 
-  /**
-   * Retrieves slot elements belonging to this component.
-   * @returns {Element[]}
-   * @private
-   */
   #getOwnSlots() {
     if (!this.#element) return [];
 
@@ -518,10 +433,37 @@ export class AvenxComponent {
   }
 
   /**
-   * Updates the transcluded content when the parent template updates.
-   * @param {NodeList|Array} virtualChildNodes - The new virtual transcluded nodes from parent.
+   * Collects elements marked with data-ax-ref that belong to this component.
+   * Elements inside nested component boundaries are excluded.
    * @private
    */
+  #collectRefs() {
+    this.$refs = {};
+
+    if (!this.#element) return;
+
+    const refElements = this.#element.querySelectorAll('[data-ax-ref]');
+    const root = this.#element;
+
+    Array.from(refElements).forEach((element) => {
+      let parent = element.parentNode;
+
+      while (parent && parent !== root) {
+        if (parent.hasAttribute && parent.hasAttribute('data-avenx-comp')) {
+          return;
+        }
+
+        parent = parent.parentNode;
+      }
+
+      const refName = element.getAttribute('data-ax-ref');
+
+      if (refName && refName.trim()) {
+        this.$refs[refName.trim()] = element;
+      }
+    });
+  }
+
   __updateTranscludedContent(virtualChildNodes) {
     const grouped = {
       default: [],
@@ -550,7 +492,9 @@ export class AvenxComponent {
       slots.forEach((slotEl) => {
         const name = this.#resolveSlotName(slotEl);
 
-        const newChildren = name ? grouped.named[name] || [] : grouped.default || [];
+        const newChildren = name
+          ? grouped.named[name] || []
+          : grouped.default || [];
 
         const newSlotWrapper = slotEl.cloneNode(false);
 
@@ -559,8 +503,14 @@ export class AvenxComponent {
         });
 
         const hasContent = newChildren.some((node) => {
-          if (node.nodeType === 1 && node.nodeName !== '!--' && node.nodeName !== '#comment') return true;
-          if (node.nodeType === 3 && node.textContent.trim().length > 0) return true;
+          if (node.nodeType === 1 && node.nodeName !== '!--' && node.nodeName !== '#comment') {
+            return true;
+          }
+
+          if (node.nodeType === 3 && node.textContent.trim().length > 0) {
+            return true;
+          }
+
           return false;
         });
 
@@ -568,20 +518,21 @@ export class AvenxComponent {
           newSlotWrapper.setAttribute('data-avenx-transcluded', 'true');
         } else {
           newSlotWrapper.removeAttribute('data-avenx-transcluded');
+
           this.#getDefaultSlotChildren(name).forEach((child) => {
             newSlotWrapper.appendChild(child);
           });
         }
 
-        this.#patcher.patchElement(slotEl, newSlotWrapper, (expression) => this.#resolveTemplateExpression(expression));
+        this.#patcher.patchElement(
+          slotEl,
+          newSlotWrapper,
+          (expression) => this.#resolveTemplateExpression(expression),
+        );
       });
     }
   }
 
-  /**
-   * Internal method called after the component is mounted to the DOM.
-   * @private
-   */
   __afterMount() {
     this.#isMounted = true;
 
@@ -593,14 +544,18 @@ export class AvenxComponent {
       try {
         this.#methods.onMount();
       } catch (error) {
-        logger.error(formatMessage(AvenxErrorCodes.LIFECYCLE_HOOK_ERROR, this.constructor.name, 'onMount', error));
+        logger.error(
+          formatMessage(
+            AvenxErrorCodes.LIFECYCLE_HOOK_ERROR,
+            this.constructor.name,
+            'onMount',
+            error,
+          ),
+        );
       }
     }
   }
 
-  /**
-   * Unmounts the component and triggers cleanup.
-   */
   unmount() {
     this.#eventBinder.unbind(this.#element);
 
@@ -612,7 +567,14 @@ export class AvenxComponent {
       try {
         this.#methods.onUnmount();
       } catch (error) {
-        logger.error(formatMessage(AvenxErrorCodes.LIFECYCLE_HOOK_ERROR, this.constructor.name, 'onUnmount', error));
+        logger.error(
+          formatMessage(
+            AvenxErrorCodes.LIFECYCLE_HOOK_ERROR,
+            this.constructor.name,
+            'onUnmount',
+            error,
+          ),
+        );
       }
     }
 
@@ -636,22 +598,19 @@ export class AvenxComponent {
       this._propsHandler.teardown();
     }
 
+    this.$refs = {};
+
     if (this.#element) {
       delete this.#element.__avenx_comp_instance;
       this.#element.innerHTML = '';
       this.#element = null;
     }
 
-    // Decrement runtime style reference count for this component class
     styleMountManager.unmount(this.constructor);
 
     this.#isMounted = false;
   }
 
-  /**
-   * Updates the component's props and triggers an update if they changed.
-   * @param {object} newProps - The new props to apply.
-   */
   setProps(newProps) {
     const currentProps = this.props;
 
@@ -668,10 +627,6 @@ export class AvenxComponent {
     }
   }
 
-  /**
-   * The current active route metadata.
-   * @returns {{hash: string, page: string, params: Record<string, any>}} The route details.
-   */
   get $route() {
     if (typeof window !== 'undefined' && window.__avenx_routers) {
       for (const router of window.__avenx_routers) {
@@ -680,56 +635,46 @@ export class AvenxComponent {
         }
       }
     }
+
     return { hash: '', page: '', params: {} };
   }
 
-  /**
-   * Evaluates an expression in the component's scope.
-   * @param {string} expression - The expression to evaluate.
-   * @param {object} [extraScope] - Additional scope variables.
-   * @returns {any} The result of the evaluation.
-   * @protected
-   */
   _evaluate(expression, extraScope = {}) {
-    return this.#evaluator.evaluateExpression(expression, this.#createScope(this.#methods, extraScope), this.state);
+    return this.#evaluator.evaluateExpression(
+      expression,
+      this.#createScope(this.#methods, extraScope),
+      this.state,
+    );
   }
 
-  /**
-   * @returns {Element|null} The component's root element.
-   * @protected
-   */
   _getElement() {
     return this.#element;
   }
 
-  /**
-   * @returns {object} The bridges accessible to the component.
-   * @protected
-   */
   _getBridges() {
     return this.#bridges;
   }
 
-  /**
-   * Mounts the component to a target element.
-   * @param {Element|string} target - The target element or selector.
-   */
   mount(target) {
     this.#lifecycle.mount(this, target);
   }
 
-  /**
-   * Internal method to initialize injected properties from ancestors.
-   * @private
-   */
   __initInjection() {
     const injectOption =
       this.inject ||
-      (typeof this.constructor.inject === 'function' ? this.constructor.inject() : this.constructor.inject);
+      (typeof this.constructor.inject === 'function'
+        ? this.constructor.inject()
+        : this.constructor.inject);
+
     if (!injectOption) return;
 
     let injectMap = {};
-    const resolvedOption = typeof injectOption === 'function' ? injectOption.call(this) : injectOption;
+
+    const resolvedOption =
+      typeof injectOption === 'function'
+        ? injectOption.call(this)
+        : injectOption;
+
     if (Array.isArray(resolvedOption)) {
       for (const key of resolvedOption) {
         injectMap[key] = key;
@@ -742,10 +687,15 @@ export class AvenxComponent {
       Object.defineProperty(this, localKey, {
         get: () => {
           const ancestor = this.#findAncestorProviding(provideKey);
+
           if (!ancestor) {
-            logger.warn(`[AvenxComponent] Injected key "${provideKey}" not found in any ancestor component.`);
+            logger.warn(
+              `[AvenxComponent] Injected key "${provideKey}" not found in any ancestor component.`,
+            );
+
             return undefined;
           }
+
           return this.#getAncestorProvidedValue(ancestor, provideKey);
         },
         enumerable: true,
@@ -754,132 +704,138 @@ export class AvenxComponent {
     }
   }
 
-  /**
-   * Finds the nearest ancestor component that provides the specified key.
-   * @param {string} key - The provided key to search for.
-   * @returns {AvenxComponent|null} The ancestor component instance, or null.
-   * @private
-   */
   #findAncestorProviding(key) {
     const el = this._getElement();
+
     if (!el) return null;
+
     let parentEl = el.parentNode;
+
     while (parentEl) {
       if (parentEl.__avenx_comp_instance) {
         const comp = parentEl.__avenx_comp_instance;
+
         if (this.#componentProvides(comp, key)) {
           return comp;
         }
       }
+
       parentEl = parentEl.parentNode;
     }
+
     return null;
   }
 
-  /**
-   * Checks if a component provides the specified key.
-   * @param {AvenxComponent} comp - The component to check.
-   * @param {string} key - The provided key.
-   * @returns {boolean} True if the component provides the key.
-   * @private
-   */
   #componentProvides(comp, key) {
     const provideOption =
       comp.provide ||
-      (typeof comp.constructor.provide === 'function' ? comp.constructor.provide() : comp.constructor.provide);
+      (typeof comp.constructor.provide === 'function'
+        ? comp.constructor.provide()
+        : comp.constructor.provide);
+
     if (!provideOption) return false;
 
-    const resolved = typeof provideOption === 'function' ? provideOption.call(comp) : provideOption;
+    const resolved =
+      typeof provideOption === 'function'
+        ? provideOption.call(comp)
+        : provideOption;
 
     if (Array.isArray(resolved)) {
       return resolved.includes(key);
-    } else if (resolved && typeof resolved === 'object') {
+    }
+
+    if (resolved && typeof resolved === 'object') {
       return key in resolved;
     }
+
     return false;
   }
 
-  /**
-   * Retrieves the provided value for a key from an ancestor component.
-   * @param {AvenxComponent} comp - The ancestor component instance.
-   * @param {string} key - The provided key.
-   * @returns {any} The value.
-   * @private
-   */
   #getAncestorProvidedValue(comp, key) {
     if (comp._providedState && key in comp._providedState) {
       const val = comp._providedState[key];
+
       if (typeof val === 'function') {
         return val;
       }
+
       return val;
     }
 
     const provideOption =
       comp.provide ||
-      (typeof comp.constructor.provide === 'function' ? comp.constructor.provide() : comp.constructor.provide);
+      (typeof comp.constructor.provide === 'function'
+        ? comp.constructor.provide()
+        : comp.constructor.provide);
+
     if (!provideOption) return undefined;
 
-    const resolved = typeof provideOption === 'function' ? provideOption.call(comp) : provideOption;
+    const resolved =
+      typeof provideOption === 'function'
+        ? provideOption.call(comp)
+        : provideOption;
 
     if (Array.isArray(resolved)) {
       return comp._getScopeValue(key);
-    } else if (resolved && typeof resolved === 'object') {
+    }
+
+    if (resolved && typeof resolved === 'object') {
       const val = resolved[key];
+
       if (typeof val === 'function') {
         return val.bind(comp);
       }
+
       return val;
     }
+
     return undefined;
   }
 
-  /**
-   * Internal method to initialize provided properties as a reactive proxy.
-   * @private
-   */
   __initProvide() {
     const provideOption =
       this.provide ||
-      (typeof this.constructor.provide === 'function' ? this.constructor.provide() : this.constructor.provide);
+      (typeof this.constructor.provide === 'function'
+        ? this.constructor.provide()
+        : this.constructor.provide);
+
     if (!provideOption) return;
 
-    const resolved = typeof provideOption === 'function' ? provideOption.call(this) : provideOption;
+    const resolved =
+      typeof provideOption === 'function'
+        ? provideOption.call(this)
+        : provideOption;
 
     if (resolved && typeof resolved === 'object' && !Array.isArray(resolved)) {
-      // Create a reactive proxy of the provided object
       const handlerFactory = new ProxyHandlerFactory({
-        onChange: () => {
-          // Do not call scheduleUpdate of this component
-        },
+        onChange: () => {},
       });
+
       this._providedState = new Proxy(resolved, handlerFactory.create());
     }
   }
 
-  /**
-   * Retrieves a property or method from the component's scope.
-   * Used for array-based provide to resolve keys dynamically.
-   * @param {string} key - The key to retrieve.
-   * @returns {any} The value.
-   * @protected
-   */
   _getScopeValue(key) {
     if (this.state && key in this.state) {
       return this.state[key];
     }
+
     if (this.props && key in this.props) {
       return this.props[key];
     }
+
     if (this.#methods && key in this.#methods) {
       return this.#methods[key];
     }
+
     if (this.#bridges && key in this.#bridges) {
       return this.#bridges[key];
     }
+
     if (key in this) {
       return this[key];
     }
+
     return undefined;
   }
 }

--- a/test/unit/componentRefs.test.js
+++ b/test/unit/componentRefs.test.js
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+import { MockDOMElement, setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ * Tests data-ax-ref collection and component-scoped DOM references.
+ */
+async function testComponentRefs() {
+  console.log('🧪 Testing data-ax-ref DOM element referencing...');
+
+  setupDOMMock();
+
+  try {
+    const comp = new AvenxComponent(
+      {},
+      {},
+      {},
+      '<div><input data-ax-ref="myInput"></div>',
+      {},
+    );
+
+    const root = new MockDOMElement('div');
+    const input = new MockDOMElement('input');
+
+    input.setAttribute('data-ax-ref', 'myInput');
+    root.appendChild(input);
+
+    comp.__setMountTarget(root);
+
+    // __setMountTarget clears the initial content, so append the element
+    // again to simulate the rendered component DOM.
+    root.appendChild(input);
+
+    comp.runUpdate();
+
+    assert.strictEqual(
+      comp.$refs.myInput,
+      input,
+      '$refs.myInput should point to the referenced DOM element.',
+    );
+
+    console.log('  ✅ Referenced DOM element is available through $refs.');
+
+    comp.unmount();
+
+    assert.deepStrictEqual(
+      comp.$refs,
+      {},
+      '$refs should be cleared when the component is unmounted.',
+    );
+
+    console.log('  ✅ $refs are cleared after unmount.');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+(async () => {
+  try {
+    await testComponentRefs();
+    console.log('✅ Component refs tests passed successfully!');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Component refs tests failed!');
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Description

This PR documents the current component nesting limitation in Avenx-JS.

## Changes

- Added a new `Component Nesting Restrictions` section.
- Clarified that custom components can only be resolved and mounted inside Page templates (`.page.js`).
- Documented the empty DOM element symptom when components are nested inside standard `.component.js` templates.
- Added supported and unsupported examples.
- Added recommended design practices for component composition.

## Related Issue

Closes #154 — Document Architectural Limitation: Component Nesting Constraints