### PR TITLE
Implement slot detection in ComponentParser

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -1338,6 +1338,24 @@ function serializeHTML(nodes) {
 }
 
 /**
+ * Recursively checks whether a node is a <slot> tag, or has a <slot>
+ * anywhere among its descendants. Used to disqualify a subtree from the
+ * static-optimization pass, since slots are dynamic transclusion points
+ * that DomPatcher must always be able to patch (see issue #200).
+ * @param {HTMLNode} node
+ * @returns {boolean}
+ */
+function containsSlot(node) {
+  if (node.type !== 'element') {
+    return false;
+  }
+  if (node.tagName.toLowerCase() === 'slot') {
+    return true;
+  }
+  return node.children.some((child) => containsSlot(child));
+}
+
+/**
  * Recursively determines if a node (and all its descendants) are completely static.
  * @param {HTMLNode} node
  * @returns {boolean}
@@ -1357,6 +1375,14 @@ function isStaticNode(node) {
   if (node.type === 'element') {
     const lowerTag = node.tagName.toLowerCase();
     if (lowerTag === 'template' || lowerTag === 'slot') {
+      return false;
+    }
+
+    // A wrapper that contains a <slot> anywhere beneath it must never be
+    // marked static: slot content is transcluded dynamically per-instance,
+    // so a static-tagged ancestor would cause DomPatcher to skip patching
+    // it entirely and slot updates would be silently dropped.
+    if (containsSlot(node)) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the static node optimization bug where elements containing `<slot>` tags could be incorrectly treated as static during compilation.

### Changes

* Added an explicit slot detection check during static subtree optimization.
* Prevented elements containing `<slot>` (directly or through descendants) from being marked with `data-ax-static="true"`.
* Preserved normal static optimization for nodes that do not contain slots.

### Why

`<slot>` elements are dynamic transclusion containers. Marking their parent elements as static causes the DOM patcher to skip updates, preventing slot content from rerendering correctly.

### Result

* Elements containing `<slot>` are never marked as static.
* Slot content updates propagate correctly on component rerenders.
* Existing static subtree optimizations remain unchanged for eligible nodes.

Closes #200.           



I have done some work @nathanschmid08 