### PR TITLE
docs: document app.activePage getter

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -47,6 +47,39 @@ When the cache reaches this limit, the least recently used (LRU) cached page is 
 
 The default value is `5`.
 
+## Public Properties
+
+### `activePage`
+
+Returns the currently active mounted page component instance.
+
+**Returns**
+
+`AvenxComponent | null`
+
+Returns the currently active mounted page component instance, or `null` if no page is currently mounted.
+
+This read-only property is useful for debugging, diagnostics, and telemetry.
+
+**Example**
+
+```javascript
+const currentPage = app.activePage;
+
+if (currentPage) {
+  console.log('Current page:', currentPage);
+}
+```
+
+```javascript
+const currentPage = app.activePage;
+
+analytics.track('page-state', {
+  active: currentPage !== null,
+});
+```
+
+
 ## Public Methods
 
 ### `register(name, compClass)`


### PR DESCRIPTION
## Summary

This PR documents the `app.activePage` getter in the AvenxApp API reference.

## Changes

- Added documentation for the `activePage` getter under Public Properties.
- Documented the return type (`AvenxComponent | null`).
- Explained the behavior when no page is mounted.
- Added examples demonstrating debugging and telemetry usage.

Closes #737