### PR TITLE
fix(cli): retry occupied dev server ports

### DIFF
--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -495,6 +495,31 @@ export function watchProject(cli) {
 }
 
 /**
+ * Listens on the requested port, incrementing it when the address is occupied.
+ * @param {import('http').Server} server
+ * @param {number|string} requestedPort
+ * @param {string} host
+ * @param {(port: number) => void} onListening
+ */
+export function listenWithPortFallback(server, requestedPort, host, onListening) {
+  let port = Number(requestedPort);
+
+  server.once('listening', () => onListening(port));
+  server.on('error', (err) => {
+    if (err.code !== 'EADDRINUSE' || port >= 65535) {
+      throw err;
+    }
+
+    const occupiedPort = port;
+    port += 1;
+    console.warn(`\nPort ${occupiedPort} is already in use. Trying ${port} instead.`);
+    server.listen(port, host);
+  });
+
+  server.listen(port, host);
+}
+
+/**
  * Starts a local development server and watches for changes.
  * @param {object} cli
  * @param {number|string} port
@@ -589,19 +614,8 @@ export function serveProject(cli, port, host = 'localhost') {
     });
   });
 
-  server.on('error', (err) => {
-    if (err.code === 'EADDRINUSE') {
-      console.error(
-        `\n❌ Port ${port} is already in use.\n` +
-          `   Stop the process using that port, or start the dev server on a different one.\n`,
-      );
-      process.exit(1);
-    }
-    throw err;
-  });
-
-  server.listen(port, host, () => {
-    const url = `http://${host}:${port}`;
+  listenWithPortFallback(server, port, host, (activePort) => {
+    const url = `http://${host}:${activePort}`;
     console.log(`\n🚀 Dev-Server running at ${url}`);
     if (cli.config.server.liveReload) {
       console.log(`👀 Watching for changes in ${cli.config.srcDir}/...\n`);

--- a/test/unit/serve.test.js
+++ b/test/unit/serve.test.js
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import { EventEmitter } from 'events';
+import { listenWithPortFallback } from '../../bin/commands/serve.js';
+
+class OccupiedPortServer extends EventEmitter {
+  constructor() {
+    super();
+    this.attempts = [];
+  }
+
+  listen(port, host) {
+    this.attempts.push({ port, host });
+    if (this.attempts.length === 1) {
+      const error = new Error('address already in use');
+      error.code = 'EADDRINUSE';
+      this.emit('error', error);
+    } else {
+      this.emit('listening');
+    }
+  }
+}
+
+function runTests() {
+  const server = new OccupiedPortServer();
+  const warnings = [];
+  const originalWarn = console.warn;
+  let activePort;
+
+  try {
+    console.warn = (message) => warnings.push(message);
+    listenWithPortFallback(server, 3000, 'localhost', (port) => {
+      activePort = port;
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.deepStrictEqual(server.attempts, [
+    { port: 3000, host: 'localhost' },
+    { port: 3001, host: 'localhost' },
+  ]);
+  assert.strictEqual(activePort, 3001);
+  assert.strictEqual(warnings.length, 1);
+  assert.ok(warnings[0].includes('Port 3000 is already in use'));
+  assert.ok(warnings[0].includes('Trying 3001'));
+}
+
+try {
+  runTests();
+  console.log('Dev server port fallback tests passed!');
+} catch (error) {
+  console.error('Dev server port fallback tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- retry the dev server on the next port after `EADDRINUSE`
- report both the occupied port and the fallback port
- use the selected port for the startup URL and browser launch
- add deterministic retry coverage

Fixes #557.

## Validation

- `node --import ./test/helpers/register-happy-dom.js test/unit/serve.test.js`
- localhost smoke test with an occupied ephemeral port confirmed fallback to `port + 1`
- `npx eslint bin/commands/serve.js test/unit/serve.test.js`
- `npm run build`
- `npm run test:unit`: 57 of 58 files pass; the unrelated `cliConfig.test.js` fixture failure reproduces on the unchanged prior branch

AI assistance was used during implementation. I reviewed the resulting code and tests and take responsibility for the contribution.
