### PR TITLE
Docs: Document data-ax-show Directive and Transition Hooks Integration (#648)docs: document data-ax-show directive and transition hooks integratio…

### DIFF
--- a/docs/src/content/docs/core-concepts/templates.md
+++ b/docs/src/content/docs/core-concepts/templates.md
@@ -54,9 +54,7 @@ If the expression evaluates to a falsy value, the attribute is removed and the D
 ### Example
 
 ```html
-<button disabled="{{ state.isSubmitting }}">
-  Submit
-</button>
+<button disabled="{{ state.isSubmitting }}">Submit</button>
 ```
 
 When `state.isSubmitting` is `true`, the button is rendered as disabled.
@@ -93,30 +91,19 @@ Avenx-JS automatically handles the following standard HTML boolean attributes:
 Checkbox:
 
 ```html
-<input
-  type="checkbox"
-  checked="{{ state.accepted }}"
-/>
+<input type="checkbox" checked="{{ state.accepted }}" />
 ```
 
 Input field:
 
 ```html
-<input
-  type="text"
-  required="{{ state.requireName }}"
-  readonly="{{ state.readOnly }}"
-/>
+<input type="text" required="{{ state.requireName }}" readonly="{{ state.readOnly }}" />
 ```
 
 Media element:
 
 ```html
-<video
-  controls="{{ state.showControls }}"
-  autoplay="{{ state.autoPlay }}"
-  muted="{{ state.muted }}">
-</video>
+<video controls="{{ state.showControls }}" autoplay="{{ state.autoPlay }}" muted="{{ state.muted }}"></video>
 ```
 
 Details element:
@@ -129,16 +116,60 @@ Details element:
 ```
 
 Bind boolean attributes to expressions that evaluate to `true` or `false`. Avenx-JS automatically adds or removes the attribute and updates the corresponding DOM property.
-## 4. Reactive Style Bindings (`data-ax-style`)
+
+## 4. Conditional Visibility (`data-ax-show`)
+
+The `data-ax-show` directive reactively toggles the visibility of an element by modifying its inline CSS `display` property based on the evaluated expression.
+
+### Basic Usage
+
+```html
+<div data-ax-show="state.isVisible">This content is conditionally visible.</div>
+```
+
+When `state.isVisible` evaluates to a truthy value, the element is visible. When it evaluates to a falsy value, the element is hidden using `display: none`.
+
+### How It Works & State Conservation
+
+Unlike simple directives that hardcode `display: block` or remove the element from the DOM entirely, `data-ax-show` carefully conserves your layout styling:
+
+1. **Boolean Conversion**: The directive evaluates the expression and converts the result to a strict boolean (equivalent to `!!value`).
+2. **Conserving Original Display**: On initialization, before any styles are modified, Avenx-JS saves the element's original CSS `display` property (such as `flex`, `grid`, `inline-block`, or default `""`) to an internal property (`__originalDisplay`) on the DOM element.
+3. **Restoring Visibility**:
+   - When switching to **true** (visible), the element's `style.display` is restored to its conserved `__originalDisplay` value.
+   - When switching to **false** (hidden), `style.display` is set to `'none'`.
+
+### Example with Flexbox and Grid Layouts
+
+Because `__originalDisplay` is conserved, toggling visibility will never break custom layout containers:
+
+```html
+<!-- The inline 'display: flex' is saved to __originalDisplay on init -->
+<div style="display: flex; gap: 10px;" data-ax-show="state.showToolbar">
+  <button>Action 1</button>
+  <button>Action 2</button>
+</div>
+```
+
+When `state.showToolbar` becomes `true`, the element correctly reverts to `display: flex` instead of defaulting to `block`.
+
+### Integration with Transitions
+
+`data-ax-show` integrates seamlessly with Avenx-JS's animation lifecycle when combined with `<transition>` wrappers or `data-ax-transition` attributes:
+
+- **Enter Transitions**: When switching from `false` to `true`, `display` is restored to `__originalDisplay` immediately, and the compiler triggers the `-enter`, `-enter-active`, and `-enter-to` CSS class sequence.
+- **Leave Transitions**: When switching from `true` to `false`, the element is **not** hidden immediately. Instead, the `-leave`, `-leave-active`, and `-leave-to` CSS classes are applied. An exit callback waits for the CSS transition or animation to finish before finally setting `style.display = 'none'`.
+
+For a complete guide and code examples on animating visibility toggles, see the [Transition Animations](./transitions.md#conditional-rendering-transitions) documentation.
+
+## 5. Reactive Style Bindings (`data-ax-style`)
 
 Use the `data-ax-style` directive to dynamically apply inline CSS styles using a JavaScript object.
 
 ### Basic Usage
 
 ```html
-<p data-ax-style="{{ { color: state.textColor } }}">
-  Dynamic text color
-</p>
+<p data-ax-style="{{ { color: state.textColor } }}">Dynamic text color</p>
 ```
 
 When `state.textColor` changes, the element's `color` style is updated automatically.
@@ -172,7 +203,7 @@ When `state.textColor` changes, the element's `color` style is updated automatic
 
 Using object syntax keeps templates more readable and maintainable than manually constructing inline style strings.
 
-## 4. Loops (`<@for>`)
+## 6. Loops (`<@for>`)
 
 Render arrays using the custom `<@for>` loop tag. Loop blocks are translated to `<template>` tags and managed via the `ListManager` for efficient DOM list updates:
 
@@ -182,7 +213,6 @@ Render arrays using the custom `<@for>` loop tag. Loop blocks are translated to 
 </@for>
 ```
 
-## 5. Slots & Transclusion
 ### The implicit `index` variable
 
 In addition to your item variable, every `<@for>` loop automatically injects a zero-indexed `index` variable into the template scope. You don't need to declare it — `ListManager` adds it for you on each iteration — so it's available anywhere inside the loop body, for example to number items or apply alternating styles:
@@ -198,7 +228,7 @@ In addition to your item variable, every `<@for>` loop automatically injects a z
 
 > **Note:** `index` starts at `0`. Add `1` (as shown above) if you want a human-readable, 1-based count.
 
-## 4. Slots & Transclusion
+## 7. Slots & Transclusion
 
 Components can receive child HTML blocks using `<slot>` elements. Both default and named slots are fully supported.
 
@@ -229,8 +259,7 @@ Components can receive child HTML blocks using `<slot>` elements. Both default a
 
 If a component's caller does not provide content for a given slot, Avenx-JS automatically falls back to rendering the default content defined inside that `<slot>` element in the component's template. This applies to both named and default slots. For example, in the `Card` component above, if no `slot="header"` element is passed in, the header slot will render its fallback text, `Default Header`, instead of being left empty. This makes it easy to define sensible defaults for optional component content without requiring the caller to always supply every slot.
 
-## 6. SVG Support
-## 5. Passing Props to Child Components (`data-props-*`)
+## 8. Passing Props to Child Components (`data-props-*`)
 
 Custom child components can receive props from a parent page or component using the `data-props-<propName>` attribute syntax. The parser evaluates the attribute's value as an expression in the parent's scope and passes the resulting value into the child component as a prop.
 
@@ -253,7 +282,7 @@ Here, `data-props-user` passes the value of `state.currentUser` from the parent 
 <MyProfile data-props-user="state.currentUser" data-props-isAdmin="state.isAdmin" />
 ```
 
-## 6. SVG Support
+## 9. SVG Support
 
 Avenx-JS natively supports rendering SVG elements inside templates. During template cloning and patching, the framework automatically preserves the correct SVG namespace (`http://www.w3.org/2000/svg`), ensuring that SVG graphics render correctly in the browser.
 This includes nested SVG elements such as `<rect>`, `<circle>`, `<path>`, and other SVG-specific tags. Even when templates are parsed using `DOMParser`, Avenx-JS automatically transitions SVG elements into the correct namespace during patching and cloning, so no additional configuration or manual namespace handling is required.

--- a/docs/src/content/docs/core-concepts/transitions.md
+++ b/docs/src/content/docs/core-concepts/transitions.md
@@ -159,23 +159,78 @@ A basic fade transition that changes opacity over 300 ms:
 
 ## Conditional Rendering Transitions
 
-The `<transition>` tag works transparently with `data-ax-show`. When the bound expression toggles, the element passes through the enter or leave class sequence instead of appearing or disappearing instantly.
+The `<transition>` tag (or the `data-ax-transition` attribute) works transparently with the `data-ax-show` visibility directive. When the bound expression toggles between truthy and falsy values, the element smoothly passes through the enter or leave class sequence instead of appearing or disappearing instantly.
+
+### How Visibility Toggles Integrate with Transitions
+
+When an element with `data-ax-show` is animated using a named transition:
+
+1. **Boolean Evaluation**: The expression is evaluated as a boolean (`!!value`).
+2. **State Conservation**: On initialization, the element's original inline display style (e.g., `flex`, `grid`, `block`, or empty string `""`) is conserved in `__originalDisplay`.
+3. **Switching from `false` to `true` (Enter Transition)**:
+   - The element's CSS `display` style is immediately restored to its conserved `__originalDisplay` value.
+   - The enter transition classes (`<name>-enter`, `<name>-enter-active`) are applied synchronously, followed by `<name>-enter-to` on the next animation frame.
+4. **Switching from `true` to `false` (Leave Transition)**:
+   - The element is **not** hidden immediately. Its `display` style remains active so the animation is visible.
+   - The leave transition classes (`<name>-leave`, `<name>-leave-active`, `<name>-leave-to`) are applied.
+   - A runtime exit callback waits for the CSS transition or animation to complete (listening to `transitionend`/`animationend` or fallback duration timeout). Once completed, the callback executes and sets `style.display = 'none'` on the element.
+
+### Complete Visual Example
+
+Here is a complete component example coupling a reactive visibility toggle with a CSS fade-and-scale transition:
 
 ```html
-<transition name="fade">
-  <div data-ax-show="state.isVisible">Toggle Me</div>
-</transition>
+<style>
+  /* Define transition animations */
+  .pop-enter-active,
+  .pop-leave-active {
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .pop-enter,
+  .pop-leave-to {
+    opacity: 0;
+    transform: scale(0.9) translateY(-10px);
+  }
+
+  .pop-enter-to,
+  .pop-leave {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+
+  /* Custom flex container whose display state is conserved in __originalDisplay */
+  .notification-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    background-color: #1e293b;
+    color: #f8fafc;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  }
+</style>
+
+<div class="app-container">
+  <button @click="state.showNotification = !state.showNotification">Toggle Notification</button>
+
+  <!-- Wrapping with <transition> tag -->
+  <transition name="pop">
+    <div class="notification-card" data-ax-show="state.showNotification">
+      <span>🚀 Your changes have been successfully saved!</span>
+      <button @click="state.showNotification = false">✕</button>
+    </div>
+  </transition>
+</div>
 ```
 
-When `state.isVisible` becomes `false`:
+In this example:
 
-1. Leave classes are applied
-2. After the transition completes, `display: none` is set on the element
-
-When `state.isVisible` becomes `true`:
-
-1. `display` is restored
-2. Enter classes are applied
+- When `state.showNotification` is set to `true`, the card's `display` reverts to `flex` (restored from `__originalDisplay`) and scales/fades in using the `.pop-enter*` classes.
+- When `state.showNotification` is set to `false`, the `.pop-leave*` classes scale and fade the card out while it remains in `display: flex`. Only after the 300ms transition finishes does the runtime exit callback apply `display: none`.
 
 ---
 
@@ -208,11 +263,12 @@ const router = new AvenxRouter(app, {
 
 ## Summary
 
-| Concept          | Behaviour                                                                                          |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| Default name     | `ax` when `name` is omitted                                                                        |
-| Dynamic name     | `name="{{ expr }}"` for runtime resolution                                                         |
-| Runtime fallback | Any `<transition>` elements surviving compile time are flattened by `DomPatcher`                   |
-| Cleanup trigger  | `transitionend` / `animationend` events or computed duration + 50 ms timeout                       |
-| Class sequence   | `-enter` → `-enter-active` → `-enter-to` (enter); `-leave` → `-leave-active` → `-leave-to` (leave) |
-| Rapid toggle     | In-progress transitions are cancelled immediately via `_cleanupTransition`                         |
+| Concept          | Behaviour                                                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Default name     | `ax` when `name` is omitted                                                                                            |
+| Dynamic name     | `name="{{ expr }}"` for runtime resolution                                                                             |
+| Runtime fallback | Any `<transition>` elements surviving compile time are flattened by `DomPatcher`                                       |
+| Cleanup trigger  | `transitionend` / `animationend` events or computed duration + 50 ms timeout                                           |
+| Class sequence   | `-enter` → `-enter-active` → `-enter-to` (enter); `-leave` → `-leave-active` → `-leave-to` (leave)                     |
+| Rapid toggle     | In-progress transitions are cancelled immediately via `_cleanupTransition`                                             |
+| Visibility hooks | Works with `data-ax-show`; restores `__originalDisplay` on enter, defers `display: none` until leave callback finishes |


### PR DESCRIPTION
…n (#648)
## Description
This PR resolves #648 by adding comprehensive documentation for the `data-ax-show` directive and its integration with transition hooks in the core concepts reference guides.

## Changes Made
1. **`docs/src/content/docs/core-concepts/templates.md`**:
   - Added a dedicated section: **`## 4. Conditional Visibility (data-ax-show)`**.
   - Explained how expression values are evaluated and converted to booleans (`!!value`).
   - Detailed how the original CSS display state (`flex`, `grid`, `inline-block`, etc.) is saved to `__originalDisplay` on initialization and restored when elements toggle back to visible.
   - Cleaned up and fixed the sequential numbering of subsequent sections and subsections (removing duplicate/stray headers).

2. **`docs/src/content/docs/core-concepts/transitions.md`**:
   - Expanded the **`## Conditional Rendering Transitions`** section with detailed lifecycle integration steps.
   - Detailed how switching from `false` to `true` restores `__originalDisplay` immediately while triggering entry transition classes (`-enter`, `-enter-active`, `-enter-to`).
   - Detailed how switching from `true` to `false` defers setting `display: none` until after the exit animation callback finishes.
   - Added a complete visual example coupling a visibility toggle (`data-ax-show`) with a CSS scale-and-fade animation inside a `<transition>` wrapper.
   - Updated the summary table to include visibility hooks behavior.

## Acceptance Criteria Met
- [x] A dedicated section details `data-ax-show` functionality in core-concepts.
- [x] The documentation explains how the original CSS display state is conserved.
- [x] A complete example shows how to configure a component to transition elements using `data-ax-show` alongside entry/leave animations.
- [x] All unit, integration, and system tests pass (`70/70`).
- [x] Markdown formatting verified via Prettier.