### PR TITLE
fix: add log level validation in AvenxLogger.configure (fixes #572)

### DIFF
--- a/lib/core/runtime/AvenxLogger.js
+++ b/lib/core/runtime/AvenxLogger.js
@@ -136,6 +136,11 @@ export class AvenxLogger {
     if (typeof this.config.level === 'string') {
       this.config.level = this.config.level.toLowerCase();
     }
+    // Validate level against known LogLevels; fall back to 'info' on mismatch
+    if (LogLevels[this.config.level] === undefined) {
+      this.write('warn', `Invalid log level "${this.config.level}" — falling back to "info"`);
+      this.config.level = 'info';
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes #572 — Add level input validation in AvenxLogger.configure.

## Problem
If an invalid log level (e.g. `"VERBOSE"`) is passed to `AvenxLogger.configure`, the logger accepts it silently, which can result in missing log outputs.

## Fix
Added validation in `configure()` to check the level against known `LogLevels`. On mismatch, warns and falls back to `"info"`.

## Verification
- Unit test suite: 48/48 passed
- Invalid level (`"VERBOSE"`) -> warning emitted + level reset to `"info"`
- Valid levels (`"debug"`, `"warn"`, etc.) -> unaffected