### PR TITLE
Fix encoded routing hash changes

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -87,7 +87,7 @@ export class AvenxRouter {
    * @returns {boolean} True if a non-fallback route matches.
    */
   matches(hash) {
-    return RouteMatcher.matches(this.routes, hash, this.options);
+    return RouteMatcher.matches(this.routes, decodeURIComponent(hash), this.options);
   }
 
   /**


### PR DESCRIPTION
## What was broken
The router failed to match route patterns when the hash URL contained percent-encoded characters.
## What changed
The hash matching input is now wrapped with `decodeURIComponent` in the routing resolution path.
## How to test
Test by navigating to a route with percent-encoded characters in the hash URL.