### PR TITLE
refactor: share bind directive processing

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -3,6 +3,7 @@ import path from 'path';
 import ExpressionParser from './expressionParser.js';
 import { logger } from '../core/runtime/AvenxLogger.js';
 import { AvenxErrorCodes, formatMessage } from '../core/runtime/AvenxError.js';
+import { processBindDirectives } from '../core/utils/templateUtils.js';
 
 /**
  * Strips CSS comments (/* ... *\/) from a CSS string, taking care not to touch comments within quoted strings.
@@ -660,70 +661,7 @@ class ${name} extends AvenxComponent {
    * @returns {string} The processed template.
    */
   processBindDirectives(template) {
-    if (typeof template !== 'string') return template;
-    const tagRegex = /<(input|textarea|select)\b([^>]*?)>/gi;
-    return template.replace(tagRegex, (match, tagName, attrs) => {
-      const bindRegex = /\bdata-ax-bind\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-      const bindMatch = attrs.match(bindRegex);
-      if (!bindMatch) {
-        return match;
-      }
-
-      const bindExpr = (bindMatch[1] !== undefined ? bindMatch[1] : bindMatch[2]).trim();
-      let cleanAttrs = attrs.replace(bindRegex, '').trim();
-
-      let isSelfClosing = false;
-      if (cleanAttrs.endsWith('/')) {
-        isSelfClosing = true;
-        cleanAttrs = cleanAttrs.slice(0, -1).trim();
-      }
-
-      if (tagName.toLowerCase() === 'input') {
-        const typeRegex = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-        const typeMatch = attrs.match(typeRegex);
-        const type = typeMatch ? (typeMatch[1] !== undefined ? typeMatch[1] : typeMatch[2]).toLowerCase() : 'text';
-
-        if (type === 'checkbox' || type === 'radio') {
-          // Remove existing checked attribute since data-ax-bind manages it
-          cleanAttrs = cleanAttrs.replace(/\bchecked\b(\s*=\s*(?:"[^"]*"|'[^']*'))?/gi, '').trim();
-
-          const valueRegex = /\bvalue\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-          const valueMatch = attrs.match(valueRegex);
-          const rawValue = valueMatch ? (valueMatch[1] !== undefined ? valueMatch[1] : valueMatch[2]) : null;
-
-          const getJsValue = (valStr) => {
-            if (valStr === null || valStr === undefined) return "'on'";
-            const trimmed = valStr.trim();
-            if (trimmed.includes('{{')) {
-              return trimmed.replace(/\{\{\s*|\s*\}\}/g, '');
-            }
-            return `'${trimmed.replace(/'/g, "\\'")}'`;
-          };
-
-          const jsValue = getJsValue(rawValue);
-
-          const checkedAttr =
-            type === 'checkbox'
-              ? `checked="{{ Array.isArray(${bindExpr}) ? (${bindExpr}).includes(${jsValue}) : !!(${bindExpr}) }}"`
-              : `checked="{{ (${bindExpr}) === ${jsValue} }}"`;
-
-          const eventAttr =
-            type === 'checkbox'
-              ? `@change="Array.isArray(${bindExpr}) ? (event.target.checked ? (!(${bindExpr}).includes(${jsValue}) ? (${bindExpr}).push(${jsValue}) : null) : ((${bindExpr}).includes(${jsValue}) ? (${bindExpr}).splice((${bindExpr}).indexOf(${jsValue}), 1) : null)) : (${bindExpr} = event.target.checked)"`
-              : `@change="${bindExpr} = event.target.value"`;
-
-          const suffix = isSelfClosing ? ' />' : '>';
-          return `<input ${cleanAttrs} ${checkedAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
-        }
-      }
-
-      const eventName = tagName.toLowerCase() === 'select' ? 'change' : 'input';
-      const valueAttr = `value="{{ ${bindExpr} }}"`;
-      const eventAttr = `@${eventName}="${bindExpr} = event.target.value"`;
-
-      const suffix = isSelfClosing ? ' />' : '>';
-      return `<${tagName} ${cleanAttrs} ${valueAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
-    });
+    return processBindDirectives(template);
   }
 
   /**

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -14,81 +14,9 @@ import { queueJob, nextTick as schedulerNextTick } from '../reactive/scheduler.j
 
 import { AvenxWatcher } from '../reactive/watcher.js';
 import { ProxyHandlerFactory } from '../reactive/proxyHandler.js';
+import { processBindDirectives } from '../utils/templateUtils.js';
 
 let currentMicrotaskPromise = null;
-
-/**
- * Processes data-ax-bind attributes on input, textarea, and select elements.
- * Converts data-ax-bind="expr" to value="{{ expr }}" and event listener.
- * @param {string} template - The template string.
- * @returns {string} The processed template.
- */
-function processBindDirectives(template) {
-  if (typeof template !== 'string') return template;
-  const tagRegex = /<(input|textarea|select)\b([^>]*?)>/gi;
-  return template.replace(tagRegex, (match, tagName, attrs) => {
-    const bindRegex = /\bdata-ax-bind\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-    const bindMatch = attrs.match(bindRegex);
-    if (!bindMatch) {
-      return match;
-    }
-
-    const bindExpr = (bindMatch[1] !== undefined ? bindMatch[1] : bindMatch[2]).trim();
-    let cleanAttrs = attrs.replace(bindRegex, '').trim();
-
-    let isSelfClosing = false;
-    if (cleanAttrs.endsWith('/')) {
-      isSelfClosing = true;
-      cleanAttrs = cleanAttrs.slice(0, -1).trim();
-    }
-
-    if (tagName.toLowerCase() === 'input') {
-      const typeRegex = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-      const typeMatch = attrs.match(typeRegex);
-      const type = typeMatch ? (typeMatch[1] !== undefined ? typeMatch[1] : typeMatch[2]).toLowerCase() : 'text';
-
-      if (type === 'checkbox' || type === 'radio') {
-        // Remove existing checked attribute since data-ax-bind manages it
-        cleanAttrs = cleanAttrs.replace(/\bchecked\b(\s*=\s*(?:"[^"]*"|'[^']*'))?/gi, '').trim();
-
-        const valueRegex = /\bvalue\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
-        const valueMatch = attrs.match(valueRegex);
-        const rawValue = valueMatch ? (valueMatch[1] !== undefined ? valueMatch[1] : valueMatch[2]) : null;
-
-        const getJsValue = (valStr) => {
-          if (valStr === null || valStr === undefined) return "'on'";
-          const trimmed = valStr.trim();
-          if (trimmed.includes('{{')) {
-            return trimmed.replace(/\{\{\s*|\s*\}\}/g, '');
-          }
-          return `'${trimmed.replace(/'/g, "\\'")}'`;
-        };
-
-        const jsValue = getJsValue(rawValue);
-
-        const checkedAttr =
-          type === 'checkbox'
-            ? `checked="{{ Array.isArray(${bindExpr}) ? (${bindExpr}).includes(${jsValue}) : !!(${bindExpr}) }}"`
-            : `checked="{{ (${bindExpr}) === ${jsValue} }}"`;
-
-        const eventAttr =
-          type === 'checkbox'
-            ? `@change="Array.isArray(${bindExpr}) ? (event.target.checked ? (!(${bindExpr}).includes(${jsValue}) ? (${bindExpr}).push(${jsValue}) : null) : ((${bindExpr}).includes(${jsValue}) ? (${bindExpr}).splice((${bindExpr}).indexOf(${jsValue}), 1) : null)) : (${bindExpr} = event.target.checked)"`
-            : `@change="${bindExpr} = event.target.value"`;
-
-        const suffix = isSelfClosing ? ' />' : '>';
-        return `<input ${cleanAttrs} ${checkedAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
-      }
-    }
-
-    const eventName = tagName.toLowerCase() === 'select' ? 'change' : 'input';
-    const valueAttr = `value="{{ ${bindExpr} }}"`;
-    const eventAttr = `@${eventName}="${bindExpr} = event.target.value"`;
-
-    const suffix = isSelfClosing ? ' />' : '>';
-    return `<${tagName} ${cleanAttrs} ${valueAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
-  });
-}
 
 /**
  * Base class for all Avenx components.

--- a/lib/core/utils/templateUtils.js
+++ b/lib/core/utils/templateUtils.js
@@ -1,0 +1,72 @@
+/**
+ * Processes data-ax-bind attributes on input, textarea, and select elements.
+ * Converts data-ax-bind="expr" to value="{{ expr }}" and event listener.
+ * @param {string} template - The template string.
+ * @returns {string} The processed template.
+ */
+export function processBindDirectives(template) {
+  if (typeof template !== 'string') return template;
+  const tagRegex = /<(input|textarea|select)\b([^>]*?)>/gi;
+  return template.replace(tagRegex, (match, tagName, attrs) => {
+    const bindRegex = /\bdata-ax-bind\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+    const bindMatch = attrs.match(bindRegex);
+    if (!bindMatch) {
+      return match;
+    }
+
+    const bindExpr = (bindMatch[1] !== undefined ? bindMatch[1] : bindMatch[2]).trim();
+    let cleanAttrs = attrs.replace(bindRegex, '').trim();
+
+    let isSelfClosing = false;
+    if (cleanAttrs.endsWith('/')) {
+      isSelfClosing = true;
+      cleanAttrs = cleanAttrs.slice(0, -1).trim();
+    }
+
+    if (tagName.toLowerCase() === 'input') {
+      const typeRegex = /\btype\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+      const typeMatch = attrs.match(typeRegex);
+      const type = typeMatch ? (typeMatch[1] !== undefined ? typeMatch[1] : typeMatch[2]).toLowerCase() : 'text';
+
+      if (type === 'checkbox' || type === 'radio') {
+        // Remove existing checked attribute since data-ax-bind manages it
+        cleanAttrs = cleanAttrs.replace(/\bchecked\b(\s*=\s*(?:"[^"]*"|'[^']*'))?/gi, '').trim();
+
+        const valueRegex = /\bvalue\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+        const valueMatch = attrs.match(valueRegex);
+        const rawValue = valueMatch ? (valueMatch[1] !== undefined ? valueMatch[1] : valueMatch[2]) : null;
+
+        const getJsValue = (valStr) => {
+          if (valStr === null || valStr === undefined) return "'on'";
+          const trimmed = valStr.trim();
+          if (trimmed.includes('{{')) {
+            return trimmed.replace(/\{\{\s*|\s*\}\}/g, '');
+          }
+          return `'${trimmed.replace(/'/g, "\\'")}'`;
+        };
+
+        const jsValue = getJsValue(rawValue);
+
+        const checkedAttr =
+          type === 'checkbox'
+            ? `checked="{{ Array.isArray(${bindExpr}) ? (${bindExpr}).includes(${jsValue}) : !!(${bindExpr}) }}"`
+            : `checked="{{ (${bindExpr}) === ${jsValue} }}"`;
+
+        const eventAttr =
+          type === 'checkbox'
+            ? `@change="Array.isArray(${bindExpr}) ? (event.target.checked ? (!(${bindExpr}).includes(${jsValue}) ? (${bindExpr}).push(${jsValue}) : null) : ((${bindExpr}).includes(${jsValue}) ? (${bindExpr}).splice((${bindExpr}).indexOf(${jsValue}), 1) : null)) : (${bindExpr} = event.target.checked)"`
+            : `@change="${bindExpr} = event.target.value"`;
+
+        const suffix = isSelfClosing ? ' />' : '>';
+        return `<input ${cleanAttrs} ${checkedAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
+      }
+    }
+
+    const eventName = tagName.toLowerCase() === 'select' ? 'change' : 'input';
+    const valueAttr = `value="{{ ${bindExpr} }}"`;
+    const eventAttr = `@${eventName}="${bindExpr} = event.target.value"`;
+
+    const suffix = isSelfClosing ? ' />' : '>';
+    return `<${tagName} ${cleanAttrs} ${valueAttr} ${eventAttr}`.trim().replace(/\s+/g, ' ') + suffix;
+  });
+}


### PR DESCRIPTION
## Summary

- move bind-directive processing into a shared template utility
- reuse the helper from both the compiler parser and runtime renderer
- preserve `ComponentParser.processBindDirectives()` as a delegating compatibility method

The compiler and runtime contained equivalent implementations that could drift independently. This change leaves one implementation while retaining the existing public behavior and call sites.

Fixes #406

## Validation

- `node test/unit/twoWayBinding.test.js`
- `node test/unit/componentParser.test.js`
- ESLint on all changed JavaScript files
- Prettier check on the new helper
- `git diff --check`

`npm run test:unit` passes 39 of 40 test files. The remaining `test/unit/cliConfig.test.js` failure is unrelated to this diff: it expects `app-src`, while the current default returned by the base branch is `src`.

CI note: the bundle-size workflow reports identical base and PR bundles (`68.36 KB`, `0 B` / `0.00%` difference) but fails because the existing base bundle exceeds the configured 50 KB absolute threshold. Its report-comment step also receives `403 Resource not accessible by integration` on this fork PR. The repository test workflow passes.

Development note: implemented with Codex assistance and validated locally against the focused compiler/runtime coverage.
