### PR TITLE
fix(router): warn when route guards return undefined

### DIFF
--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -20,6 +20,7 @@
  * @property {string} TEMPLATE_RENDER_ERROR - AVX_R08: Failed to interpolate expression values within component template.
  * @property {string} EVENT_HANDLER_ERROR - AVX_R09: Executing an event action callback statement failed.
  * @property {string} ROUTER_GUARD_TIMEOUT - AVX_R14: A navigation guard execution timed out.
+ * @property {string} ROUTER_GUARD_UNDEFINED_RETURN - AVX_W27: A navigation guard returned undefined.
  * @property {string} SANDBOX_VIOLATION - AVX_R15: A sandbox security violation occurred.
  * @property {string} STATE_DIRECT_REASSIGNMENT - AVX_R16: Component state was reassigned directly instead of mutated.
  * @property {string} BRIDGE_CONSTRUCTION_FAILED - AVX_R17: Failed to construct a bridge instance from a class function.
@@ -80,6 +81,7 @@ export const AvenxErrorCodes = {
   DIRECTIVE_HTML_EVALUATION_FAILED: 'AVX_W21',
   DIRECTIVE_SHOW_EVALUATION_FAILED: 'AVX_W22',
   DIRECTIVE_CLASS_EVALUATION_FAILED: 'AVX_W23',
+  ROUTER_GUARD_UNDEFINED_RETURN: 'AVX_W27',
 };
 
 /**
@@ -148,6 +150,8 @@ export const AvenxErrorMessages = {
   [AvenxErrorCodes.DIRECTIVE_HTML_EVALUATION_FAILED]: 'Failed to evaluate data-ax-html: {0}. Error: {1}',
   [AvenxErrorCodes.DIRECTIVE_SHOW_EVALUATION_FAILED]: 'Failed to evaluate data-ax-show: {0}. Error: {1}',
   [AvenxErrorCodes.DIRECTIVE_CLASS_EVALUATION_FAILED]: 'Failed to evaluate data-ax-class: {0}. Error: {1}',
+  [AvenxErrorCodes.ROUTER_GUARD_UNDEFINED_RETURN]:
+    'Navigation guard for route "{0}" returned undefined. Guards should explicitly return true, false, a redirect string, or a control object. Defaulting to allow.',
 };
 
 /**

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -124,6 +124,11 @@ export class AvenxRouter {
         Promise.race([Promise.resolve(instance.canActivate(to, from)), timeoutPromise])
           .then((result) => {
             clearTimeout(timeoutId);
+            if (result === undefined) {
+              logger.warn(formatMessage(AvenxErrorCodes.ROUTER_GUARD_UNDEFINED_RETURN, to.hash));
+              nextGuard(index + 1);
+              return;
+            }
             const isControlObject =
               typeof result === 'object' &&
               result !== null &&

--- a/test/integration/router.test.js
+++ b/test/integration/router.test.js
@@ -517,3 +517,74 @@ import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
     process.exit(1);
   }
 })();
+
+
+describe('AvenxRouter guard undefined return warning', () => {
+  it('undefined guard return should warn and still allow navigation', async () => {
+    const { AvenxApp } = await import('../../lib/core/runtime/AvenxApp.js');
+    const { AvenxGuard } = await import('../../lib/core/runtime/AvenxGuard.js');
+    const { logger } = await import('../../lib/core/runtime/AvenxLogger.js');
+    const { AvenxErrorCodes } = await import('../../lib/core/runtime/AvenxError.js');
+    const assert = await import('node:assert');
+
+    const warnings = [];
+    const originalWarn = logger.warn.bind(logger);
+    logger.warn = (...args) => {
+      warnings.push(args.join(' '));
+      return originalWarn(...args);
+    };
+
+    try {
+      document.body.innerHTML = '<div id="app"></div>';
+      class TestPage {
+        mount() {}
+        unmount() {}
+      }
+      const app = new AvenxApp({ target: '#app' });
+      app.registerPage('TestPage', TestPage);
+
+      class UndefinedGuard extends AvenxGuard {
+        canActivate() {
+          // intentionally no return
+        }
+      }
+      class AllowGuard extends AvenxGuard {
+        canActivate() {
+          return true;
+        }
+      }
+
+      app.initRouter({
+        '': 'TestPage',
+        '#/': 'TestPage',
+        '#/secure': {
+          page: 'TestPage',
+          guards: [UndefinedGuard],
+        },
+        '#/ok': {
+          page: 'TestPage',
+          guards: [AllowGuard],
+        },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      warnings.length = 0;
+      window.location.hash = '#/secure';
+      await new Promise((r) => setTimeout(r, 20));
+      assert.ok(
+        warnings.some((w) => w.includes(AvenxErrorCodes.ROUTER_GUARD_UNDEFINED_RETURN)),
+        'expected AVX_W27 warning for undefined guard return',
+      );
+
+      warnings.length = 0;
+      window.location.hash = '#/ok';
+      await new Promise((r) => setTimeout(r, 20));
+      assert.ok(
+        !warnings.some((w) => w.includes(AvenxErrorCodes.ROUTER_GUARD_UNDEFINED_RETURN)),
+        'explicit true should not warn',
+      );
+    } finally {
+      logger.warn = originalWarn;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
When a route guard's `canActivate` returns `undefined` (or a Promise that resolves to `undefined`), the router now logs `AVX_W27` via `logger.warn` and continues to allow navigation (least-breaking default). Explicit `true` / `false` / redirect strings / control objects are unchanged and do not warn.

Fixes #639

## Test plan
- [ ] Integration test: undefined return triggers warning; `return true` does not
- [ ] Existing guard allow/deny/redirect cases still pass