### PR TITLE
Fix encoded hash routes matching

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -259,7 +259,15 @@ export class AvenxRouter {
       const { regex, paramNames } = this.#compileRoute(routePattern);
 
       const [pathPart, queryPart] = hash.split('?');
-      const match = pathPart.match(regex);
+      let decodedPath;
+
+      try {
+        decodedPath = decodeURIComponent(pathPart);
+      } catch {
+        decodedPath = pathPart;
+      }
+
+      const match = decodedPath.match(regex);
 
       if (match) {
         matchedRoute = { pattern: routePattern, definition: routeDef };


### PR DESCRIPTION
Fixes #532

### Changes
- Decode encoded hash paths before route matching
- Handle malformed URI sequences safely to avoid router crashes

### Testing
- npm run test:integration