### PR TITLE
feat(compiler): support custom void tags via avenx.config.json

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -13,21 +13,35 @@ Avenx-JS reads optional project settings from `avenx.config.json` in the project
   "server": {
     "port": 3000,
     "host": "localhost"
-  }
+  },
+  "voidTags": []
 }
 ```
 
 ## Options
 
-| Option         | Type     | Default             | Rules                                                           |
-| -------------- | -------- | ------------------- | --------------------------------------------------------------- |
-| `srcDir`       | `string` | `"src"`             | Non-empty relative path to application source files.            |
-| `distDir`      | `string` | `"dist"`            | Non-empty relative path where compiled output is written.       |
-| `templatesDir` | `string` | `".avenxtemplates"` | Non-empty relative path for local generator template overrides. |
-| `server.port`  | `number` | `3000`              | Valid TCP port from `0` to `65535`.                             |
-| `server.host`  | `string` | `"localhost"`       | Non-empty host name or address for the local dev server.        |
+| Option         | Type       | Default              | Rules                                                                 |
+| -------------- | ---------- | --------------------- | ---------------------------------------------------------------------- |
+| `srcDir`       | `string`   | `"src"`              | Non-empty relative path to application source files.                  |
+| `distDir`      | `string`   | `"dist"`              | Non-empty relative path where compiled output is written.             |
+| `templatesDir` | `string`   | `".avenxtemplates"`  | Non-empty relative path for local generator template overrides.       |
+| `server.port`  | `number`   | `3000`                | Valid TCP port from `0` to `65535`.                                    |
+| `server.host`  | `string`   | `"localhost"`         | Non-empty host name or address for the local dev server.              |
+| `voidTags`     | `string[]` | `[]`                   | Extra tag names the compiler treats as void (self-closing), in addition to the built-in HTML void tags (`img`, `br`, `input`, etc.). Each entry must be a non-empty string. |
 
 Path options must be relative paths. Absolute paths are rejected during configuration loading.
+
+## Custom void tags
+
+If your templates use custom or web-component tags that are always self-closing by convention (e.g. `<my-video>` without a trailing slash), list them under `voidTags` so the compiler doesn't wait for a closing tag that will never arrive:
+
+```json
+{
+  "voidTags": ["my-video", "custom-icon"]
+}
+```
+
+Tags written with an explicit self-closing slash, like `<my-video />`, are already parsed correctly without any configuration — `voidTags` is only needed for the no-slash convention.
 
 ## Example
 
@@ -39,7 +53,8 @@ Path options must be relative paths. Absolute paths are rejected during configur
   "server": {
     "port": 5173,
     "host": "0.0.0.0"
-  }
+  },
+  "voidTags": ["my-video"]
 }
 ```
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -81,7 +81,7 @@ class AvenxCompiler {
     /**
      * @type {ComponentParser}
      */
-    this.componentParser = new ComponentParser(this.styleProcessor);
+    this.componentParser = new ComponentParser(this.styleProcessor, config.voidTags);
 
     this.init();
   }

