### PR TITLE
feat(router): update document.title on route transitions

### DIFF
--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -130,9 +130,38 @@ Only named routes count when checking whether another router "owns" a hash — w
 Because routers coordinate through a shared global registry, always call `router.destroy()` when tearing down a router instance (for example, when unmounting a micro-frontend). A router left in `window.__avenx_routers` after it's no longer in use keeps its `hashchange` listener attached and continues to be consulted by other routers' fallback checks.
 :::
 
-## 6. Route Guards
+## 6. Page Titles
 
-## 5. Route Guards
+When a route is resolved, the router can automatically update `document.title`. Add a `title` property to any route definition — either a static string or a dynamic function that receives the parsed route parameters:
+
+```javascript
+app.initRouter({
+  '/':            { page: 'Home',    title: 'Home' },
+  '/profile/:id': { page: 'Profile', title: (params) => `Profile ${params.id}` },
+  '*':            { page: 'NotFound', title: 'Page Not Found' },
+});
+```
+
+### Title Prefix & Suffix
+
+To avoid repeating your app name in every route, pass `titlePrefix` or `titleSuffix` in the router options. They are prepended / appended to every resolved title automatically:
+
+```javascript
+app.initRouter(
+  {
+    '/':      { page: 'Home',    title: 'Home' },
+    '/about': { page: 'About',  title: 'About Us' },
+  },
+  { titleSuffix: ' — MyApp' },
+);
+// Results in "Home — MyApp", "About Us — MyApp"
+```
+
+:::note
+Routes that do not declare a `title` property leave `document.title` unchanged. This lets you opt individual routes out of automatic title management.
+:::
+
+## 7. Route Guards
 
 Guards decide whether a transition to a page is allowed. Create a guard using the CLI:
 

--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -192,6 +192,42 @@ export interface AvenxRouterOptions {
      * The target hash path to redirect to if a route guard times out (e.g. '#/').
      */
     guardTimeoutRedirect?: string;
+
+    /**
+     * A string prepended to every resolved route title.
+     */
+    titlePrefix?: string;
+
+    /**
+     * A string appended to every resolved route title (e.g. ' — MyApp').
+     */
+    titleSuffix?: string;
+}
+
+/**
+ * Definition object for a single route entry.
+ */
+export interface AvenxRouteDefinition {
+    /**
+     * The registered page name to mount for this route.
+     */
+    page: string;
+
+    /**
+     * Optional guards to evaluate before activating this route.
+     */
+    guards?: Array<typeof AvenxGuard | AvenxGuard>;
+
+    /**
+     * Optional page title. Can be a static string or a function receiving
+     * the parsed route params and returning a string.
+     */
+    title?: string | ((params: Record<string, any>) => string);
+
+    /**
+     * Optional transition name for page enter/leave animations.
+     */
+    transition?: string;
 }
 
 /**
@@ -207,7 +243,7 @@ export class AvenxRouter {
     /**
      * Map of route pattern strings to Page names or route config definitions.
      */
-    routes: Record<string, string | { page: string; guards?: Array<typeof AvenxGuard | AvenxGuard> }>;
+    routes: Record<string, string | AvenxRouteDefinition>;
 
     /**
      * Info about the currently loaded route.
@@ -221,7 +257,7 @@ export class AvenxRouter {
      */
     constructor(
         app: AvenxApp,
-        routes?: Record<string, string | { page: string; guards?: Array<typeof AvenxGuard | AvenxGuard> }>,
+        routes?: Record<string, string | AvenxRouteDefinition>,
         options?: AvenxRouterOptions
     );
 
