### PR TITLE
fix(cli): use standard closing tags in init templates

### DIFF
--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -133,7 +133,7 @@ export async function initProject(cli, args = []) {
           '    max-width: 800px;\n' +
           '    margin: 0 auto;\n' +
           '}\n' +
-          '</ @css>\n',
+          '</@css>\n',
       );
       console.log(`  Created: ${cli.config.srcDir}/pages/home.page.css`);
     }
@@ -161,7 +161,7 @@ export async function initProject(cli, args = []) {
           '    max-width: 800px;\n' +
           '    margin: 0 auto;\n' +
           '}\n' +
-          '</ @css>\n',
+          '</@css>\n',
       );
       console.log(`  Created: ${cli.config.srcDir}/pages/about.page.css`);
     }
@@ -186,7 +186,7 @@ export async function initProject(cli, args = []) {
           '    @def primary #6366f1;\n' +
           '    @def dark #1e1b4b;\n' +
           '    @def gray #e2e8f0;\n' +
-          '</ @global>\n\n' +
+          '</@global>\n\n' +
           '<@css>\n' +
           '    container {\n' +
           '        display: flex;\n' +
@@ -204,7 +204,7 @@ export async function initProject(cli, args = []) {
           '    link:hover {\n' +
           '        color: @primary;\n' +
           '    }\n' +
-          '</ @css>\n',
+          '</@css>\n',
       );
       console.log(`  Created: ${cli.config.srcDir}/components/navbar/navbar.component.css`);
     }

--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -615,6 +615,12 @@ async function runTest() {
     assert.ok(fs.existsSync(navbarCss), 'navbar.component.css should exist');
     assert.ok(fs.existsSync(mainAppJs), 'main.app.js should exist');
 
+    assert.match(fs.readFileSync(homePageCss, 'utf-8'), /<\/@css>/, 'home page CSS should use a standard closing tag');
+    assert.match(fs.readFileSync(aboutPageCss, 'utf-8'), /<\/@css>/, 'about page CSS should use a standard closing tag');
+    const navbarCssContent = fs.readFileSync(navbarCss, 'utf-8');
+    assert.match(navbarCssContent, /<\/@global>/, 'navbar CSS should use a standard global closing tag');
+    assert.match(navbarCssContent, /<\/@css>/, 'navbar CSS should use a standard CSS closing tag');
+
     // Verify mainAppJs contains routing layout registration
     const interactiveMainAppContent = fs.readFileSync(mainAppJs, 'utf-8');
     assert.ok(interactiveMainAppContent.includes("app.register('Navbar', Navbar)"), 'navbar component should be registered');


### PR DESCRIPTION
## What Problem This Solves

The routing layout generated by `avenx init` used non-standard closing tags with a space after `</`.

## Why This Change Was Made

The templates now emit the documented `</@css>` and `</@global>` forms, with system-test coverage for every generated CSS file.

## User Impact

Newly scaffolded projects no longer contain malformed-looking style closing tags.

## Evidence

- `npx eslint bin/commands/init.js test/system/cli.test.js`
- `npm run test:system` — 1 file passed, 0 failed
- `git diff --check`

Fixes Avenx-JS/avenx-js#635
