### PR TITLE
feat: implement dynamic dependency pruning in watcher 

### DIFF
--- a/lib/core/reactive/watcher.js
+++ b/lib/core/reactive/watcher.js
@@ -178,12 +178,19 @@ export class AvenxWatcher {
    */
   get() {
     pushWatcher(this);
+    const oldDeps = this.deps;
+    this.deps = new Set();
+
     try {
       const value = this.getter();
       if (this.options.deep) {
         traverse(value);
       }
+      this.cleanupDeps(oldDeps);
       return value;
+    } catch (err) {
+      this.deps = oldDeps;
+      throw err;
     } finally {
       popWatcher();
     }
@@ -208,7 +215,28 @@ export class AvenxWatcher {
    * @param {Set<AvenxWatcher>} watchersSet - Set mapping to this dependency.
    */
   addDep(target, key, watchersSet) {
+    for (const dep of this.deps) {
+      if (dep.watchersSet === watchersSet) {
+        return;
+      }
+    }
     this.deps.add({ target, key, watchersSet });
+  }
+
+  /**
+   * Compares active dependencies against old dependencies and unsubscribes from stale dependencies.
+   * @param {Set<{target: object, key: string, watchersSet: Set<AvenxWatcher>}>} oldDeps
+   */
+  cleanupDeps(oldDeps) {
+    const activeWatcherSets = new Set();
+    for (const dep of this.deps) {
+      activeWatcherSets.add(dep.watchersSet);
+    }
+    for (const oldDep of oldDeps) {
+      if (!activeWatcherSets.has(oldDep.watchersSet)) {
+        oldDep.watchersSet.delete(this);
+      }
+    }
   }
 
   /**

--- a/test/unit/watcher.test.js
+++ b/test/unit/watcher.test.js
@@ -277,6 +277,70 @@ function testFunctionBasedComputedProperty() {
   console.log('  ✅ Function-based computed property is reactive!');
 }
 
+/**
+ * Tests dynamic dependency pruning during conditional branch changes.
+ */
+function testDynamicDependencyPruning() {
+  console.log('🧪 Testing AvenxWatcher dynamic dependency pruning...');
+
+  const state = new StateFactory().create({
+    cond: true,
+    a: 10,
+    b: 20,
+  });
+
+  let callbackCount = 0;
+  let evaluatedValue = null;
+
+  const watcher = new AvenxWatcher(
+    () => (state.cond ? state.a : state.b),
+    (newVal) => {
+      callbackCount++;
+      evaluatedValue = newVal;
+    },
+  );
+
+  assert.strictEqual(watcher.value, 10);
+
+  // Updating active dependency 'a' while cond=true
+  state.a = 15;
+  assert.strictEqual(watcher.value, 15);
+  assert.strictEqual(callbackCount, 1);
+  assert.strictEqual(evaluatedValue, 15);
+
+  // Updating inactive dependency 'b' should NOT trigger callback
+  state.b = 25;
+  assert.strictEqual(callbackCount, 1);
+
+  // Switch condition branch to false (now accesses 'b')
+  state.cond = false;
+  assert.strictEqual(watcher.value, 25);
+  assert.strictEqual(callbackCount, 2);
+  assert.strictEqual(evaluatedValue, 25);
+
+  // 'a' is now a stale dependency: mutating 'a' should NOT trigger callback
+  state.a = 100;
+  assert.strictEqual(callbackCount, 2);
+
+  // Mutating 'b' SHOULD trigger callback
+  state.b = 50;
+  assert.strictEqual(watcher.value, 50);
+  assert.strictEqual(callbackCount, 3);
+  assert.strictEqual(evaluatedValue, 50);
+
+  // Switch condition branch back to true (now accesses 'a')
+  state.cond = true;
+  assert.strictEqual(watcher.value, 100);
+  assert.strictEqual(callbackCount, 4);
+  assert.strictEqual(evaluatedValue, 100);
+
+  // 'b' is now stale again
+  state.b = 999;
+  assert.strictEqual(callbackCount, 4);
+
+  console.log('  ✅ Dynamic dependency pruning tests passed!');
+}
+
 async function runTests() {
   try {
     testBasicWatcher();
@@ -284,6 +348,7 @@ async function runTests() {
     testWatcherTeardown();
     testComponentWatchAPI();
     testFunctionBasedComputedProperty();
+    testDynamicDependencyPruning();
     await testBridgeTargetedUpdates();
     console.log('✅ All AvenxWatcher tests passed successfully!');
   } catch (error) {


### PR DESCRIPTION
Fixes [#636](https://github.com/Avenx-JS/avenx-js/issues/636) 

## Prune Unused Dependencies in AvenxWatcher

### Problem
A watcher keeps old dependencies after conditional code evaluates. When an unused dependency changes value, the watcher re-evaluates. This causes low performance and memory leaks.

### Solution
Update the `AvenxWatcher` class in `lib/core/reactive/watcher.js`:
1. Save the list of active dependencies before the getter function runs.
2. Collect new dependencies into a new set during evaluation.
3. Compare the new set against the old dependencies after evaluation.
4. Remove the watcher from dependencies that are no longer used.
5. Add a unit test in `test/unit/watcher.test.js` to verify dependency removal.

### Verification
- Run `node test/unit/watcher.test.js` to verify watcher behavior.
- Run `npm test` to run all unit tests. All 70 test suites pass successfully.