### PR TITLE
fix(compiler): warn when multiple <state> tags are present

### DIFF
--- a/lib/compiler/expressionParser.js
+++ b/lib/compiler/expressionParser.js
@@ -1,3 +1,6 @@
+import { logger } from '../core/runtime/AvenxLogger.js';
+import { AvenxErrorCodes } from '../core/runtime/AvenxError.js';
+import { TemplateValidationError } from './errors/TemplateValidationError.js';
 /**
  * ExpressionParser is responsible for extracting state, computed properties,
  * and methods from Avenx component source code.
@@ -10,6 +13,12 @@ class ExpressionParser {
    */
   parseState(content) {
     const state = {};
+    const stateTags = content.match(/<state\s+[\s\S]*?\s*\/>/g) || [];
+    if (stateTags.length > 1) {
+      logger.warn(
+        new TemplateValidationError(AvenxErrorCodes.COMPILER_MULTIPLE_STATE_TAGS).message,
+      );
+    }
     const match = content.match(/<state\s+([\s\S]*?)\s*\/>/);
     if (match) {
       const attrRegex = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -21,6 +21,7 @@
  * @property {string} EVENT_HANDLER_ERROR - AVX_R09: Executing an event action callback statement failed.
  * @property {string} ROUTER_GUARD_TIMEOUT - AVX_R14: A navigation guard execution timed out.
  * @property {string} ROUTER_GUARD_UNDEFINED_RETURN - AVX_W27: A navigation guard returned undefined.
+ * @property {string} COMPILER_MULTIPLE_STATE_TAGS - AVX_W28: Multiple <state> tags; only the first is used.
  * @property {string} SANDBOX_VIOLATION - AVX_R15: A sandbox security violation occurred.
  * @property {string} STATE_DIRECT_REASSIGNMENT - AVX_R16: Component state was reassigned directly instead of mutated.
  * @property {string} BRIDGE_CONSTRUCTION_FAILED - AVX_R17: Failed to construct a bridge instance from a class function.
@@ -82,6 +83,7 @@ export const AvenxErrorCodes = {
   DIRECTIVE_SHOW_EVALUATION_FAILED: 'AVX_W22',
   DIRECTIVE_CLASS_EVALUATION_FAILED: 'AVX_W23',
   ROUTER_GUARD_UNDEFINED_RETURN: 'AVX_W27',
+  COMPILER_MULTIPLE_STATE_TAGS: 'AVX_W28',
 };
 
 /**
@@ -152,6 +154,8 @@ export const AvenxErrorMessages = {
   [AvenxErrorCodes.DIRECTIVE_CLASS_EVALUATION_FAILED]: 'Failed to evaluate data-ax-class: {0}. Error: {1}',
   [AvenxErrorCodes.ROUTER_GUARD_UNDEFINED_RETURN]:
     'Navigation guard for route "{0}" returned undefined. Guards should explicitly return true, false, a redirect string, or a control object. Defaulting to allow.',
+  [AvenxErrorCodes.COMPILER_MULTIPLE_STATE_TAGS]:
+    'Multiple <state> tags found in component source. Only the first <state> declaration is reactive; subsequent tags are ignored.',
 };
 
 /**

--- a/test/unit/expression_parser.test.js
+++ b/test/unit/expression_parser.test.js
@@ -1,5 +1,7 @@
 import assert from 'assert';
 import ExpressionParser from '../../lib/compiler/expressionParser.js';
+import { logger } from '../../lib/core/runtime/AvenxLogger.js';
+import { AvenxErrorCodes } from '../../lib/core/runtime/AvenxError.js';
 
 try {
   console.log('🧪 Testing ExpressionParser upgrades...');
@@ -117,6 +119,30 @@ try {
   );
   assert.strictEqual(complexMethods.postData, "console.log('posting');");
   assert.strictEqual(complexMethods.multiLineAttrs, 'return 42;');
+
+
+  // Multiple <state> tags: warn (AVX_W28) and only parse the first
+  {
+    const warnings = [];
+    const originalWarn = logger.warn;
+    logger.warn = (msg) => warnings.push(String(msg));
+    try {
+      const multiState = `
+        <state a="1" label="first" />
+        <state b="2" label="second" />
+      `;
+      const multi = ep.parseState(multiState);
+      assert.strictEqual(multi.a, 1);
+      assert.strictEqual(multi.label, 'first');
+      assert.strictEqual(multi.b, undefined);
+      assert.ok(
+        warnings.some((w) => w.includes(AvenxErrorCodes.COMPILER_MULTIPLE_STATE_TAGS)),
+        'expected AVX_W28 warning for multiple <state> tags',
+      );
+    } finally {
+      logger.warn = originalWarn;
+    }
+  }
 
   console.log('  ✅ ExpressionParser upgrades tests passed!');
 } catch (error) {


### PR DESCRIPTION
## Summary
`ExpressionParser.parseState` only ever registers the first `<state … />` tag. Additional tags were ignored with no signal.

This adds `AVX_W28` (`COMPILER_MULTIPLE_STATE_TAGS`) and logs it via `logger.warn` when more than one `<state>` tag is present. Parsing behavior for the first tag is unchanged.

Fixes #638

## Test plan
- [ ] `test/unit/expression_parser.test.js` — multiple tags warn and only first attrs are returned
- [ ] Single `<state>` components produce no new warning