### PR TITLE
docs(api): fix runtime import examples

### DIFF
--- a/docs/src/content/docs/api-reference/testing.md
+++ b/docs/src/content/docs/api-reference/testing.md
@@ -31,7 +31,7 @@ Creates a deep proxy around a bridge class or object, tracking method calls and 
 **Example**
 
 ```javascript
-import { AvenxMock } from 'avenx-core';
+import { AvenxMock } from 'avenx-core/runtime';
 import AuthBridge from '../src/global/auth.bridge.js';
 
 const mockAuth = AvenxMock.createMockBridge(AuthBridge, { isLoggedIn: false });
@@ -55,7 +55,7 @@ Creates and returns a new `AvenxSandbox` instance for mounting components in iso
 - `AvenxSandbox`: A new sandbox instance.
 
 ```javascript
-import { AvenxMock } from 'avenx-core';
+import { AvenxMock } from 'avenx-core/runtime';
 
 const sandbox = AvenxMock.createSandbox();
 ```
@@ -77,7 +77,7 @@ Dispatches an event on a DOM element (or a mock element), for simulating user in
 - Otherwise, falls back to manually walking up `parentNode` and invoking matching `listeners[eventName]` handlers, respecting `stopPropagation()`.
 
 ```javascript
-import { AvenxMock } from 'avenx-core';
+import { AvenxMock } from 'avenx-core/runtime';
 
 AvenxMock.trigger(buttonElement, 'click');
 ```
@@ -158,7 +158,7 @@ Mounts a component (or page) class in isolation using the sandbox's registered b
 **Example**
 
 ```javascript
-import { AvenxMock } from 'avenx-core';
+import { AvenxMock } from 'avenx-core/runtime';
 import Counter from '../src/components/counter/counter.component.js';
 
 const sandbox = AvenxMock.createSandbox();
@@ -178,7 +178,7 @@ console.log(wrapper.html);
 ### Full Example: Testing a Component with a Mocked Bridge
 
 ```javascript
-import { AvenxMock } from 'avenx-core';
+import { AvenxMock } from 'avenx-core/runtime';
 import ProfileCard from '../src/components/profile-card/profile-card.component.js';
 import UserBridge from '../src/global/user.bridge.js';
 

--- a/docs/src/content/docs/api-reference/utils.md
+++ b/docs/src/content/docs/api-reference/utils.md
@@ -88,7 +88,7 @@ The core reactivity APIs include `StateFactory`, `AvenxWatcher`, and the `AvenxC
 ### Constructor
 
 ```javascript
-import { StateFactory } from 'avenx-core';
+import { StateFactory } from 'avenx-core/runtime';
 
 const stateFactory = new StateFactory();
 ```
@@ -123,7 +123,7 @@ If `initialState` is already an Avenx reactive proxy, `create()` returns the exi
 **Example**
 
 ```javascript
-import { StateFactory } from 'avenx-core';
+import { StateFactory } from 'avenx-core/runtime';
 
 const stateFactory = new StateFactory();
 
@@ -160,7 +160,7 @@ const state = stateFactory.create(
 ### Constructor
 
 ```javascript
-import { AvenxWatcher } from 'avenx-core';
+import { AvenxWatcher } from 'avenx-core/runtime';
 
 const watcher = new AvenxWatcher(getter, callback, options);
 ```
@@ -267,7 +267,7 @@ Watchers registered with `this.watch()` are stored by the component and automati
 The getter function determines which reactive state properties should be tracked.
 
 ```javascript
-import { AvenxComponent } from 'avenx-core';
+import { AvenxComponent } from 'avenx-core/runtime';
 
 class CounterComponent extends AvenxComponent {
   constructor() {


### PR DESCRIPTION
## Summary

Update utility and testing API examples to import runtime classes from `avenx-core/runtime`.

## Background

The root package exports the compiler, so the existing examples fail for runtime APIs.

Closes #364

## Changes

- fix `StateFactory`, `AvenxWatcher`, and `AvenxComponent` imports
- fix all `AvenxMock` imports

## Verification

- [ ] `npm test`
- [ ] `npm run lint`
- [ ] documentation build