### PR TITLE
fix(runtime): identify duplicate component registrations

### DIFF
--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -131,6 +131,9 @@ export class AvenxApp {
    * @param {typeof AvenxComponent} compClass - The component class.
    */
   register(name, compClass) {
+    if (this.components.has(name)) {
+      throw new AvenxError(AvenxErrorCodes.COMPILER_DUPLICATE_COMPONENT_NAME, `  "${name}"`);
+    }
     this.components.set(name, compClass);
   }
 

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -65,6 +65,17 @@ function testAppErrorHandling() {
 
   const app = new AvenxApp({ target: '#app' });
 
+  app.register('DuplicateWidget', AvenxComponent);
+  assert.throws(
+    () => {
+      app.register('DuplicateWidget', AvenxComponent);
+    },
+    (err) => {
+      return err instanceof AvenxError && err.code === 'AVX_C03' && err.message.includes('"DuplicateWidget"');
+    },
+    'Should identify the duplicate component name',
+  );
+
   // Test mounting unregistered page throws AVX_R02
   assert.throws(
     () => {


### PR DESCRIPTION
## Summary

- reject a second runtime component registration with the existing `AVX_C03` error
- include the conflicting component name in the error details
- add regression coverage for the error code and diagnostic name

Fixes #568.

## Validation

- `node --import ./test/helpers/register-happy-dom.js test/unit/error.test.js`
- `npx eslint lib/core/runtime/AvenxApp.js test/unit/error.test.js`
- `npm run build`
- `npm run test:unit`: 56 of 57 files pass; the unrelated `cliConfig.test.js` fixture failure reproduces on the unchanged prior branch

AI assistance was used during implementation. I reviewed the resulting code and tests and take responsibility for the contribution.