--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -6,6 +6,111 @@ import { AvenxErrorCodes, formatMessage } from '../core/runtime/AvenxError.js';
 import { processBindDirectives } from '../core/utils/templateUtils.js';
 
 /**
+ * The set of HTML tags that are void (self-closing / no children) by
+ * default. Custom tags can be added on top of this list on a per-project
+ * basis via the `voidTags` array in `avenx.config.json` (see
+ * {@link getCustomVoidTags} and issue #198).
+ * @type {string[]}
+ */
+const DEFAULT_VOID_TAGS = [
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+];
+
+/**
+ * Builds the effective set of void tags for a parse/serialize pass by
+ * combining {@link DEFAULT_VOID_TAGS} with any project-specific tags.
+ * @param {string[]} [customVoidTags] - Additional void tag names (lowercase).
+ * @returns {Set<string>}
+ */
+function buildVoidTagsSet(customVoidTags = []) {
+  return new Set([...DEFAULT_VOID_TAGS, ...customVoidTags]);
+}
+
+/**
+ * Cache of resolved `avenx.config.json` contents, keyed by the directory
+ * the search started from, so each component file doesn't re-read and
+ * re-parse the config from disk.
+ * @type {Map<string, object|null>}
+ */
+const configCache = new Map();
+
+/**
+ * Walks up the directory tree from `startDir` looking for an
+ * `avenx.config.json` file, and returns its parsed contents (or `null` if
+ * none is found, or if it fails to parse).
+ * @param {string} startDir - Absolute directory to start searching from.
+ * @returns {object|null}
+ */
+function loadAvenxConfig(startDir) {
+  if (configCache.has(startDir)) {
+    return configCache.get(startDir);
+  }
+
+  let config = null;
+  let currentDir = startDir;
+  while (currentDir) {
+    const configPath = path.join(currentDir, 'avenx.config.json');
+    if (fs.existsSync(configPath)) {
+      try {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      } catch (err) {
+        // NOTE: no matching AvenxErrorCodes entry was available to wire this
+        // through formatMessage() - flagging for review, add e.g.
+        // COMPILER_INVALID_CONFIG if the project wants a structured code here.
+        logger.warn(`[Avenx] Failed to parse avenx.config.json at ${configPath}: ${err.message}`);
+        config = null;
+      }
+      break;
+    }
+    const parent = path.dirname(currentDir);
+    if (parent === currentDir) {
+      break;
+    }
+    currentDir = parent;
+  }
+
+  configCache.set(startDir, config);
+  return config;
+}
+
+/**
+ * Resolves the list of project-specific void tags declared in
+ * `avenx.config.json` (via a `voidTags` array) for the given component
+ * file, e.g.:
+ * ```json
+ * { "voidTags": ["my-video", "my-icon"] }
+ * ```
+ * @param {string} [filePath] - Absolute path of the component file being compiled.
+ * @returns {string[]} Lowercased, trimmed custom void tag names. Empty if none configured.
+ */
+function getCustomVoidTags(filePath) {
+  if (!filePath) {
+    return [];
+  }
+  const startDir = path.resolve(path.dirname(filePath));
+  const config = loadAvenxConfig(startDir);
+  if (!config || !Array.isArray(config.voidTags)) {
+    return [];
+  }
+  return config.voidTags
+    .filter((tag) => typeof tag === 'string' && tag.trim() !== '')
+    .map((tag) => tag.trim().toLowerCase());
+}
+
+/**
  * Strips CSS comments (/* ... *\/) from a CSS string, taking care not to touch comments within quoted strings.
  * @param {string} css - The CSS string.
  * @returns {string} The CSS string without comments.
@@ -115,7 +220,7 @@ class ComponentParser {
     template = this.processComponentTags(template);
 
     // Identify and mark static subtrees for patcher performance optimization
-    template = this.optimizeStaticSubtrees(template);
+    template = this.optimizeStaticSubtrees(template, filePath);
 
     const methodStrings = Object.entries(methods)
       .map(([k, v]) => `${k}: \`${v}\``)
@@ -297,7 +402,7 @@ class ${name} extends AvenxComponent {
       this.validateTemplate(template, state, computed, methods, filePath, name);
     }
     template = this.processForLoops(template);
-    template = this.processTransitionTags(template);
+    template = this.processTransitionTags(template, filePath);
     return template
       .split('\n')
       .filter((line) => line.trim() !== '')
@@ -928,13 +1033,16 @@ class ${name} extends AvenxComponent {
   /**
    * Processes transition tags in the template, converting them to data-ax-transition attributes.
    * @param {string} template - The HTML template string.
+   * @param {string} [filePath] - The component file path, used to resolve project-specific
+   *   void tags from `avenx.config.json` (see {@link getCustomVoidTags}).
    * @returns {string} The processed template.
    */
