### PR TITLE
docs: clarify single <state /> tag constraint per component (#368)

### DIFF
--- a/docs/src/content/docs/core-concepts/components.md
+++ b/docs/src/content/docs/core-concepts/components.md
@@ -26,6 +26,27 @@ The component file contains configuration tags at the top and the HTML template 
 </div>
 ```
 
+## Single `<state />` Tag Per Component
+
+> **Important:** Only the **first** `<state />` tag in a `.component.js` file is parsed. If a component contains more than one `<state />` tag, every tag after the first is silently ignored, and the properties declared in those extra tags will **not** become reactive.
+
+It can be tempting to split state declarations into multiple `<state />` tags to keep them organized, for example by feature or by section:
+
+```html
+<!-- This will NOT work as expected -->
+<state username="Guest" isLoggedIn="false" />
+<state theme="light" notifications="true" />
+```
+
+In the example above, only `username` and `isLoggedIn` become reactive state. `theme` and `notifications` are dropped during compilation with no warning or error, which can cause confusing bugs where a property behaves as if it were never declared.
+
+All reactive properties for a component must be combined into a **single, unified** `<state />` tag:
+
+```html
+<!-- Correct: all properties in one <state /> tag -->
+<state username="Guest" isLoggedIn="false" theme="light" notifications="true" />
+```
+
 ## Attribute Coercion & Types
 
 Every attribute passed to `<state>` starts as a plain HTML attribute string. Before the value is assigned to reactive state, the component compiler's expression parser coerces it into the corresponding JavaScript type: strings, booleans, numbers, arrays, and objects are all resolved automatically.


### PR DESCRIPTION
## What
Adds a documentation note to `docs/src/content/docs/core-concepts/components.md` explaining that only the first `<state />` tag in a `.component.js` file is parsed by the compiler.

## Why
`ExpressionParser.js`'s `parseState()` extracts state using a non-global regex (`content.match(/<state\s+([\s\S]*?)\s*\/>/)`), which only matches the first `<state />` occurrence. Any subsequent `<state />` tags in the same file are silently dropped, with no warning or error — this was undocumented and has caused confusion when properties fail to become reactive.

## Changes
- New "Single `<state />` Tag Per Component" section added right after the first component example, before "Attribute Coercion & Types".
- Includes a bad example (two `<state />` tags, second one silently ignored) and the corrected version (single, unified `<state />` tag).

Closes #368