@@ -318,7 +354,7 @@ export class AvenxApp {
      * @param options Router options.
      */
     initRouter(
-        routes: Record<string, string | { page: string; guards?: Array<typeof AvenxGuard | AvenxGuard> }>,
+        routes: Record<string, string | AvenxRouteDefinition>,
         options?: AvenxRouterOptions
     ): AvenxRouter;
 }

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -317,6 +317,7 @@ export class AvenxRouter {
           this.navigate(result);
         } else {
           this.currentRoute = to;
+          this.#applyTitle(def, params);
           const transitionName = (typeof def === 'object' && def.transition) || this.options.transition;
           this.app.mountPage(pageName, params, { transition: transitionName });
         }
@@ -332,6 +333,36 @@ export class AvenxRouter {
           }
         }
       });
+  }
+
+  /**
+   * Resolves the title from a route definition and updates document.title.
+   * Supports static strings and dynamic functions that receive route params.
+   * @param {string | object} def - The route definition.
+   * @param {object} params - Parsed route parameters.
+   * @private
+   */
+  #applyTitle(def, params) {
+    const rawTitle = typeof def === 'object' ? def.title : undefined;
+    if (rawTitle === undefined) return;
+
+    let resolved;
+    if (typeof rawTitle === 'function') {
+      try {
+        resolved = rawTitle(params);
+      } catch (err) {
+        logger.warn(`[AvenxRouter] title() threw an error: ${err}`);
+        return;
+      }
+    } else {
+      resolved = rawTitle;
+    }
+
+    if (typeof resolved !== 'string') return;
+
+    const prefix = this.options.titlePrefix || '';
+    const suffix = this.options.titleSuffix || '';
+    document.title = prefix + resolved + suffix;
   }
 
   #currentRouteProxy = null;

