### PR TITLE
refactor(renderer): decouple boolean attributes map

### DIFF
--- a/lib/core/renderer/constants.js
+++ b/lib/core/renderer/constants.js
@@ -1,0 +1,27 @@
+/**
+ * A set of known HTML boolean attributes.
+ * @type {Set<string>}
+ */
+
+export const BOOLEAN_ATTRIBUTES = new Set([
+  'checked',
+  'disabled',
+  'required',
+  'readonly',
+  'selected',
+  'multiple',
+  'autofocus',
+  'novalidate',
+  'formnovalidate',
+  'hidden',
+  'open',
+  'reversed',
+  'loop',
+  'controls',
+  'autoplay',
+  'muted',
+  'default',
+  'ismap',
+  'async',
+  'defer',
+]);

--- a/lib/core/renderer/domPatch.js
+++ b/lib/core/renderer/domPatch.js
@@ -1,35 +1,9 @@
 import { AvenxErrorCodes, formatMessage } from '../runtime/AvenxError.js';
 import { logger } from '../runtime/AvenxLogger.js';
 import { HtmlEscaper, SafeHtml } from '../security/escapeHtml.js';
+import { BOOLEAN_ATTRIBUTES } from './constants.js';
 
 const escaper = new HtmlEscaper();
-
-/**
- * A set of known HTML boolean attributes.
- * @type {Set<string>}
- */
-const BOOLEAN_ATTRIBUTES = new Set([
-  'checked',
-  'disabled',
-  'required',
-  'readonly',
-  'selected',
-  'multiple',
-  'autofocus',
-  'novalidate',
-  'formnovalidate',
-  'hidden',
-  'open',
-  'reversed',
-  'loop',
-  'controls',
-  'autoplay',
-  'muted',
-  'default',
-  'ismap',
-  'async',
-  'defer',
-]);
 
 /**
  * Helper to compute transition/animation duration from element computed styles.


### PR DESCRIPTION
## What does this PR do?

This PR decouples the boolean attributes map from the DOM patching logic.

## Changes

- Moved `BOOLEAN_ATTRIBUTES` to `lib/core/renderer/constants.js`
- Imported the shared constant into `domPatch.js`
- Kept the existing behavior unchanged

## Testing

- All tests pass
- Total: 63
- Passed: 63
- Failed: 0

Fixes #508