### PR TITLE
test(cli): add coverage for --version / -v flags (#569)

### DIFF
--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -55,6 +55,31 @@ async function runTest() {
   try {
     setup();
 
+    console.log('🧪 Testing avenx --version / -v...');
+
+    const packageJsonForVersion = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8'),
+    );
+    const expectedVersionOutput = `Avenx-JS v${packageJsonForVersion.version}`;
+
+    const longFlagResult = runCli(['--version']);
+    assert.strictEqual(longFlagResult.status, 0, '--version should exit with code 0');
+    assert.strictEqual(
+      longFlagResult.stdout.trim(),
+      expectedVersionOutput,
+      '--version should print the installed package version',
+    );
+
+    const shortFlagResult = runCli(['-v']);
+    assert.strictEqual(shortFlagResult.status, 0, '-v should exit with code 0');
+    assert.strictEqual(
+      shortFlagResult.stdout.trim(),
+      expectedVersionOutput,
+      '-v should print the installed package version',
+    );
+
+    console.log('✅ --version / -v tests passed!');
+
     // Run the init command in the test directory and capture output
     const init1Output = execSync(`node ${BIN_PATH} init`, { cwd: TEST_DIR, encoding: 'utf8' });
 


### PR DESCRIPTION
## Summary
Adds system test coverage for the `avenx --version` / `avenx -v` flags in `bin/avenx.js`.

## Context
Issue #569 requested `--version`/`-v` support, but investigation showed this was already implemented — the actual gap was missing test coverage. See discussion on the issue for details.

## Changes
- Added a test block in `test/system/cli.test.js` that spawns the real CLI binary via the existing `runCli()` helper
- Asserts both `--version` and `-v` exit with code `0`
- Asserts stdout matches `Avenx-JS v<version>`, read dynamically from `package.json` (no hardcoded version)

## Testing
Ran the full system test suite locally — all tests pass, including the new block.

Closes #569