### PR TITLE
feat(cli): add default prettier config to init

### DIFF
--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -246,4 +246,15 @@ export async function initProject(cli, args = []) {
   if (isInteractive) {
     process.stdin.pause();
   }
+
+  // Create initial .prettierrc
+  const prettierPath = path.join(cli.baseDir, '.prettierrc');
+
+  if (!fs.existsSync(prettierPath)) {
+    const template = readTemplate(cli.baseDir, cli.config, cli.frameworkDir, 'init', '.prettierrc');
+
+    fs.writeFileSync(prettierPath, template);
+
+    console.log('  Created: .prettierrc');
+  }
 }

--- a/templates/init/.prettierrc
+++ b/templates/init/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 120
+}


### PR DESCRIPTION
## Summary

This PR adds a default `.prettierrc` file when initializing a new Avenx project. #561 

### Changes

- Generate a `.prettierrc` during `avenx init` if one does not already exist.
- Uses the project's default formatting configuration.

### Why

Providing a default Prettier configuration gives new projects a consistent formatting setup out of the box and improves the developer experience.

### Testing

- Ran `node bin/avenx.js init` inside the repository.
- Ran `node ../avenx-js/bin/avenx.js init` in a fresh directory.
- Verified that `.prettierrc` is created only when it does not already exist.