### PR TITLE
docs: add AVX_W14 troubleshooting guide

### DIFF
--- a/docs/src/content/docs/troubleshooting/errors.md
+++ b/docs/src/content/docs/troubleshooting/errors.md
@@ -168,6 +168,62 @@ export default {
 
 Using optional chaining and fallback values helps prevent runtime exceptions during route title evaluation.
 
+### AVX_W14 — COMPONENT_RESTORE_SLOT_CONTENT_FAILED
+
+**Warning Message**
+Failed to restore default slot content. Error: {0}
+
+**Cause:** This warning relates to how Avenx-JS handles component **slots** — placeholder regions inside a component's template where a parent can inject custom ("transcluded") content, falling back to the component's own default markup when nothing is provided. When transcluded content is unmounted (for example, when a parent stops passing slot content, or the component itself unmounts and remounts), Avenx-JS attempts to restore the slot's original default template elements so the component returns to a consistent state. This warning is emitted when that restore step fails.
+
+This typically happens for a few common reasons:
+
+- Code outside the component (custom DOM manipulation, a third-party library, or a browser extension) directly mutated the DOM nodes inside the slot, so the renderer's internal reference to the original default content no longer matches the live DOM.
+- The default slot content itself contained elements that were later removed or replaced by other framework logic before the restore attempt ran.
+- Rapid mount/unmount cycles on the same component instance interrupted the restore process before it completed.
+
+**Impact:** When this restore fails, the slot may be left empty or in an inconsistent state rather than falling back to the component's intended default content. This is a rendering consistency issue, not a security issue, but it can result in visibly broken or missing UI where default slot content was expected.
+
+**Resolution:** To resolve this warning:
+
+1. Avoid directly mutating the DOM inside a component's slot region from outside the framework (e.g. via `document.querySelector` plus manual `appendChild`/`removeChild` calls). Let Avenx-JS own all DOM updates within its managed tree.
+2. If you're integrating a third-party library that manipulates the DOM (such as a jQuery plugin or a non-Avenx widget), mount it outside the component's slot boundary, or use a dedicated wrapper/bridge pattern instead of injecting it directly into slot content.
+3. Avoid rapidly toggling a component's mounted state or its slot content in the same render cycle; batch these changes where possible.
+4. If the warning persists without any external DOM manipulation, it may indicate a genuine bug — check for other components or event handlers that could be mutating shared DOM nodes.
+
+**Incorrect**
+
+```javascript
+// Directly manipulating DOM nodes inside a component's slot from outside Avenx-JS
+const slotContainer = document.querySelector('.my-component .slot-content');
+slotContainer.innerHTML = '<p>Injected externally</p>';
+```
+
+Manipulating the slot's DOM outside of Avenx-JS's rendering tree causes the renderer's internal reference to the default content to become stale, so it cannot reliably restore it later.
+
+**Correct**
+
+```html
+<MyComponent>
+  <p>Custom transcluded content</p>
+</MyComponent>
+```
+
+Pass content through the component's own slot mechanism so Avenx-JS can track and restore it correctly.
+
+**Defensive Example**
+
+```javascript
+// If integrating a non-Avenx widget, mount it in its own container
+// outside the component's slot boundary rather than inside it.
+```
+
+```html
+<MyComponent></MyComponent>
+<div id="third-party-widget-container"></div>
+```
+
+Keeping externally-managed DOM separate from Avenx-managed slot regions prevents the renderer from losing track of default slot content.
+
 ### AVX_W15 — COMPONENT_INJECT_KEY_NOT_FOUND
 
 **Warning Message**


### PR DESCRIPTION
Documents warning code AVX_W14 (COMPONENT_RESTORE_SLOT_CONTENT_FAILED) in the troubleshooting guide, following the existing format used for other AVX_W* codes.
Changes

Added a new ### AVX_W14 — COMPONENT_RESTORE_SLOT_CONTENT_FAILED section to docs/src/content/docs/troubleshooting/errors.md, placed in numeric order
Explained slot element behavior and default fallback content in Avenx-JS
Documented causes of restore failure (external DOM mutations outside the virtual renderer's control) and safe integration patterns

Closes #448