### PR TITLE
feat: introduce declarative link directive data-ax-link (#194)

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -44,6 +44,18 @@ export class AvenxRouter {
 
     this.hashChangeHandler = () => this.#handleRoute();
     window.addEventListener('hashchange', this.hashChangeHandler);
+
+    // Intercept clicks on data-ax-link elements globally
+    window.addEventListener('click', (e) => {
+      const target = e.target.closest('[data-ax-link]');
+      if (target) {
+        e.preventDefault();
+        const route = target.getAttribute('data-ax-link');
+        if (route) {
+          this.navigate(route);
+        }
+      }
+    });
   }
 
   /**
@@ -58,7 +70,9 @@ export class AvenxRouter {
    * @param {string} hash - The target hash (e.g., '#/about').
    */
   navigate(hash) {
-    let targetHash = hash;
+    // Force clean paths like '/profile' into hash paths like '#/profile'
+    let targetHash = hash.startsWith('#') ? hash : '#' + hash;
+    
     if (this.options && this.options.prefix) {
       const prefix = this.options.prefix;
       if (targetHash.startsWith('#/')) {


### PR DESCRIPTION
## Description
Addresses #194 by introducing a runtime declarative link directive (`data-ax-link`). This decouples the codebase from strict hash-based markup configurations, enabling clean routing syntax while maintaining full compatibility with the underlying router structure.

## Changes Made
* **Global Click Interception:** Added a dynamic event listener inside the `AvenxRouter` constructor to intercept click actions on elements leveraging `data-ax-link`. It intercepts nested targets via `.closest()`, blocks the browser's default reload path via `preventDefault()`, and routes matching values.
* **Path Normalization:** Updated the `navigate()` sequence to inspect the incoming parameter. Clean routes (e.g., `/profile`) are seamlessly normalized into the expected internal hash syntax (e.g., `#/profile`).

## Acceptance Criteria Verified
- [x] Supports clean relative targets like `<a data-ax-link="/profile">`.
- [x] Click events intercept correctly to update the internal application route.
- [x] Handles dynamic binding flows smoothly by extracting the parameter string at runtime.