### PR TITLE
docs: fix AVX_W16 documentation rendering

### DIFF
--- a/docs/src/content/docs/troubleshooting/errors.md
+++ b/docs/src/content/docs/troubleshooting/errors.md
@@ -941,7 +941,9 @@ const state = {
 ```
 
 When rendered, the sanitizer strips the `<script>` tag and logs:
+```text
 [Avenx Validation Warning] Sanitized tag "<script>" when stripping content.
+```
 
 The safe portion of the markup (`<p>Hello!</p>`) still renders normally.
 


### PR DESCRIPTION
## Summary

This PR fixes a documentation rendering issue affecting the `AVX_W16` troubleshooting section.

## Changes

- Wrap the AVX_W16 warning message in a fenced `text` code block.
- Restore rendering of the remaining documentation sections on the official documentation site.

Closes #493