### PR TITLE
docs: replace Maps(hash) with navigate(hash) in router-guard API

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -31,7 +31,7 @@ const router = AvenxApp.initRouter(routes, {
 
 ### Methods
 
-- ### `Maps(hash)`
+- ### `navigate(hash)`
   Programs a programmatic navigation to the specified route hash. It updates the browser history and triggers the matching route lifecycle.
 
 ### `destroy()`


### PR DESCRIPTION
## Summary
The Router-Guard API docs listed Maps(hash), but the runtime method is navigate(hash).

Fixes #618

## Test plan
- [x] Docs now document navigate(hash)
- [x] Docs-only change