### PR TITLE
fix/weakmap-cleanup

### DIFF
--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -422,6 +422,12 @@ export class ProxyHandlerFactory {
       value = value[RAW_SYMBOL];
     }
     const oldValue = target[key];
+ 
+    
+    if(isReactiveTarget(oldValue)){
+      parentMap.delete(oldValue)
+    }
+
     target[key] = value;
 
     if (isReactiveTarget(value)) {
@@ -507,7 +513,13 @@ export class ProxyHandlerFactory {
    */
   deleteProperty(target, key) {
     const hasKey = Reflect.has(target, key);
+    const oldValue = target[key];
     const result = Reflect.deleteProperty(target, key);
+    
+    if(isReactiveTarget(oldValue)){
+      parentMap.delete(oldValue)
+    }
+
     if (hasKey) {
       trigger(target, key);
       this.onChange();
@@ -601,6 +613,12 @@ export class ProxyHandlerFactory {
           value = value[RAW_SYMBOL];
         }
         const oldValue = target[key];
+        // Remove stale parent reference of the old child
+
+        if(isReactiveTarget){
+          parentMap.delete(oldValue)
+        }
+
         target[key] = value;
 
         if (isReactiveTarget(value)) {
@@ -615,7 +633,15 @@ export class ProxyHandlerFactory {
       },
       deleteProperty: (target, key) => {
         const hasKey = Reflect.has(target, key);
+        const oldValue = target[key]
+
         const result = Reflect.deleteProperty(target, key);
+
+        // Remove stale parent reference of the deleted child
+        if(isReactiveTarget(oldValue)){
+          parentMap.delete(oldValue)
+        }
+
         if (hasKey) {
           trigger(target, key);
           this.onChange();

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -56,7 +56,13 @@ export class ProxyHandlerFactory {
    * @param {object} [options.instance] - The component instance for fallback property lookups.
    * @param {boolean} [options.bypassSymbol] - Bypasses Symbol check during lookup.
    */
-  constructor({ computedKeys = [], onChange = () => {}, getComputedValue = () => undefined, instance = null, bypassSymbol = false } = {}) {
+  constructor({
+    computedKeys = [],
+    onChange = () => {},
+    getComputedValue = () => undefined,
+    instance = null,
+    bypassSymbol = false,
+  } = {}) {
     /** @type {Set<string>} @private */
     this.computedKeys = new Set(computedKeys);
     /** @type {function(): void} @private */
@@ -146,6 +152,10 @@ export class ProxyHandlerFactory {
 
         target.set(k, rawVal);
 
+        if (isReactiveTarget(oldValue)) {
+          parentMap.delete(oldValue);
+        }
+
         if (isReactiveTarget(rawVal)) {
           parentMap.set(rawVal, { parentTarget: target, parentKey: k });
         }
@@ -160,11 +170,19 @@ export class ProxyHandlerFactory {
     if (key === 'delete') {
       return (k) => {
         const hasKey = target.has(k);
+        const oldValue = target.get(k);
+
         const result = target.delete(k);
+
         if (hasKey) {
+          if (isReactiveTarget(oldValue)) {
+            parentMap.delete(oldValue);
+          }
+
           trigger(target, [k, 'size']);
           this.onChange();
         }
+
         return result;
       };
     }
@@ -305,11 +323,18 @@ export class ProxyHandlerFactory {
       return (val) => {
         const rawVal = val && val[RAW_SYMBOL] ? val[RAW_SYMBOL] : val;
         const hasVal = target.has(rawVal);
+
         const result = target.delete(rawVal);
+
         if (hasVal) {
+          if (isReactiveTarget(rawVal)) {
+            parentMap.delete(rawVal);
+          }
+
           trigger(target, [rawVal, 'size']);
           this.onChange();
         }
+
         return result;
       };
     }
@@ -422,12 +447,10 @@ export class ProxyHandlerFactory {
       value = value[RAW_SYMBOL];
     }
     const oldValue = target[key];
- 
-    
-    if(isReactiveTarget(oldValue)){
-      parentMap.delete(oldValue)
-    }
 
+    if (isReactiveTarget(oldValue)) {
+      parentMap.delete(oldValue);
+    }
     target[key] = value;
 
     if (isReactiveTarget(value)) {
@@ -515,9 +538,9 @@ export class ProxyHandlerFactory {
     const hasKey = Reflect.has(target, key);
     const oldValue = target[key];
     const result = Reflect.deleteProperty(target, key);
-    
-    if(isReactiveTarget(oldValue)){
-      parentMap.delete(oldValue)
+
+    if (isReactiveTarget(oldValue)) {
+      parentMap.delete(oldValue);
     }
 
     if (hasKey) {
@@ -613,10 +636,9 @@ export class ProxyHandlerFactory {
           value = value[RAW_SYMBOL];
         }
         const oldValue = target[key];
-        // Remove stale parent reference of the old child
 
-        if(isReactiveTarget){
-          parentMap.delete(oldValue)
+        if (isReactiveTarget(oldValue)) {
+          parentMap.delete(oldValue);
         }
 
         target[key] = value;
@@ -633,13 +655,11 @@ export class ProxyHandlerFactory {
       },
       deleteProperty: (target, key) => {
         const hasKey = Reflect.has(target, key);
-        const oldValue = target[key]
-
+        const oldValue = target[key];
         const result = Reflect.deleteProperty(target, key);
 
-        // Remove stale parent reference of the deleted child
-        if(isReactiveTarget(oldValue)){
-          parentMap.delete(oldValue)
+        if (isReactiveTarget(oldValue)) {
+          parentMap.delete(oldValue);
         }
 
         if (hasKey) {
@@ -661,4 +681,4 @@ export class ProxyHandlerFactory {
     }
     return proxy;
   }
-}
+} 


### PR DESCRIPTION
## What does this PR do?

This PR cleans up stale parent references from `parentMap` when nested reactive objects are overwritten or deleted.

## Changes

- Remove the old child reference from `parentMap` when a property is overwritten.
- Remove the deleted child reference from `parentMap`.
- Apply the cleanup logic to both the main proxy handler and nested proxy handlers.

## Testing

- All tests pass
- Total: 63
- Passed: 63
- Failed: 0

Fixes #529