### PR TITLE
fix(sanitizer): support configured custom void tags

### DIFF
--- a/lib/core/security/sanitize.js
+++ b/lib/core/security/sanitize.js
@@ -232,6 +232,12 @@ export class Sanitizer {
     for (const [tag, attrs] of Object.entries(attributesSource)) {
       this.allowedAttributes[tag.toLowerCase()] = attrs.map((a) => a.toLowerCase());
     }
+    // Instance-specific void-element set so configured custom void tags
+    // don't mutate the module-level default.
+    this.voidElements = new Set([
+      ...VOID_ELEMENTS,
+      ...(config.voidTags ?? []).map((t) => t.toLowerCase()),
+    ]);
   }
 
   /**
@@ -288,7 +294,7 @@ export class Sanitizer {
         const tagName = child.tagName.toLowerCase();
 
         if (this.allowedTags.has(tagName)) {
-          const isVoid = VOID_ELEMENTS.has(tagName);
+          const isVoid = this.voidElements.has(tagName);
           result += `<${tagName}`;
 
           // Process attributes

--- a/test/unit/sanitize.test.js
+++ b/test/unit/sanitize.test.js
@@ -105,9 +105,53 @@ function testSanitizerFallback() {
   }
 }
 
+function testCustomVoidTags() {
+  console.log('🧪 Testing Sanitizer custom void tags...');
+  setupDOMMock();
+
+  try {
+    // 1. Default void tags still self-close correctly
+    const defaultSanitizer = new Sanitizer();
+    const brContainer = new MockDOMElement('div');
+    brContainer.appendChild(new MockDOMElement('br'));
+    assert.strictEqual(defaultSanitizer._sanitizeNode(brContainer), '<br />');
+
+    // 2. Custom void tag self-closes
+    const customSanitizer = new Sanitizer({
+      allowedTags: ['div', 'my-icon'],
+      voidTags: ['my-icon'],
+    });
+    const iconContainer = new MockDOMElement('div');
+    iconContainer.appendChild(new MockDOMElement('my-icon'));
+    assert.strictEqual(customSanitizer._sanitizeNode(iconContainer), '<my-icon />');
+
+    // 3. Mixed-case voidTags are normalized to lowercase
+    const mixedCaseSanitizer = new Sanitizer({
+      allowedTags: ['div', 'my-icon'],
+      voidTags: ['My-Icon'],
+    });
+    const mixedContainer = new MockDOMElement('div');
+    mixedContainer.appendChild(new MockDOMElement('my-icon'));
+    assert.strictEqual(mixedCaseSanitizer._sanitizeNode(mixedContainer), '<my-icon />');
+
+    // 4. No voidTags config — custom element gets closing tag (backward compat)
+    const noVoidSanitizer = new Sanitizer({
+      allowedTags: ['div', 'my-icon'],
+    });
+    const noVoidContainer = new MockDOMElement('div');
+    noVoidContainer.appendChild(new MockDOMElement('my-icon'));
+    assert.strictEqual(noVoidSanitizer._sanitizeNode(noVoidContainer), '<my-icon></my-icon>');
+
+    console.log('  ✅ Custom void tags tests passed!');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
 try {
   testSanitizerWithDOM();
   testSanitizerFallback();
+  testCustomVoidTags();
   console.log('✅ All Sanitizer tests successfully completed!');
   process.exit(0);
 } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #642.

The sanitizer previously only recognized the built-in HTML void elements,
ignoring custom `voidTags` configured through Avenx configuration.

### Changes

- Create an instance-specific void element set by combining the default HTML
  void elements with configured `voidTags`.
- Use the instance set during HTML serialization.
- Add unit tests covering:
  - built-in void elements
  - configured custom void tags
  - case normalization
  - backward compatibility

### Details

- `VOID_ELEMENTS` module-level constant is **not mutated**. Each `Sanitizer`
  instance owns its own `Set`.
- Tags are normalized to lowercase, matching existing behavior for
  `allowedTags` and `allowedAttributes`.
- No changes to the parser, compiler, config validation, or security logic.
- All 70 existing tests continue to pass. 4 new test cases added.