### PR TITLE
docs: standardize validation error guidelines for compiler and runtime agents

### DIFF
--- a/.agents/compiler_agent.md
+++ b/.agents/compiler_agent.md
@@ -33,7 +33,7 @@ Maintain and optimize the Avenx-JS build-time compiler system, including compone
 ## Best Practices
 
 * **Robust Regex & AST**: Rely on AST parsing where possible to avoid fragile regex matching on complex template syntax.
-* **Error Context**: Throw detailed compiler exceptions referencing target files and line counts to help developers debug syntax errors.
+* **Error Context**: Before implementing compiler validation errors, warnings, or exception handling, review `errors.md` and reuse existing Avenx warning/error codes whenever applicable. Throw detailed compiler exceptions referencing target files and line counts to help developers debug syntax errors.
 * **Hashed Selection**: When processing scoped styles, verify that all selectors (excluding global blocks) are appended with the correct component scope hash.
 
 ## Success Criteria

--- a/.agents/runtime_agent.md
+++ b/.agents/runtime_agent.md
@@ -35,6 +35,7 @@ Maintain and optimize the Avenx-JS core runtime, reactivity engine, state manage
 
 * **Batch state updates**: Batch state modifications when modifying multiple properties concurrently to minimize redundant render cycles.
 * **Proxy containment**: When returning proxy handlers, always clean up listeners if a target component/key is destroyed or garbage-collected.
+* **Error Handling**: Before implementing runtime validation errors, warnings, or exception handling, review `errors.md` and reuse 	existing Avenx warning/error codes whenever applicable. Follow the centralized warning format instead of creating custom logging 	formats.
 * **List Diffing**: When updating list components, use unique keys to allow correct recycling of DOM elements instead of fully re-creating nodes.
 
 ## Success Criteria


### PR DESCRIPTION
## Summary

Adds guidelines for compiler and runtime agents to use Avenx's centralized error and warning definitions.

## Changes

* Updated `.agents/compiler_agent.md`
* Updated `.agents/runtime_agent.md`
* Added instructions to review `errors.md` before implementing validation errors or warnings.
* Added guidance to reuse existing Avenx warning/error codes whenever applicable.

