### PR TITLE
Fix issue with encoded routing hash matching

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -46,7 +46,7 @@ export class AvenxRouter {
 
     this.delegate.registerRouter(this);
 
-    this.unsubscribeHashChange = this.unsubscribeHashChange = this.delegate.onHashChange(() => this.#handleRoute(decodeURIComponent(window.location.hash)));
+    this.unsubscribeHashChange = this.delegate.onHashChange(() => this.#handleRoute());
     this.unsubscribeLinkClick = this.delegate.onLinkClick((route) => this.navigate(route));
   }
 
@@ -97,7 +97,8 @@ export class AvenxRouter {
    */
   navigate(hash) {
     // Force clean paths like '/profile' into hash paths like '#/profile'
-    let targetHash = hash.startsWith('#') ? hash : '#' + hash;
+    let targetHash = hash.startsWith('#') ? decodeURIComponent(hash) : '#' + decodeURIComponent(hash);
+
 
     if (this.options && this.options.prefix) {
       const prefix = this.options.prefix;

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -46,7 +46,7 @@ export class AvenxRouter {
 
     this.delegate.registerRouter(this);
 
-    this.unsubscribeHashChange = this.delegate.onHashChange(() => this.#handleRoute());
+    this.unsubscribeHashChange = this.unsubscribeHashChange = this.delegate.onHashChange(() => this.#handleRoute(decodeURIComponent(window.location.hash)));
     this.unsubscribeLinkClick = this.delegate.onLinkClick((route) => this.navigate(route));
   }
 


### PR DESCRIPTION
I've found that our router was struggling to match route patterns when the hash included percent-encoded characters. To fix this, I've updated the hash matching input to use `decodeURIComponent`, which should handle these encoded characters correctly. You can test the updated router by using hash routes with percent-encoded characters, such as '#/path%20with%20spaces'.