### PR TITLE
feat(router): parse query parameters into primitive values

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -259,7 +259,21 @@ export class AvenxRouter {
         });
         if (queryPart) {
           const queryParams = new URLSearchParams(queryPart);
-          params.query = Object.fromEntries(queryParams.entries());
+          const parsedQuery = {};
+
+          for (const [key, value] of queryParams.entries()) {
+            if (value === "true") {
+              parsedQuery[key] = true;
+            } else if (value === "false") {
+              parsedQuery[key] = false;
+            } else if (/^\d+$/.test(value)) {
+              parsedQuery[key] = Number(value);
+            } else {
+              parsedQuery[key] = value;
+            }
+          }
+
+          params.query = parsedQuery;
         }
         break;
       }

--- a/lib/core/runtime/test/unit/router_wildcard.test.js
+++ b/lib/core/runtime/test/unit/router_wildcard.test.js
@@ -114,6 +114,14 @@ function teardownWindowMock() {
     // 5. A route not under the wildcard prefix should not match
     assert.strictEqual(router.matches('#/other'), false, 'matches() should not match unrelated paths');
 
+        // 6. Query params should be parsed into primitive values
+    window.location.hash = '#/docs/intro?flag=true&count=42&name=foo';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.strictEqual(router.currentRoute.params.query.flag, true);
+    assert.strictEqual(router.currentRoute.params.query.count, 42);
+    assert.strictEqual(router.currentRoute.params.query.name, 'foo');
+
     router.destroy();
     teardownWindowMock();
     teardownDOMMock();


### PR DESCRIPTION
## Summary

This PR improves query parameter parsing in the router by automatically converting primitive values.

### Changes

- Convert `"true"` and `"false"` query values to booleans.
- Convert numeric query values (e.g. `"42"`) to numbers.
- Preserve other query values as strings.
- Added unit tests covering the new behavior.

### Example

Before:

```js
{
  flag: "true",
  count: "42",
  name: "foo"
}

After:
{
  flag: true,
  count: 42,
  name: "foo"
}

Fixes #243


## Before clicking "Create pull request"

Just like with your previous PR, send me a **screenshot of the PR page** (showing the title, description, 