### PR TITLE
docs(router): add query parameters section and document state.query in guards

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -66,6 +66,18 @@ This lifecycle method is executed prior to entering a route.
 Redirect paths returned from `canActivate` must start with `#`. `AvenxRouter.navigate` only applies the configured `prefix` and namespace settings to hash paths — a path without the `#` prefix bypasses this resolution and can break navigation in apps served with a custom `prefix`.
 :::
 
+:::note
+When the matched route hash includes query parameters,both `to.params.query` and `from.params.query` contain the parsed query object- using the type coercion rules described in [Query Parameters](/core-concepts/routing/#query-parameters). This lets a guard make decisions based on query values, for example:
+```javascript
+  canActivate(to, from) {
+    if (to.hash.startsWith('#/dashboard') && to.params.query?.tab === 'admin' && !window.isAdmin) {
+      return '#/dashboard';
+    }
+    return true;
+  }
+```
+:::
+
 #### Sample Guard Implementation
 
 ```javascript

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -38,6 +38,49 @@ Route segments starting with `:` are dynamic variables. The values parsed from t
   <h1>Viewing Profile ID: {{ id }}</h1>
 </div>
 ```
+### Query Parameters
+
+The portion of a route hash after `?` is automatically parsed into an object and made available as `state.query`. This works alongside dynamic parameters (`:id`) and can be read the same way,in templates or actions:
+
+```html
+<!-- src/pages/dashboard.page.js -->
+<!-- #/dashboard?tab=analytics&user=123 ->state.query.tab==='analytics' -->
+    <div class="dashboard">
+      <h1>Current tab: {{ query.tab }}</h1>
+    </div>
+
+```
+
+Query parameters are also available inside component actions using `this.state.query`:
+
+```javascript
+//src/pages/dashboard.page.js
+onMount() {
+  const tab = this.state.query.tab;
+  this.loadTabData(tab);
+}
+```
+#### Type Coercion
+While dynamic route parameters are always strings, query parameter values on the other hand are coerced based on their content:
+
+| Raw value | Parsed as |
+| ---- | ---- |
+| `"true"` | Boolean `true` |
+|`"false"` | Boolean `false`|
+| A numeric string(e.g. `"123"`) |  `Number` (e.g.`123`) |
+| Anything else | `String` |
+
+```javascript
+//#/settings?darkMode=true&fontSize=16&theme=blue
+state.query={
+  darkMode : true, //boolean
+  fontSize:16,     //number
+  theme: 'blue'   //string
+}
+```
+:::note
+If the route hash has no `?` segment,`state.query` is undefined rather than an empty object. Hence, check for its existence before accessing nested properties.
+:::
 
 ### Wildcard Path Matchers
 


### PR DESCRIPTION
… (#153)
## Summary

Added documentation for query parameter parsing (`state.query`), which was previously undocumented 

Closes #153

## Changes done :

- Added a **"Query Parameters"** section to `docs/src/content/docs/core-concepts/routing.md`, placed after **Dynamic Route Parameters** and before **Wildcard Path Matchers**, since both are URL-based concepts and this keeps the documentation flow logical.
  - Explains how `?key=value` segments are parsed and made available as `state.query`
  - Includes a template usage example and a component action (`onMount`) usage example
  - Documents automatic type coercion (`"true"`/`"false"` → boolean, numeric strings → `Number`, everything else stays a string)
  - Notes that `state.query` is `undefined` and not empty when the route hash has no `?` segment
- Added a `:::note` to `docs/src/content/docs/api-reference/router-guard.md`, documenting that `to.params.query` and `from.params.query` are available inside `canActivate(to, from)`, with a short example guard demonstrating a query-based redirect. Links back to the Query Parameters section for the coercion rules to avoid duplicating them.

## Acceptance Criteria (from #153)

- [x] Add a "Query Parameters" section in `routing.md` showing how parameters are mapped to `state.query`
- [x] Add a code example showing how to read `state.query.tab` in templates and component actions
- [x] Document the `query` property structure on `to` and `from` route descriptors in `router-guard.md`

## Verification

Query parameter parsing and type coercion behavior were verified directly against the implementation in `AvenxRouter.js` (`#handleRoute`), rather than assumed from the issue description alone, to ensure the documentation matches actual behavior.
