### PR TITLE
fix(renderer): remove old event listeners before binding new listeners

### DIFF
--- a/lib/core/events/bindEvents.js
+++ b/lib/core/events/bindEvents.js
@@ -159,10 +159,10 @@ export class EventBinder {
     };
     traverse(root);
 
-    if (!root.__avenx_delegated_listeners) {
-      root.__avenx_delegated_listeners = new Map();
+    if (!root.__avenxDelegatedListeners) {
+      root.__avenxDelegatedListeners = new Map();
     }
-    const delegatedMap = root.__avenx_delegated_listeners;
+    const delegatedMap = root.__avenxDelegatedListeners;
     const existing = this.#boundEvents.get(root) || new Map();
 
     eventNames.forEach((eventName) => {
@@ -214,13 +214,13 @@ export class EventBinder {
    * @param {Element} root
    */
   #unbindDelegated(root) {
-    if (root.__avenx_delegated_listeners) {
-      root.__avenx_delegated_listeners.forEach((handler, eventName) => {
+    if (root.__avenxDelegatedListeners) {
+      root.__avenxDelegatedListeners.forEach((handler, eventName) => {
         if (typeof root.removeEventListener === 'function') {
           root.removeEventListener(eventName, handler);
         }
       });
-      delete root.__avenx_delegated_listeners;
+      delete root.__avenxDelegatedListeners;
     }
     const existing = this.#boundEvents.get(root);
     if (existing) {
@@ -257,10 +257,10 @@ export class EventBinder {
     traverse(root);
 
     elements.forEach((el) => {
-      if (!el.__avenx_direct_listeners) {
-        el.__avenx_direct_listeners = new Map();
+      if (!el.__avenxDirectListeners) {
+        el.__avenxDirectListeners = new Map();
       }
-      const directMap = el.__avenx_direct_listeners;
+      const directMap = el.__avenxDirectListeners;
       const existing = this.#boundEvents.get(el) || new Map();
       const handlers = this.#getEventHandlers(el);
 
@@ -414,13 +414,13 @@ export class EventBinder {
     traverse(root);
 
     elements.forEach((el) => {
-      if (el.__avenx_direct_listeners) {
-        el.__avenx_direct_listeners.forEach((handler, eventName) => {
+      if (el.__avenxDirectListeners) {
+        el.__avenxDirectListeners.forEach((handler, eventName) => {
           if (typeof el.removeEventListener === 'function') {
             el.removeEventListener(eventName, handler);
           }
         });
-        delete el.__avenx_direct_listeners;
+        delete el.__avenxDirectListeners;
       }
 
       const existing = this.#boundEvents.get(el);

--- a/lib/core/events/bindEvents.js
+++ b/lib/core/events/bindEvents.js
@@ -159,41 +159,54 @@ export class EventBinder {
     };
     traverse(root);
 
-    eventNames.forEach((eventName) => {
-      const existing = this.#boundEvents.get(root) || new Map();
-      if (!existing.has(eventName)) {
-        const handler = (event) => {
-          let current = (event && event.target) || root;
-          while (current) {
-            if (belongsToComponent(current, root)) {
-              const handlers = this.#getEventHandlers(current);
-              handlers.forEach((h) => {
-                const parts = h.fullName.split('.');
-                const baseEventName = parts[0];
-                if (baseEventName === eventName) {
-                  const modifiers = parts.slice(1);
-                  if (h.value) {
-                    this.#executeWithModifiers(dispatcher, h.value, event, modifiers, current, h.attrName);
-                  }
-                }
-              });
-            }
-            if (current === root) {
-              break;
-            }
-            current = current.parentNode;
-            if (event.cancelBubble) {
-              break;
-            }
-          }
-        };
+    if (!root.__avenx_delegated_listeners) {
+      root.__avenx_delegated_listeners = new Map();
+    }
+    const delegatedMap = root.__avenx_delegated_listeners;
+    const existing = this.#boundEvents.get(root) || new Map();
 
-        if (typeof root.addEventListener === 'function') {
-          root.addEventListener(eventName, handler);
+    eventNames.forEach((eventName) => {
+      if (delegatedMap.has(eventName)) {
+        const oldHandler = delegatedMap.get(eventName);
+        if (typeof root.removeEventListener === 'function') {
+          root.removeEventListener(eventName, oldHandler);
         }
-        existing.set(eventName, handler);
-        this.#boundEvents.set(root, existing);
+        delegatedMap.delete(eventName);
+        existing.delete(eventName);
       }
+
+      const handler = (event) => {
+        let current = (event && event.target) || root;
+        while (current) {
+          if (belongsToComponent(current, root)) {
+            const handlers = this.#getEventHandlers(current);
+            handlers.forEach((h) => {
+              const parts = h.fullName.split('.');
+              const baseEventName = parts[0];
+              if (baseEventName === eventName) {
+                const modifiers = parts.slice(1);
+                if (h.value) {
+                  this.#executeWithModifiers(dispatcher, h.value, event, modifiers, current, h.attrName);
+                }
+              }
+            });
+          }
+          if (current === root) {
+            break;
+          }
+          current = current.parentNode;
+          if (event.cancelBubble) {
+            break;
+          }
+        }
+      };
+
+      if (typeof root.addEventListener === 'function') {
+        root.addEventListener(eventName, handler);
+      }
+      delegatedMap.set(eventName, handler);
+      existing.set(eventName, handler);
+      this.#boundEvents.set(root, existing);
     });
   }
 
@@ -201,14 +214,23 @@ export class EventBinder {
    * @param {Element} root
    */
   #unbindDelegated(root) {
+    if (root.__avenx_delegated_listeners) {
+      root.__avenx_delegated_listeners.forEach((handler, eventName) => {
+        if (typeof root.removeEventListener === 'function') {
+          root.removeEventListener(eventName, handler);
+        }
+      });
+      delete root.__avenx_delegated_listeners;
+    }
     const existing = this.#boundEvents.get(root);
-    if (!existing) return;
-    existing.forEach((handler, eventName) => {
-      if (typeof root.removeEventListener === 'function') {
-        root.removeEventListener(eventName, handler);
-      }
-    });
-    this.#boundEvents.delete(root);
+    if (existing) {
+      existing.forEach((handler, eventName) => {
+        if (typeof root.removeEventListener === 'function') {
+          root.removeEventListener(eventName, handler);
+        }
+      });
+      this.#boundEvents.delete(root);
+    }
   }
 
   /**
@@ -235,13 +257,27 @@ export class EventBinder {
     traverse(root);
 
     elements.forEach((el) => {
+      if (!el.__avenx_direct_listeners) {
+        el.__avenx_direct_listeners = new Map();
+      }
+      const directMap = el.__avenx_direct_listeners;
+      const existing = this.#boundEvents.get(el) || new Map();
       const handlers = this.#getEventHandlers(el);
+
+      // Remove any existing direct listeners on el before binding new ones
+      directMap.forEach((oldHandler, baseEventName) => {
+        if (typeof el.removeEventListener === 'function') {
+          el.removeEventListener(baseEventName, oldHandler);
+        }
+      });
+      directMap.clear();
+      existing.clear();
+
       handlers.forEach((h) => {
         const parts = h.fullName.split('.');
         const baseEventName = parts[0];
-        const existing = this.#boundEvents.get(el) || new Map();
 
-        if (!existing.has(baseEventName)) {
+        if (!directMap.has(baseEventName)) {
           const handler = (event) => {
             const currentHandlers = this.#getEventHandlers(el);
             currentHandlers.forEach((ch) => {
@@ -258,6 +294,7 @@ export class EventBinder {
           if (typeof el.addEventListener === 'function') {
             el.addEventListener(baseEventName, handler);
           }
+          directMap.set(baseEventName, handler);
           existing.set(baseEventName, handler);
           this.#boundEvents.set(el, existing);
         }
@@ -377,14 +414,24 @@ export class EventBinder {
     traverse(root);
 
     elements.forEach((el) => {
+      if (el.__avenx_direct_listeners) {
+        el.__avenx_direct_listeners.forEach((handler, eventName) => {
+          if (typeof el.removeEventListener === 'function') {
+            el.removeEventListener(eventName, handler);
+          }
+        });
+        delete el.__avenx_direct_listeners;
+      }
+
       const existing = this.#boundEvents.get(el);
-      if (!existing) return;
-      existing.forEach((handler, eventName) => {
-        if (typeof el.removeEventListener === 'function') {
-          el.removeEventListener(eventName, handler);
-        }
-      });
-      this.#boundEvents.delete(el);
+      if (existing) {
+        existing.forEach((handler, eventName) => {
+          if (typeof el.removeEventListener === 'function') {
+            el.removeEventListener(eventName, handler);
+          }
+        });
+        this.#boundEvents.delete(el);
+      }
     });
   }
 

--- a/test/unit/event_leak.test.js
+++ b/test/unit/event_leak.test.js
@@ -27,6 +27,12 @@ try {
     addEventListener(event, callback) {
       boundListeners.push({ event, callback });
     },
+    removeEventListener(event, callback) {
+      const idx = boundListeners.findIndex((l) => l.event === event && l.callback === callback);
+      if (idx !== -1) {
+        boundListeners.splice(idx, 1);
+      }
+    },
     // Test helper to fire events directly
     trigger(event, data) {
       boundListeners.forEach((listener) => {
@@ -51,6 +57,7 @@ try {
 
   assert.strictEqual(boundListeners.length, 4, 'Should add exactly 4 common event listeners');
   assert.ok(boundListeners.some(l => l.event === 'click'), 'Should have click listener');
+  assert.ok(mockElement.__avenx_delegated_listeners instanceof Map, 'Should store active listeners on element property');
 
   // 3. Trigger event & verify it executes the initial handler expression
   mockElement.trigger('click', { type: 'click' });
@@ -63,7 +70,7 @@ try {
   // 5. Bind again (simulating component update cycle)
   binder.bind(mockElement, dispatcher);
 
-  // Verify that NO duplicate listener was added
+  // Verify that NO duplicate listener was added and old listener was torn down
   assert.strictEqual(boundListeners.length, 4, 'Should NOT add new event listeners on update');
 
   // 6. Trigger event again & verify it executes the LATEST handler expression exactly once
@@ -73,7 +80,73 @@ try {
   assert.strictEqual(executionCalls.length, 1, 'Should execute updated handler exactly once (no duplicates)');
   assert.strictEqual(executionCalls[0].expression, 'handleClick(2)', 'Should execute the updated handler expression');
 
-  // 7. Verify subtree traversal during unbind on Element (nodeType = 1)
+  // 7. Verify direct binding tearing down old listeners on re-bind
+  console.log('  Testing direct listener property tracking and teardown on re-bind...');
+  const buttonListeners = [];
+  const buttonMock = {
+    nodeType: 1,
+    tagName: 'BUTTON',
+    attributes: [{ name: '@click', value: 'onClick1()' }],
+    getAttribute(name) {
+      const attr = this.attributes.find((a) => a.name === name);
+      return attr ? attr.value : null;
+    },
+    setAttribute(name, value) {
+      const attr = this.attributes.find((a) => a.name === name);
+      if (attr) {
+        attr.value = value;
+      } else {
+        this.attributes.push({ name, value });
+      }
+    },
+    addEventListener(event, callback) {
+      buttonListeners.push({ event, callback });
+    },
+    removeEventListener(event, callback) {
+      const idx = buttonListeners.findIndex((l) => l.event === event && l.callback === callback);
+      if (idx !== -1) {
+        buttonListeners.splice(idx, 1);
+      }
+    },
+    trigger(event, data) {
+      buttonListeners.forEach((listener) => {
+        if (listener.event === event) {
+          listener.callback(data);
+        }
+      });
+    },
+  };
+  const fragmentMock = {
+    nodeType: 11,
+    childNodes: [buttonMock],
+  };
+
+  const rebindBinder = new EventBinder();
+  rebindBinder.bind(fragmentMock, dispatcher);
+
+  assert.strictEqual(buttonListeners.length, 1, 'Direct binding should attach 1 listener');
+  assert.ok(buttonMock.__avenx_direct_listeners instanceof Map, 'Direct active listeners should be stored on __avenx_direct_listeners');
+  assert.strictEqual(buttonMock.__avenx_direct_listeners.size, 1);
+
+  // Trigger click on button
+  executionCalls.length = 0;
+  buttonMock.trigger('click', { type: 'click' });
+  assert.strictEqual(executionCalls.length, 1, 'Should trigger handler callback once');
+  assert.strictEqual(executionCalls[0].expression, 'onClick1()');
+
+  // Modify button attribute and re-bind using a DIFFERENT EventBinder instance
+  buttonMock.setAttribute('@click', 'onClick2()');
+  const secondBinder = new EventBinder();
+  secondBinder.bind(fragmentMock, dispatcher);
+
+  // Should tear down previous listener and attach new listener without duplication
+  assert.strictEqual(buttonListeners.length, 1, 'Re-binding direct listener should tear down previous registration');
+  executionCalls.length = 0;
+  buttonMock.trigger('click', { type: 'click' });
+  assert.strictEqual(executionCalls.length, 1, 'Clicked patched button triggers callback exactly once');
+  assert.strictEqual(executionCalls[0].expression, 'onClick2()');
+
+  // 8. Verify subtree traversal during unbind on Element (nodeType = 1)
   const childListeners = [];
   const childMock = {
     nodeType: 1,
@@ -121,6 +194,7 @@ try {
   // This should traverse parentMock and clean up childMock's direct event listeners
   directBinder.unbind(parentMock);
   assert.strictEqual(childListeners.length, 0, 'Child event listener should be removed when unbinding parent');
+  assert.strictEqual(childMock.__avenx_direct_listeners, undefined, 'Direct listener property deleted after unbind');
 
   console.log('  ✅ EventBinder duplicate listeners and leak prevention tests passed!');
 } catch (error) {

--- a/test/unit/event_leak.test.js
+++ b/test/unit/event_leak.test.js
@@ -57,7 +57,7 @@ try {
 
   assert.strictEqual(boundListeners.length, 4, 'Should add exactly 4 common event listeners');
   assert.ok(boundListeners.some(l => l.event === 'click'), 'Should have click listener');
-  assert.ok(mockElement.__avenx_delegated_listeners instanceof Map, 'Should store active listeners on element property');
+  assert.ok(mockElement.__avenxDelegatedListeners instanceof Map, 'Should store active listeners on element property');
 
   // 3. Trigger event & verify it executes the initial handler expression
   mockElement.trigger('click', { type: 'click' });
@@ -125,8 +125,8 @@ try {
   rebindBinder.bind(fragmentMock, dispatcher);
 
   assert.strictEqual(buttonListeners.length, 1, 'Direct binding should attach 1 listener');
-  assert.ok(buttonMock.__avenx_direct_listeners instanceof Map, 'Direct active listeners should be stored on __avenx_direct_listeners');
-  assert.strictEqual(buttonMock.__avenx_direct_listeners.size, 1);
+  assert.ok(buttonMock.__avenxDirectListeners instanceof Map, 'Direct active listeners should be stored on __avenxDirectListeners');
+  assert.strictEqual(buttonMock.__avenxDirectListeners.size, 1);
 
   // Trigger click on button
   executionCalls.length = 0;
@@ -194,7 +194,7 @@ try {
   // This should traverse parentMock and clean up childMock's direct event listeners
   directBinder.unbind(parentMock);
   assert.strictEqual(childListeners.length, 0, 'Child event listener should be removed when unbinding parent');
-  assert.strictEqual(childMock.__avenx_direct_listeners, undefined, 'Direct listener property deleted after unbind');
+  assert.strictEqual(childMock.__avenxDirectListeners, undefined, 'Direct listener property deleted after unbind');
 
   console.log('  ✅ EventBinder duplicate listeners and leak prevention tests passed!');
 } catch (error) {


### PR DESCRIPTION
Fixes #553 

### Description

#### Problem
During DOM updates, the renderer binds new event listeners to modified elements without removing old listeners. This causes duplicate event callbacks when a user clicks a patched button.

#### Solution
- Store active event listeners as properties on DOM elements (`__avenx_delegated_listeners` and `__avenx_direct_listeners`).
- Remove old event listeners from elements before adding new event listeners.
- Delete listener properties from elements during the unbind process.

#### Result
- Clicking a patched element triggers its event callback exactly once.
- Prevents memory leaks and duplicate event executions.
- All unit and integration tests pass successfully.