### PR TITLE
refactor(compiler): standardize style preprocessor errors

### DIFF
--- a/lib/compiler/StyleProcessor.js
+++ b/lib/compiler/StyleProcessor.js
@@ -682,7 +682,7 @@ class StyleProcessor {
         return output;
       }
     } catch (err) {
-      logger.error(`Error compiling ${type}: ${err.message}`);
+      logger.error(new StyleCompilerError(AvenxErrorCodes.COMPILER_PREPROCESSOR_FAILED, type, err.message).message);
       return cssContent;
     }
 
@@ -744,7 +744,7 @@ const VLQ_BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01
  * @returns {string}
  */
 export function encodeVLQ(value) {
-  let vlq = value < 0 ? ((-value) << 1) | 1 : value << 1;
+  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
   let encoded = '';
   do {
     let digit = vlq & 31;

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -60,6 +60,7 @@ export const AvenxErrorCodes = {
   COMPILER_STATIC_SUBTREE_OPTIMIZATION_FAILED: 'AVX_W06',
   COMPILER_PREPROCESSOR_MISSING: 'AVX_W24',
   COMPILER_INVALID_CONFIG: 'AVX_W25',
+  COMPILER_PREPROCESSOR_FAILED: 'AVX_W26',
 
   // Runtime Warnings (AVX_W*)
   PAGE_ALREADY_REGISTERED: 'AVX_W07',
@@ -113,8 +114,7 @@ export const AvenxErrorMessages = {
   [AvenxErrorCodes.SANDBOX_VIOLATION]: 'Sandbox security violation: {0}',
   [AvenxErrorCodes.STATE_DIRECT_REASSIGNMENT]:
     'Cannot reassign component state directly (e.g. "this.state = {...}"). Reassigning the entire state object replaces the reactive Proxy and breaks change detection. Mutate individual properties instead, e.g. "this.state.propertyName = value" or "Object.assign(this.state, {...})".',
-  [AvenxErrorCodes.BRIDGE_CONSTRUCTION_FAILED]:
-    'Failed to construct bridge "{0}". Constructor threw an error: {1}',
+  [AvenxErrorCodes.BRIDGE_CONSTRUCTION_FAILED]: 'Failed to construct bridge "{0}". Constructor threw an error: {1}',
 
   // Compiler Warnings (AVX_W01 - AVX_W06)
   [AvenxErrorCodes.COMPILER_BUNDLE_SIZE_EXCEEDED]: 'WARNING: {0} exceeds {1} KB ({2} KB)',
@@ -123,24 +123,28 @@ export const AvenxErrorMessages = {
   [AvenxErrorCodes.COMPILER_UNMATCHED_FOR_TAG]: 'Unmatched <@for> tags in template.',
   [AvenxErrorCodes.COMPILER_TRANSITION_PARSE_FAILED]: 'Failed to parse transition tags: {0}',
   [AvenxErrorCodes.COMPILER_STATIC_SUBTREE_OPTIMIZATION_FAILED]: 'Failed to optimize static subtrees: {0}',
-  [AvenxErrorCodes.COMPILER_PREPROCESSOR_MISSING]: 'Preprocessor module "{0}" is not installed. Falling back to raw CSS.',
+  [AvenxErrorCodes.COMPILER_PREPROCESSOR_MISSING]:
+    'Preprocessor module "{0}" is not installed. Falling back to raw CSS.',
   [AvenxErrorCodes.COMPILER_INVALID_CONFIG]: 'Failed to parse avenx.config.json at "{0}": {1}',
+  [AvenxErrorCodes.COMPILER_PREPROCESSOR_FAILED]: 'Error compiling {0}: {1}',
 
   // Runtime Warnings (AVX_W07 - AVX_W23)
   [AvenxErrorCodes.PAGE_ALREADY_REGISTERED]: 'Page "{0}" is already registered and will be overwritten.',
-  [AvenxErrorCodes.ROUTE_PATH_MISSING_LEADING_SLASH]: 'Route path "{0}" lacks a leading slash. This may prevent hash paths from resolving properly.',
+  [AvenxErrorCodes.ROUTE_PATH_MISSING_LEADING_SLASH]:
+    'Route path "{0}" lacks a leading slash. This may prevent hash paths from resolving properly.',
   [AvenxErrorCodes.ROUTE_PARAM_DECODE_FAILED]: 'Failed to decode route parameter "{0}": {1}',
   [AvenxErrorCodes.ROUTE_NOT_FOUND]: 'No route defined for hash: {0}',
   [AvenxErrorCodes.ROUTE_TITLE_EVALUATION_FAILED]: 'title() threw an error: {0}',
   [AvenxErrorCodes.PAGE_PROP_EVALUATION_FAILED]: 'Failed to evaluate prop expression: {0}. Error: {1}',
-  [AvenxErrorCodes.PAGE_COMPONENT_NOT_REGISTERED]: 'Component \'{0}\' not found in registry.',
+  [AvenxErrorCodes.PAGE_COMPONENT_NOT_REGISTERED]: "Component '{0}' not found in registry.",
   [AvenxErrorCodes.COMPONENT_RESTORE_SLOT_CONTENT_FAILED]: 'Failed to restore default slot content. Error: {0}',
   [AvenxErrorCodes.COMPONENT_INJECT_KEY_NOT_FOUND]: 'Injected key "{0}" not found in any ancestor component.',
   [AvenxErrorCodes.SECURITY_SANITIZED_TAG]: 'Sanitized tag "<{0}>" when stripping content.',
   [AvenxErrorCodes.SECURITY_SANITIZED_ATTRIBUTE]: 'Sanitized attribute "{0}" when stripping content.',
   [AvenxErrorCodes.RENDER_LIST_EVALUATION_FAILED]: 'Failed to evaluate list expression: {0}. Error: {1}',
   [AvenxErrorCodes.RENDER_KEY_EVALUATION_FAILED]: 'Failed to evaluate key expression: {0}. Error: {1}',
-  [AvenxErrorCodes.RENDER_LIST_DUPLICATE_KEY]: 'Duplicate key "{0}" detected in list expression "{1}". Appending index suffix to prevent node reuse conflict.',
+  [AvenxErrorCodes.RENDER_LIST_DUPLICATE_KEY]:
+    'Duplicate key "{0}" detected in list expression "{1}". Appending index suffix to prevent node reuse conflict.',
   [AvenxErrorCodes.DIRECTIVE_HTML_EVALUATION_FAILED]: 'Failed to evaluate data-ax-html: {0}. Error: {1}',
   [AvenxErrorCodes.DIRECTIVE_SHOW_EVALUATION_FAILED]: 'Failed to evaluate data-ax-show: {0}. Error: {1}',
   [AvenxErrorCodes.DIRECTIVE_CLASS_EVALUATION_FAILED]: 'Failed to evaluate data-ax-class: {0}. Error: {1}',

--- a/test/unit/compilerError.test.js
+++ b/test/unit/compilerError.test.js
@@ -56,6 +56,22 @@ function runTests() {
   assert.ok(configErr.message.includes('[AVX_W25]'));
   assert.ok(configErr.message.includes('avenx.config.json'));
 
+  // 6. StyleCompilerError preprocessor compilation failure (AVX_W26)
+  const preprocessErr = new StyleCompilerError(
+    AvenxErrorCodes.COMPILER_PREPROCESSOR_FAILED,
+    'sass',
+    'Unexpected token',
+  );
+
+  assert.ok(preprocessErr instanceof Error, 'StyleCompilerError should inherit from Error');
+  assert.ok(preprocessErr instanceof AvenxError, 'StyleCompilerError should inherit from AvenxError');
+  assert.ok(preprocessErr instanceof CompilerError, 'StyleCompilerError should inherit from CompilerError');
+  assert.strictEqual(preprocessErr.name, 'StyleCompilerError');
+  assert.strictEqual(preprocessErr.code, 'AVX_W26');
+  assert.ok(preprocessErr.message.includes('[AVX_W26]'));
+  assert.ok(preprocessErr.message.includes('sass'));
+  assert.ok(preprocessErr.message.includes('Unexpected token'));
+
   console.log('  ✅ Specialized compiler error classes unit tests passed!');
 }
 


### PR DESCRIPTION
## Summary

This PR standardizes the remaining compiler preprocessor error handling path in `StyleProcessor.js` by replacing the generic error log with `StyleCompilerError`.

## Changes

- Added `COMPILER_PREPROCESSOR_FAILED (AVX_W26)` to `AvenxErrorCodes`
- Added the corresponding message to `AvenxErrorMessages`
- Updated `StyleProcessor.js` to log `StyleCompilerError`
- Added a unit test for the new compiler error

## Validation

- ✅ All tests passed (65/65)