### PR TITLE
feat: support keyboard system modifiers

### DIFF
--- a/lib/core/events/bindEvents.js
+++ b/lib/core/events/bindEvents.js
@@ -306,7 +306,21 @@ export class EventBinder {
       executedSet.add(attrName);
     }
 
-    // 2. Check key modifiers for keyboard events
+    // 2. Check system key modifiers
+    const SYSTEM_MODIFIER_MAP = {
+      ctrl: 'ctrlKey',
+      alt: 'altKey',
+      shift: 'shiftKey',
+      meta: 'metaKey',
+      cmd: 'metaKey',
+    };
+
+    const systemModifiers = modifiers.filter(m => Object.prototype.hasOwnProperty.call(SYSTEM_MODIFIER_MAP, m));
+    if (systemModifiers.some(mod => !event || event[SYSTEM_MODIFIER_MAP[mod]] !== true)) {
+      return;
+    }
+
+    // 3. Check key modifiers for keyboard events
     const KEY_MODIFIER_MAP = {
       enter: 'Enter',
       esc: 'Escape',
@@ -327,7 +341,7 @@ export class EventBinder {
       }
     }
 
-    // 3. Apply prevent & stop modifiers
+    // 4. Apply prevent & stop modifiers
     if (modifiers.includes('prevent') && event && typeof event.preventDefault === 'function') {
       event.preventDefault();
     }

--- a/test/unit/eventModifiers.test.js
+++ b/test/unit/eventModifiers.test.js
@@ -232,6 +232,39 @@ try {
   escEl.trigger('keydown', { type: 'keydown', key: 'Escape' });
   assert.strictEqual(executedSource, 'handleEsc', 'Pressing Escape should run esc handler');
 
+  // 12. Test keyboard system modifiers
+  for (const [modifier, eventProperty] of [
+    ['ctrl', 'ctrlKey'],
+    ['alt', 'altKey'],
+    ['shift', 'shiftKey'],
+    ['meta', 'metaKey'],
+    ['cmd', 'metaKey'],
+  ]) {
+    const systemEl = createMockElement('BUTTON', { [`@click.${modifier}`]: `handle${modifier}` });
+    binder.bind(systemEl, dispatcher);
+    resetDispatcher();
+
+    systemEl.trigger('click', { type: 'click', [eventProperty]: false });
+    assert.strictEqual(executedSource, null, `.${modifier} should reject events without the modifier`);
+
+    systemEl.trigger('click', { type: 'click', [eventProperty]: true });
+    assert.strictEqual(executedSource, `handle${modifier}`, `.${modifier} should accept matching events`);
+  }
+
+  // 13. Test a system modifier chained with a key modifier
+  const shiftEnterEl = createMockElement('INPUT', { '@keydown.shift.enter': 'handleShiftEnter' });
+  binder.bind(shiftEnterEl, dispatcher);
+  resetDispatcher();
+
+  shiftEnterEl.trigger('keydown', { type: 'keydown', key: 'Enter', shiftKey: false });
+  assert.strictEqual(executedSource, null, 'Shift+Enter should require Shift');
+
+  shiftEnterEl.trigger('keydown', { type: 'keydown', key: 'Escape', shiftKey: true });
+  assert.strictEqual(executedSource, null, 'Shift+Enter should require Enter');
+
+  shiftEnterEl.trigger('keydown', { type: 'keydown', key: 'Enter', shiftKey: true });
+  assert.strictEqual(executedSource, 'handleShiftEnter', 'Shift+Enter should run the handler');
+
   // 7. Test compilation of modifier attributes in ComponentParser
   const sp = new StyleProcessor();
   const cp = new ComponentParser(sp);


### PR DESCRIPTION
## Change

- add `.ctrl`, `.alt`, `.shift`, `.meta`, and `.cmd` system-key modifiers
- require every requested system modifier before dispatching the handler
- cover positive and negative cases for each modifier
- cover a chained `@keydown.shift.enter` handler

## Why

EventBinder already filters named keys such as `.enter`, but it had no way to
express common keyboard shortcuts. Mapping modifiers to the standard event
flags keeps this logic local to the existing modifier pipeline and allows
system and named-key filters to compose.

## Checks

- `node test/unit/eventModifiers.test.js`
- `npm run lint -- --quiet`
- `npm test`: 69/71 test files passed; the two unrelated failures require
  writing user-level files outside the repository sandbox

Fixes #637
