### PR TITLE
fix(style): scope comma-separated selectors

### DIFF
--- a/lib/compiler/StyleProcessor.js
+++ b/lib/compiler/StyleProcessor.js
@@ -49,6 +49,70 @@ function stripCssComments(css) {
 }
 
 /**
+ * Applies a component hash to each selector in a selector list.
+ * Commas inside functions, attribute selectors, strings, and escapes are not
+ * selector delimiters and must be preserved.
+ * @param {string} selectorList - The CSS selector list.
+ * @param {string} hash - The component scope hash.
+ * @returns {string} The scoped selector list.
+ */
+function scopeSelectorList(selectorList, hash) {
+  const selectors = [];
+  let current = '';
+  let inString = null;
+  let parenthesisDepth = 0;
+  let bracketDepth = 0;
+
+  for (let i = 0; i < selectorList.length; i++) {
+    const char = selectorList[i];
+
+    if (char === '\\') {
+      current += char;
+      if (i + 1 < selectorList.length) {
+        current += selectorList[++i];
+      }
+      continue;
+    }
+
+    if (inString) {
+      current += char;
+      if (char === inString) inString = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inString = char;
+      current += char;
+    } else if (char === '(') {
+      parenthesisDepth++;
+      current += char;
+    } else if (char === ')') {
+      parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+      current += char;
+    } else if (char === '[') {
+      bracketDepth++;
+      current += char;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      current += char;
+    } else if (char === ',' && parenthesisDepth === 0 && bracketDepth === 0) {
+      selectors.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  selectors.push(current);
+
+  return selectors
+    .map((selector) => selector.trim())
+    .filter(Boolean)
+    .map((selector) => (selector.includes('&') ? selector.replace(/&/g, `.${hash}`) : `.${hash}${selector}`))
+    .join(', ');
+}
+
+/**
  * StyleProcessor is responsible for handling all CSS-related logic during the build process.
  * This includes managing global CSS variables, scoping component-specific styles using hashes,
  * and extracting CSS rules into a global stylesheet.
@@ -339,11 +403,7 @@ class StyleProcessor {
               }
             } else {
               // Regular selector rule
-              if (selector.includes('&')) {
-                selector = selector.replace(/&/g, `.${hash}`);
-              } else {
-                selector = `.${hash}${selector}`;
-              }
+              selector = scopeSelectorList(selector, hash);
               outputRules += `${selector} { ${body} }\n`;
             }
           }

--- a/test/unit/styleProcessor.test.js
+++ b/test/unit/styleProcessor.test.js
@@ -54,6 +54,33 @@ try {
     'Should scope nested selectors inside @supports',
   );
 
+  // Verify selector lists inside comma-separated media queries
+  const mediaListCss = `
+    @media screen and (min-width: 40rem), print {
+        h1, h2 { color: navy; }
+        &:is(.compact, .dense), [data-state="open,ready"] { display: block; }
+    }
+    `;
+  const spMediaList = new StyleProcessor();
+  const hashMediaList = spMediaList.getHash(mediaListCss, 'MediaListComponent');
+  spMediaList.extractRules(mediaListCss, hashMediaList);
+  const generatedMediaListCss = spMediaList.scopedStyles;
+
+  assert.ok(
+    generatedMediaListCss.includes('@media screen and (min-width: 40rem), print {'),
+    'Should retain comma-separated media queries',
+  );
+  assert.ok(
+    generatedMediaListCss.includes(`.${hashMediaList}h1, .${hashMediaList}h2 { color: navy; }`),
+    'Should scope every selector inside media queries',
+  );
+  assert.ok(
+    generatedMediaListCss.includes(
+      `.${hashMediaList}:is(.compact, .dense), .${hashMediaList}[data-state="open,ready"] { display: block; }`,
+    ),
+    'Should preserve nested commas while scoping selector lists',
+  );
+
   // Verify comments and braces inside quoted strings
   const commentCurlyCss = `
     /* comment { */


### PR DESCRIPTION
## Summary

- scope every selector in a comma-separated selector list
- preserve commas inside pseudo-class functions, attribute selectors, strings, and escapes
- cover selector lists nested under comma-separated media queries

## Tests

- `node test/unit/styleProcessor.test.js`
- `npm run lint`
- `npm run test:unit` (37 passed; existing `cliConfig.test.js` project-root assertion failed)
- `npm test` (52 passed; the same config test and sandboxed CLI project-root test failed)

Closes #399