### PR TITLE
feat(cli): allow disabling dev server live reload

### DIFF
--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -519,12 +519,15 @@ export function watchProject(cli) {
  * @param {string} [host]
  */
 export function serveProject(cli, port, host = 'localhost') {
-  cli.liveReloadClients = [];
   buildProject(cli);
-  watchProject(cli);
+
+  if (cli.config.server.liveReload) {
+    cli.liveReloadClients = [];
+    watchProject(cli);
+  }
 
   const server = http.createServer((req, res) => {
-    if (req.url === '/__avenx_live_reload__') {
+    if (cli.config.server.liveReload && req.url === '/__avenx_live_reload__') {
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
@@ -576,7 +579,7 @@ export function serveProject(cli, port, host = 'localhost') {
         }
       } else {
         let responseContent = content;
-        if (contentType === 'text/html') {
+        if (cli.config.server.liveReload && contentType === 'text/html') {
           const script = `
 <script>
     window.__avenx_inspect_enabled = true;
@@ -618,7 +621,9 @@ export function serveProject(cli, port, host = 'localhost') {
   server.listen(port, host, () => {
     const url = `http://${host}:${port}`;
     console.log(`\n🚀 Dev-Server running at ${url}`);
-    console.log(`👀 Watching for changes in ${cli.config.srcDir}/...\n`);
+    if (cli.config.server.liveReload) {
+      console.log(`👀 Watching for changes in ${cli.config.srcDir}/...\n`);
+    }
     openBrowser(url);
   });
 }

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -12,7 +12,8 @@ Avenx-JS reads optional project settings from `avenx.config.json` in the project
   "templatesDir": ".avenxtemplates",
   "server": {
     "port": 3000,
-    "host": "localhost"
+    "host": "localhost",
+    "liveReload": true
   },
   "voidTags": []
 }
@@ -27,6 +28,7 @@ Avenx-JS reads optional project settings from `avenx.config.json` in the project
 | `templatesDir` | `string`   | `".avenxtemplates"`  | Non-empty relative path for local generator template overrides.       |
 | `server.port`  | `number`   | `3000`                | Valid TCP port from `0` to `65535`.                                    |
 | `server.host`  | `string`   | `"localhost"`         | Non-empty host name or address for the local dev server.              |
+| `server.liveReload` | `boolean` | `true`              | Enables file watching, automatic browser reloads, and inspection script injection. |
 | `voidTags`     | `string[]` | `[]`                   | Extra tag names the compiler treats as void (self-closing), in addition to the built-in HTML void tags (`img`, `br`, `input`, etc.). Each entry must be a non-empty string. |
 
 Path options must be relative paths. Absolute paths are rejected during configuration loading.
@@ -52,13 +54,16 @@ Tags written with an explicit self-closing slash, like `<my-video />`, are alrea
   "templatesDir": ".avenxtemplates",
   "server": {
     "port": 5173,
-    "host": "0.0.0.0"
+    "host": "0.0.0.0",
+    "liveReload": false
   },
   "voidTags": ["my-video"]
 }
 ```
 
 The configuration is merged with the defaults, so you can override only the settings your project needs.
+
+Set `server.liveReload` to `false` when the dev server should serve HTML without watching for changes or injecting the live-reload and inspection client script.
 
 ## Logging Options
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -102,6 +102,7 @@ function loadConfig(baseDir) {
     server: {
       port: 3000,
       host: 'localhost',
+      liveReload: true,
     },
     style: {
       preprocessor: 'none',
@@ -137,7 +138,7 @@ function loadConfig(baseDir) {
           logger.warn(`Unknown configuration option "${key}" in avenx.config.json${suggestion} Supported top-level options are: ${allowedTopLevel.join(', ')}.`);
         } else {
           if (key === 'server' && userConfig.server && typeof userConfig.server === 'object' && !Array.isArray(userConfig.server)) {
-            const allowedServerKeys = ['port', 'host'];
+            const allowedServerKeys = ['port', 'host', 'liveReload'];
             for (const subKey of Object.keys(userConfig.server)) {
               if (!allowedServerKeys.includes(subKey)) {
                 const closest = getClosestKey(subKey, allowedServerKeys);
@@ -214,6 +215,10 @@ function loadConfig(baseDir) {
 
     if (typeof config.server.host !== 'string' || config.server.host.trim() === '') {
       throw new Error('server.host must be a non-empty string');
+    }
+
+    if (typeof config.server.liveReload !== 'boolean') {
+      throw new Error('server.liveReload must be a boolean');
     }
 
     return config;

--- a/test/unit/cliConfig.test.js
+++ b/test/unit/cliConfig.test.js
@@ -57,12 +57,13 @@ try {
     assert.strictEqual(defaults.distDir, 'dist');
     assert.strictEqual(defaults.templatesDir, '.avenxtemplates');
     assert.strictEqual(defaults.server.port, 3000);
+    assert.strictEqual(defaults.server.liveReload, true);
 
     console.log('  Testing valid custom config merge...');
     writeTestConfig({
       srcDir: 'app-src',
       distDir: 'public-out',
-      server: { port: 8080 },
+      server: { port: 8080, liveReload: false },
     });
     const customConfig = loadConfig();
     assert.strictEqual(customConfig.srcDir, 'app-src');
@@ -70,6 +71,7 @@ try {
     assert.strictEqual(customConfig.templatesDir, '.avenxtemplates');
     assert.strictEqual(customConfig.server.port, 8080);
     assert.strictEqual(customConfig.server.host, 'localhost');
+    assert.strictEqual(customConfig.server.liveReload, false);
 
     console.log('  Testing invalid config schema validations...');
     writeTestConfig({ srcDir: '' });
@@ -98,6 +100,9 @@ try {
 
     writeTestConfig({ server: { host: '' } });
     assertThrows(() => loadConfig(), 'server.host must be a non-empty string');
+
+    writeTestConfig({ server: { liveReload: 'false' } });
+    assertThrows(() => loadConfig(), 'server.liveReload must be a boolean');
 
     writeTestConfig({ voidTags: 'not-an-array' });
     assertThrows(() => loadConfig(), 'voidTags must be an array of non-empty strings');


### PR DESCRIPTION
## Summary

- add a validated `server.liveReload` option defaulting to `true`
- disable file watching, SSE listeners, and HTML client-script injection when configured as `false`
- document the option and test its default, override, and validation behavior

## Testing

- Passed in the clean network-off verifier: `node --import ./test/helpers/register-happy-dom.js test/unit/cliConfig.test.js && npm test`

---
<!-- northset-receipt:M-1061:start -->
### Verification

the repository's declared test command exited 0 on this exact head (`b2c731c`) in a network-off container, before this PR was opened.
No workflow or CI files are modified in this change.
Commands, environment, and hashes: [receipt M-1061](https://northset-oss.github.io/verification-pilot/receipts/M-1061/) — checkable in ~30 seconds without trusting us.
This record covers Northset's own contribution; it is not maintainer verification.
Maintainers: request a separate private run for any PR in your queue — open a run request: https://github.com/northset-oss/verification-pilot/issues/new?template=request-a-run.yml or email oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1061:end -->

AI-assisted and reviewed by Northset; I take responsibility for this submission.
