### PR TITLE
docs(logging): document AvenxLogger, AvenxApp logging option, and clarify config scope

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -15,6 +15,23 @@ const app = new AvenxApp({ target: '#app' });
 | --------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `config.target` | `string` | A valid DOM selector (e.g., `'#app'`) pointing to the root element. Throws exception `[AVX_R01]` if not found. |
 | `config.keepAliveLimit` | `number` | Maximum number of inactive keep-alive page instances stored in the internal LRU cache. When the limit is exceeded, the least recently used cached page is removed. Default: `5`. |
+| `config.logging` | `object` | Configuration applied to the shared runtime `logger` on startup. Accepts the same options as `AvenxLogger` (`level`, `silent`, `formatter`, `transports`). See [AvenxLogger](/api-reference/utils/#avenxlogger). |
+
+### `logging`
+
+Pass a `logging` object to configure the shared `logger` instance that `AvenxApp`, components, and your own application code use. This is separate from the `logging` option in `avenx.config.json`, which only affects the CLI's build-time output — see [Logging Options](/getting-started/configuration/#logging-options).
+
+```javascript
+const app = new AvenxApp({
+  target: '#app',
+  logging: {
+    level: 'debug',
+    silent: false,
+  },
+});
+```
+
+If omitted, the shared logger keeps its default configuration (`level: 'info'`, `silent: false`).
 
 ### `keepAliveLimit`
 The `keepAliveLimit` option controls how many inactive pages configured with `keepAlive: true` can remain cached in memory.

--- a/docs/src/content/docs/api-reference/utils.md
+++ b/docs/src/content/docs/api-reference/utils.md
@@ -420,6 +420,17 @@ logger.warn("Cache miss.");
 logger.error("Failed to load configuration.");
 ```
 
+This is the same instance that `AvenxApp` configures when you pass a `logging` option to its constructor, so `logger.configure()` calls and the `logging` option affect the same shared state:
+
+```js
+const app = new AvenxApp({
+  target: "#app",
+  logging: { level: "debug" },
+});
+```
+
+Note that this is unrelated to the `logging` option in `avenx.config.json`, which only controls the CLI's own build-time output, not this runtime logger.
+
 ---
 
 ## Creating a Custom Logger
@@ -454,6 +465,8 @@ logger.trace("Verbose logging is now enabled.");
 
 You can update one or more configuration options at any time using `configure()`.
 
+If `level` is set to a value that isn't one of the supported log levels, `configure()` logs a warning and falls back to `"info"`.
+
 ---
 
 ## Custom Formatter
@@ -474,6 +487,8 @@ const logger = new AvenxLogger({
 ---
 
 ## Custom Transport
+
+By default, `AvenxLogger` uses `consoleTransport`, which dispatches each level to a `console` method: `fatal` logs via `console.error`, `trace` logs via `console.debug`, and every other level logs via the matching `console` method (e.g. `info` → `console.info`), falling back to `console.log` if no matching method exists.
 
 Custom transports allow log messages to be forwarded to destinations other than the browser console.
 

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -122,7 +122,9 @@ To analyze Avenx-JS performance timings:
 
 ## Logging Options
 
-Avenx-JS includes a configurable logging system that can be customized globally through the `logging` section in `avenx.config.json`.
+Avenx-JS includes a configurable logging system that can be customized through the `logging` section in `avenx.config.json`.
+
+This setting only controls the **CLI's build-time output** — the messages printed to your terminal while running commands like `avenx build` or `avenx dev`. It has no effect on logging inside your compiled application (the `logger` calls that run in the browser). To configure logging for your running app, pass a `logging` option to the `AvenxApp` constructor, or use the `AvenxLogger` class directly — see [AvenxLogger](/api-reference/utils/#avenxlogger) in the API reference.
 
 ### Configuration
 


### PR DESCRIPTION
## What this does
- Documents the `AvenxLogger` class and the shared `logger` export in `api-reference/utils.md`
- Adds the previously-undocumented `logging` option on the `AvenxApp` constructor in `api-reference/app.md`
- Clarifies that `avenx.config.json`'s `logging` option only controls the CLI's build-time output, and is separate from the runtime `logger` used inside the compiled app — these two were previously conflated in the docs

## Acceptance criteria
- [x] Add a "Logging Options" section under `getting-started/configuration.md`
- [x] Document `AvenxLogger` and the global `logger` export in `api-reference/utils.md`
- [x] Provide code snippets demonstrating programmatic log level overrides and configurations

Docs-only change, no code touched.

Closes #384