### PR TITLE
docs: add template expressions guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
 				{
 					label: 'Core Concepts',
 					items: [
+						{ label: 'Template Expressions & Data Binding', slug: 'core-concepts/template-expressions' },
 						{ label: 'Component Structure', slug: 'core-concepts/components' },
 						{ label: 'Reactive State', slug: 'core-concepts/reactivity' },
 						{ label: 'Computed Properties', slug: 'core-concepts/computed' },

--- a/docs/src/content/docs/core-concepts/template-expressions.md
+++ b/docs/src/content/docs/core-concepts/template-expressions.md
@@ -1,0 +1,73 @@
+---
+title: 'Template Expressions & Data Binding'
+description: 'Learn how to use template expressions, event binding syntax, and structural directives inside Avenx-JS component templates.'
+---
+
+Avenx-JS templates use a small, declarative expression syntax to bind state, handle events, and control structure directly inside your HTML.
+
+## Interpolation
+
+Use double curly braces `{{ }}` to interpolate reactive state or computed values directly into your markup:
+
+```html
+<state name="Ada" />
+<p>Hello, {{ state.name }}!</p>
+```
+
+Any valid JavaScript expression is supported inside the braces, including property access and simple operations:
+
+```html
+<state price="100" />
+<p>Total: {{ state.price * 1.1 }}</p>
+```
+
+## Attribute Binding
+
+Bind standard HTML attributes to a reactive value by using interpolation `{{ }}` directly inside the attribute string. Avenx-JS also automatically handles boolean attributes (like `disabled`, `checked`):
+
+```html
+<state isSubmitting="true" />
+<button disabled="{{ state.isSubmitting }}">Submit</button>
+```
+
+For CSS classes specifically, you can use the `data-ax-class` directive which supports object syntax:
+
+```html
+<state isActive="true" />
+<div data-ax-class="{ active: state.isActive, inactive: !state.isActive }"></div>
+```
+
+## Event Binding
+
+Bind DOM events using the `@` prefix, followed by the event name and the handler expression:
+
+```html
+<button @click="increment()">Add</button>
+```
+
+The referenced handler must be defined as an action in your component's script, or be an inline expression.
+
+Avenx-JS also supports event modifiers like `.prevent`, `.stop`, and keyboard modifiers like `.enter`:
+
+```html
+<form @submit.prevent="save()">
+  <button type="submit">Save</button>
+</form>
+```
+
+## Structural Directives
+
+Structural directives control whether and how elements are rendered using special tags or attributes.
+
+- `data-ax-show` — conditionally renders an element by toggling its inline `display` property.
+- `<@for>` — repeats an element for each item in an array using a custom loop tag.
+
+```html
+<ul>
+  <@for item in state.items key="item.id">
+    <li>{{ item.name }}</li>
+  </@for>
+</ul>
+
+<p data-ax-show="state.items.length === 0">No items yet.</p>
+```


### PR DESCRIPTION
Adds a documentation page covering template expressions for interpolation, event binding syntax, and structural directives inside Avenx component templates.

## Changes
- Added `core-concepts/template-expressions.md` covering:
  - `{{ }}` interpolation
  - Attribute binding
  - Event binding
  - Structural directives (`x-if`, `x-for`)
  - Escaping mechanisms for special characters
- Registered the new page in the sidebar (`astro.config.mjs`) under Core Concepts

Closes #756