### PR TITLE
docs: document VirtualList component and clarify live-reloading in CL…

### DIFF
--- a/docs/src/content/docs/api-reference/virtuallist.md
+++ b/docs/src/content/docs/api-reference/virtuallist.md
@@ -1,0 +1,28 @@
+# <VirtualList>
+
+The `<VirtualList>` component is a built-in, globally available component designed for high-performance virtualized list rendering of massive datasets. It automatically handles dynamic element recycling, layout paddings, and dynamic item height updates.
+
+## Props
+
+| Prop | Type | Description |
+| :--- | :--- | :--- |
+| `items` | `Array` | The dataset array to be rendered in the list. |
+| `itemHeight` / `item-height` | `Number` | The height of each item. Supports both camelCase (`itemHeight`) and kebab-case (`item-height`). |
+
+> **Note:** `<VirtualList>` includes built-in `ResizeObserver` support to handle dynamic row resizing automatically.
+
+---
+
+## Usage Example
+
+To pass templates into the `<VirtualList>`, use the `data-ax-as="item"` directive on your template slot:
+
+```html
+<VirtualList :item-height="50" :items="myLargeDataset">
+  <template data-ax-as="item" let:item>
+    <div class="list-item">
+      <h3>{{ item.title }}</h3>
+      <p>{{ item.description }}</p>
+    </div>
+  </template>
+</VirtualList>

--- a/docs/src/content/docs/cli-reference/commands.md
+++ b/docs/src/content/docs/cli-reference/commands.md
@@ -77,7 +77,7 @@ Compiles the project once and then continues running in the background, watching
 
 Whenever a file in the `src/` directory changes, Avenx automatically rebuilds the project and updates the generated files in the `dist/` directory. This keeps your compiled output up to date without manually running `avenx build` after every change.
 
-Unlike `avenx serve`, the `watch` command does not start a local development server or provide browser hot reloading. It only watches for file changes and continuously rebuilds the project in the background.
+Unlike `avenx serve`, the `watch` command does not start a local development server or provide browser live reloading. It only watches for file changes and continuously rebuilds the project in the background.
 
 **Example:**
 
@@ -89,7 +89,13 @@ Press **Ctrl + C** to stop watching.
 
 ### 6. `avenx serve [port]`
 
-Starts a local hot-reloading development server (default port: 3000). It watches the `src/` directory for changes, automatically triggers a rebuild, and sends a live reload event to connected browser instances via a Server-Sent Events (SSE) bridge.
+Starts a local live-reloading development server (default port: 3000). 
+
+#### Description
+
+The development server watches the `src/` directory for code modifications and automatically triggers a project rebuild. It utilizes a Server-Sent Events (SSE) bridge to instantly dispatch a reload event to all connected browser instances upon a successful compilation.
+
+> **Note on Reloading Behavior:** When a code change is detected, the development server triggers a full page refresh (`window.location.reload()`) in the connected browsers to apply the updates. This is a **Live Reloading** mechanism rather than Hot Module Replacement (HMR); as a result, transient local application state will be reset when the page refreshes.
 
 ### 7. `avenx check` (alias: `lint`)
 


### PR DESCRIPTION
## Summary
This Pull Request addresses two open documentation tasks: documenting the built-in `<VirtualList>` component and clarifying the development server's reloading mechanics in the CLI reference guide.

## Changes

### 1. Built-in Components Reference (Closes #380)
* Created a new API reference document at `docs/src/content/docs/api-reference/virtuallist.md`.
* Documented the properties (`items`, `itemHeight`, and `item-height`), detailing support for both camelCase and kebab-case prop attributes.
* Added clear template usage examples showing how to pass child blocks via the `<template data-ax-as="item">` slot.
* Highlighted built-in `ResizeObserver` support for tracking dynamic row resizing automatically.

### 2. CLI Reference Guide (Closes #366)
* Updated `docs/src/content/docs/cli-reference/commands.md`.
* Replaced instances of `"hot-reloading"` with `"live-reloading"` under both `avenx watch` and `avenx serve` commands.
* Clarified the exact technical behavior of the development server, explicitly stating that file changes trigger a full page refresh via a Server-Sent Events (SSE) bridge (`window.location.reload()`) which resets transient local application state.

## Verification Checklist
- [x] New `<VirtualList>` markdown documentation file maps to correct file layout structures.
- [x] CLI reference text cleanly updates reloading syntax without changing functional commands.