--- a/test/integration/router_title.test.js
+++ b/test/integration/router_title.test.js
@@ -1,0 +1,255 @@
+import assert from 'assert';
+import { AvenxApp } from '../../lib/core/runtime/AvenxApp.js';
+import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
+import { setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ *
+ */
+class TestPage extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>Test Page</div>';
+  }
+}
+
+let hashListeners = [];
+
+/**
+ *
+ */
+function setupWindowMock() {
+  hashListeners = [];
+  global.window = {
+    addEventListener: (event, cb) => {
+      if (event === 'hashchange') hashListeners.push(cb);
+    },
+    removeEventListener: (event, cb) => {
+      if (event === 'hashchange') hashListeners = hashListeners.filter((l) => l !== cb);
+    },
+    location: {
+      _hash: '',
+      get hash() {
+        return this._hash;
+      },
+      set hash(val) {
+        this._hash = val;
+        hashListeners.forEach((listener) => listener());
+      },
+    },
+  };
+}
+
+/**
+ *
+ */
+function teardownWindowMock() {
+  delete global.window;
+}
+
+(async () => {
+  try {
+    console.log('🧪 Testing Router document.title updates...');
+
+    // ── 1. Static title string ───────────────────────────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    const app1 = new AvenxApp({ target: 'div' });
+    app1.registerPage('Home', TestPage);
+    app1.registerPage('About', TestPage);
+
+    const router1 = app1.initRouter({
+      '#/': { page: 'Home', title: 'Home Page' },
+      '#/about': { page: 'About', title: 'About Us' },
+    });
+
+    window.location.hash = '#/';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Home Page', 'Static title should be set for Home');
+
+    window.location.hash = '#/about';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'About Us', 'Static title should be set for About');
+
+    router1.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ Static title string works');
+
+    // ── 2. Dynamic title function ────────────────────────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    const app2 = new AvenxApp({ target: 'div' });
+    app2.registerPage('Profile', TestPage);
+
+    const router2 = app2.initRouter({
+      '#/profile/:id': { page: 'Profile', title: (params) => `Profile ${params.id}` },
+    });
+
+    window.location.hash = '#/profile/42';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Profile 42', 'Dynamic title should interpolate params');
+
+    window.location.hash = '#/profile/99';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Profile 99', 'Dynamic title should update on param change');
+
+    router2.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ Dynamic title function works');
+
+    // ── 3. titleSuffix option ────────────────────────────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    const app3 = new AvenxApp({ target: 'div' });
+    app3.registerPage('Home', TestPage);
+    app3.registerPage('Contact', TestPage);
+
+    const router3 = app3.initRouter(
+      {
+        '#/': { page: 'Home', title: 'Home' },
+        '#/contact': { page: 'Contact', title: 'Contact' },
+      },
+      { titleSuffix: ' — MyApp' },
+    );
+
+    window.location.hash = '#/';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Home — MyApp', 'titleSuffix should be appended');
+
+    window.location.hash = '#/contact';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Contact — MyApp', 'titleSuffix should be appended to all routes');
+
+    router3.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ titleSuffix option works');
+
+    // ── 4. titlePrefix option ────────────────────────────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    const app4 = new AvenxApp({ target: 'div' });
+    app4.registerPage('Home', TestPage);
+
+    const router4 = app4.initRouter(
+      {
+        '#/': { page: 'Home', title: 'Dashboard' },
+      },
+      { titlePrefix: 'MyApp | ' },
+    );
+
+    window.location.hash = '#/';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'MyApp | Dashboard', 'titlePrefix should be prepended');
+
+    router4.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ titlePrefix option works');
+
+    // ── 5. No title field — document.title unchanged ─────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    document.title = 'Original Title';
+
+    const app5 = new AvenxApp({ target: 'div' });
+    app5.registerPage('Home', TestPage);
+
+    const router5 = app5.initRouter({
+      '#/': 'Home',
+    });
+
+    window.location.hash = '#/';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Original Title', 'document.title should not change when no title is defined');
+
+    router5.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ No title field leaves document.title unchanged');
+
+    // ── 6. Throwing title function — gracefully handled ──────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    document.title = 'Before Error';
+
+    const app6 = new AvenxApp({ target: 'div' });
+    app6.registerPage('Bad', TestPage);
+
+    // Suppress the expected warning
+    const originalWarn = console.warn;
+    let caughtWarning = '';
+    console.warn = (msg) => {
+      caughtWarning = msg;
+    };
+
+    const router6 = app6.initRouter({
+      '#/bad': {
+        page: 'Bad',
+        title: () => {
+          throw new Error('broken');
+        },
+      },
+    });
+
+    window.location.hash = '#/bad';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    console.warn = originalWarn;
+
+    assert.strictEqual(document.title, 'Before Error', 'document.title should not change when title() throws');
+    assert.ok(caughtWarning.includes('title()'), 'A warning should be logged when title() throws');
+
+    router6.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ Throwing title function is gracefully handled');
+
+    // ── 7. Dynamic title with query params ───────────────────────────────
+    setupDOMMock();
+    setupWindowMock();
+
+    const app7 = new AvenxApp({ target: 'div' });
+    app7.registerPage('Search', TestPage);
+
+    const router7 = app7.initRouter({
+      '#/search/:term': {
+        page: 'Search',
+        title: (params) => `Search: ${params.term}${params.query?.page ? ` (Page ${params.query.page})` : ''}`,
+      },
+    });
+
+    window.location.hash = '#/search/avenx?page=2';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(document.title, 'Search: avenx (Page 2)', 'Title function should have access to query params');
+
+    router7.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ Dynamic title with query params works');
+
+    console.log('  ✅ All Router document.title tests passed!');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Router document.title tests failed!');
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
transitions now update `document.title` automatically. Add a `title` property to route definitions — either a static string or a `title(params)` function for dynamic segments.

```js
app.initRouter({
  '/':            { page: 'Home',    title: 'Home' },
  '/profile/:id': { page: 'Profile', title: (params) => `Profile ${params.id}` },
}, { titleSuffix: ' — MyApp' });
```

- Routes without `title` leave `document.title` unchanged (non-breaking)
- `titlePrefix` / `titleSuffix` router options reduce repetition
- Throwing `title()` functions are caught and logged as warnings
- Added `AvenxRouteDefinition` interface to type definitions
- 7 integration tests covering all scenarios