-  processTransitionTags(template) {
+  processTransitionTags(template, filePath) {
     try {
-      const nodes = parseHTML(template);
+      const customVoidTags = getCustomVoidTags(filePath);
+      const nodes = parseHTML(template, customVoidTags);
       const processed = this.processTransitionTagsInTree(nodes);
-      return serializeHTML(processed);
+      return serializeHTML(processed, customVoidTags);
     } catch (err) {
       logger.warn(formatMessage(AvenxErrorCodes.COMPILER_TRANSITION_PARSE_FAILED, err));
       return template;
@@ -981,13 +1089,16 @@ class ${name} extends AvenxComponent {
   /**
    * Identifies static elements/subtrees and marks them with data-ax-static="true".
    * @param {string} template - The compiled HTML template.
+   * @param {string} [filePath] - The component file path, used to resolve project-specific
+   *   void tags from `avenx.config.json` (see {@link getCustomVoidTags}).
    * @returns {string} The optimized template.
    */
-  optimizeStaticSubtrees(template) {
+  optimizeStaticSubtrees(template, filePath) {
     try {
-      const nodes = parseHTML(template);
+      const customVoidTags = getCustomVoidTags(filePath);
+      const nodes = parseHTML(template, customVoidTags);
       this.markStaticNodes(nodes, false);
-      return serializeHTML(nodes);
+      return serializeHTML(nodes, customVoidTags);
     } catch (err) {
       logger.warn(formatMessage(AvenxErrorCodes.COMPILER_STATIC_SUBTREE_OPTIMIZATION_FAILED, err));
       return template;
@@ -1119,29 +1230,19 @@ function parseAttributes(attrStr) {
 /**
  * Parses an HTML string into a tree of HTMLNode elements.
  * @param {string} html
+ * @param {string[]} [customVoidTags] - Additional project-specific void tag
+ *   names (lowercase), loaded from `avenx.config.json`. Merged on top of
+ *   {@link DEFAULT_VOID_TAGS}. Regardless of this list, any tag that is
+ *   written with a self-closing slash (e.g. `<my-video />`) is always
+ *   treated as void so it never requires a matching closing tag.
  * @returns {HTMLNode[]}
  */
-function parseHTML(html) {
+function parseHTML(html, customVoidTags = []) {
   const root = new HTMLNode('element', 'root');
   const stack = [root];
   let i = 0;
 
-  const voidTags = new Set([
-    'area',
-    'base',
-    'br',
-    'col',
-    'embed',
-    'hr',
-    'img',
-    'input',
-    'link',
-    'meta',
-    'param',
-    'source',
-    'track',
-    'wbr',
-  ]);
+  const voidTags = buildVoidTagsSet(customVoidTags);
 
   while (i < html.length) {
     // 1. Check for comment
@@ -1254,10 +1355,15 @@ function parseHTML(html) {
 /**
  * Serializes an HTMLNode tree back to an HTML string.
  * @param {HTMLNode[]} nodes
+ * @param {string[]} [customVoidTags] - Additional project-specific void tag
+ *   names (lowercase), loaded from `avenx.config.json`. Should match what
+ *   was passed to {@link parseHTML} for the same template so a custom void
+ *   tag round-trips consistently.
  * @returns {string}
  */
-function serializeHTML(nodes) {
+function serializeHTML(nodes, customVoidTags = []) {
   let result = '';
+  const voidTags = buildVoidTagsSet(customVoidTags);
   for (const node of nodes) {
     if (node.type === 'text') {
       result += node.content;
@@ -1273,26 +1379,10 @@ function serializeHTML(nodes) {
           attrsStr += ` ${name}="${escapedVal}"`;
         }
       }
-      const voidTags = new Set([
-        'area',
-        'base',
-        'br',
-        'col',
-        'embed',
-        'hr',
-        'img',
-        'input',
-        'link',
-        'meta',
-        'param',
-        'source',
-        'track',
-        'wbr',
-      ]);
       if (voidTags.has(node.tagName.toLowerCase()) || node.isSelfClosing) {
         result += `<${node.tagName}${attrsStr} />`;
       } else {
-        result += `<${node.tagName}${attrsStr}>${serializeHTML(node.children)}</${node.tagName}>`;
+        result += `<${node.tagName}${attrsStr}>${serializeHTML(node.children, customVoidTags)}</${node.tagName}>`;
       }
     }
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -103,6 +103,7 @@ function loadConfig(baseDir) {
     style: {
       preprocessor: 'none',
     },
+    voidTags: [],
   };
 
   const rootDir = baseDir || findProjectRoot(process.cwd());
@@ -116,7 +117,16 @@ function loadConfig(baseDir) {
     const userConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
     if (userConfig && typeof userConfig === 'object' && !Array.isArray(userConfig)) {
-      const allowedTopLevel = ['srcDir', 'distDir', 'templatesDir', 'server', 'style', 'outputName', 'logging'];
+      const allowedTopLevel = [
+        'srcDir',
+        'distDir',
+        'templatesDir',
+        'server',
+        'style',
+        'outputName',
+        'logging',
+        'voidTags',
+      ];
       for (const key of Object.keys(userConfig)) {
         if (!allowedTopLevel.includes(key)) {
           const closest = getClosestKey(key, allowedTopLevel);
@@ -189,6 +199,10 @@ function loadConfig(baseDir) {
     }
     if (path.isAbsolute(config.templatesDir)) {
       throw new Error('templatesDir must be a relative path');
+    }
+
+    if (!Array.isArray(config.voidTags) || config.voidTags.some((tag) => typeof tag !== 'string' || tag.trim() === '')) {
+      throw new Error('voidTags must be an array of non-empty strings');
     }
 
     if (typeof config.server.port !== 'number' || config.server.port < 0 || config.server.port > 65535) {

--- a/test/unit/componentParser.test.js
+++ b/test/unit/componentParser.test.js
@@ -170,6 +170,28 @@ try {
   assert.ok(templateWithComments.includes('<div class="test">'));
   assert.ok(templateWithComments.includes('<p>Hello  World</p>'));
   console.log('  ✅ HTML Comments Stripping tests passed!');
+  console.log('🧪 Testing custom void tags from config...');
+  const cpWithVoidTags = new ComponentParser(sp, ['my-video', 'custom-icon']);
+
+  // Test: custom void tag without self-closing slash is treated as void
+  const templateCustomVoid = cpWithVoidTags.extractTemplate(
+    '<div><my-video src="a.mp4"><p>Trailing text</p></div>',
+    {},
+    'TestComp',
+  );
+  assert.ok(templateCustomVoid.includes('<my-video src="a.mp4" />'));
+  assert.ok(templateCustomVoid.includes('<p>Trailing text</p>'));
+
+  // Test: explicit self-closing slash still works without any config
+  const templateSelfClosing = cp.extractTemplate('<div><my-video src="a.mp4" /></div>', {}, 'TestComp');
+  assert.ok(templateSelfClosing.includes('<my-video src="a.mp4" />'));
+
+  // Test: unknown custom tags without the config entry are NOT treated as void
+  const templateUnknownTag = cp.extractTemplate('<div><my-video src="a.mp4"><p>Inside</p></my-video></div>', {}, 'TestComp');
+  assert.ok(templateUnknownTag.includes('<p>Inside</p>'));
+  assert.ok(!templateUnknownTag.includes('<my-video src="a.mp4" />'));
+
+  console.log('  ✅ Custom void tags tests passed!');
 } catch (error) {
   console.error('❌ ComponentParser tests failed!');
   console.error(error);


### PR DESCRIPTION
feat(compiler): support custom void tags via avenx.config.json

Adds a `voidTags` option to avenx.config.json so templates can use
custom/web-component tags that are self-closing by convention (e.g.
<my-video>) without triggering a tag-mismatch parse error.

- lib/config.js: recognize `voidTags` as a top-level config key,
  default to [], validate as an array of non-empty strings
- lib/compiler.js: thread config.voidTags into ComponentParser
- lib/compiler/ComponentParser.js: merge custom void tags into the
  parser/serializer's void-tag set
- docs: document the voidTags option
- tests: cover custom void tags with and without config, and confirm
  explicit self-closing tags (<tag />) still work without config

Closes #198