### PR TITLE
docs: document VirtualList index slot property

### DIFF
--- a/docs/src/content/docs/api-reference/virtuallist.md
+++ b/docs/src/content/docs/api-reference/virtuallist.md
@@ -18,14 +18,24 @@ The `<VirtualList>` component is a built-in, globally available component design
 
 ## Usage Example
 
-To pass templates into the `<VirtualList>`, use the `data-ax-as="item"` directive on your template slot:
+To pass templates into the `<VirtualList>`, use the `data-ax-as="item"` directive on your template slot.
+
+The template exposes the following variables:
+
+| Variable | Description |
+| :--- | :--- |
+| `item` | The current item being rendered. |
+| `index` | The zero-based index of the current item in the list. |
 
 ```html
 <VirtualList :item-height="50" :items="myLargeDataset">
-  <template data-ax-as="item" let:item>
+  <template data-ax-as="item" let:item let:index>
     <div class="list-item">
+      <span>#{{ index }}</span>
       <h3>{{ item.title }}</h3>
       <p>{{ item.description }}</p>
     </div>
   </template>
 </VirtualList>
+
+The `index` variable is automatically provided by `<VirtualList>` and represents the zero-based position of the current item in the rendered list.


### PR DESCRIPTION
## Summary

This PR updates the `VirtualList` API documentation to document the implicitly exposed `index` slot variable.

### Edits
- Added documentation describing the available template slot variables (`item` and `index`).
- Documented that `index` represents the zero-based index of the current item.
- Updated the usage example to demonstrate accessing and rendering the `index` value within the template.

### Why

The `VirtualList` component already exposes the `index` variable to template slots, but this behavior was not documented. This change makes the API reference more complete and helps developers discover and use the feature.