### PR TITLE
docs: document Node prerequisites (#383) and avenx clean command (#382)

### DIFF
--- a/docs/src/content/docs/cli-reference/commands.md
+++ b/docs/src/content/docs/cli-reference/commands.md
@@ -65,3 +65,19 @@ The `check` command parses all local templates to catch potential runtime errors
 
 - **`0`**: Success. All templates successfully parsed with no validation errors or warnings.
 - **`1`**: Validation Failure. The command will exit with code 1 if any template warnings or errors are detected, making it ideal for CI/CD linting pipelines.
+
+### 7. `avenx clean`
+
+Clears out compiled distribution outputs to prepare for a fresh build.
+
+#### Description
+
+The `clean` command deletes the compiled distribution directory to ensure no stale files persist in your build environment. This is highly useful for CI/CD build pipelines to guarantee a clean state before executing production builds.
+
+#### Default Behavior
+
+Upon execution, it securely deletes the default distribution directory (typically `dist/`).
+
+#### Configuration
+
+The target folder deleted by this command is determined by the output directories specified in your `avenx.config.json` file.

--- a/docs/src/content/docs/getting-started/install.md
+++ b/docs/src/content/docs/getting-started/install.md
@@ -2,6 +2,12 @@
 title: 'Installation'
 description: 'Step-by-step installation instructions for Avenx-JS using npm and npx.'
 ---
+## Prerequisites
+
+Before installing the Avenx CLI, ensure your environment meets the following requirements:
+
+*   **Node.js**: Version `18.0.0` or later is strictly required.
+*   **Compatibility Check**: Upon startup, the CLI automatically verifies your Node.js engine version. Running the CLI on unsupported, older environments will cause the application to terminate immediately with an exit code `1`.
 
 To begin using Avenx-JS, make sure you have [Node.js](https://nodejs.org/) (v16 or higher recommended) installed on your machine.
 


### PR DESCRIPTION
## Description
This PR addresses two quick documentation updates:

1. **Node.js Prerequisites (Issue #383)**: 
   * Added a "Prerequisites" section to `install.md` specifying Node.js `v18.0.0` or later as a requirement.
   * Documented the CLI's engine compatibility checks and its exit code `1` behavior on older runtimes.

2. **`avenx clean` Command (Issue #382)**: 
   * Added documentation for the `avenx clean` CLI command in `commands.md`.
   * Outlined its default behavior (deleting the distribution folder, typically `dist/`) and how its target path references `avenx.config.json`.

## Related Issues
* Closes #383
* Closes #382