### PR TITLE
docs: improve keepAliveLimit documentation

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -34,18 +34,25 @@ const app = new AvenxApp({
 If omitted, the shared logger keeps its default configuration (`level: 'info'`, `silent: false`).
 
 ### `keepAliveLimit`
-The `keepAliveLimit` option controls how many inactive pages configured with `keepAlive: true` can remain cached in memory.
+
+The `keepAliveLimit` option controls the maximum number of inactive pages configured with `keepAlive: true` that can remain cached in memory.
+
+AvenxApp maintains an internal Least Recently Used (LRU) cache for keep-alive page instances. When a user navigates away from a keep-alive page, its `onDeactivate()` lifecycle hook runs and the page instance is moved into the cache instead of being destroyed immediately.
+
+If adding another inactive page would exceed `keepAliveLimit`, the least recently used cached page is evicted from memory and its `onUnmount()` lifecycle hook is called.
+
+The default value is `5`.
 
 ```javascript
 const app = new AvenxApp({
   target: '#app',
-  keepAliveLimit: 5,
+  keepAliveLimit: 3,
 });
 ```
 
-When the cache reaches this limit, the least recently used (LRU) cached page is evicted and its `onUnmount()` lifecycle hook is called.
+For example, if four routes are configured with `keepAlive: true` and `keepAliveLimit` is set to `3`, only three inactive page instances are retained in memory. When the fourth page is cached, the least recently used cached page is evicted and its `onUnmount()` hook executes.
 
-The default value is `5`.
+Applications with limited memory budgets may prefer a smaller value, while applications that benefit from preserving more inactive pages can increase the limit.
 
 ## Public Properties
 

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -44,6 +44,25 @@ When a cached page is restored, the `onActivate(params)` lifecycle hook is calle
 
 This behavior is useful for pages that should preserve their state between navigations, such as dashboards, forms, or long lists.
 
+### `keepAliveLimit`
+
+The maximum number of inactive keep-alive page instances is controlled by the `keepAliveLimit` option passed to the `AvenxApp` constructor.
+
+When navigating away from a page configured with `keepAlive: true`:
+
+1. `onDeactivate()` runs and the page instance is moved into the internal LRU cache.
+2. If caching another inactive page would exceed `keepAliveLimit`, the least recently used cached page is evicted.
+3. The evicted page's `onUnmount()` lifecycle hook runs.
+
+```javascript
+const app = new AvenxApp({
+  target: '#app',
+  keepAliveLimit: 3,
+});
+```
+
+With this configuration, navigating among four or more keep-alive pages retains only the three most recently used inactive page instances in memory. Older cached pages are automatically removed as needed.
+
 
 
 ## 3. Dynamic Route Parameters


### PR DESCRIPTION
## Summary

This PR improves the documentation for the `keepAliveLimit` option.

### Changes

- Explain how the internal LRU cache works.
- Clarify the lifecycle difference between `onDeactivate()` and `onUnmount()`.
- Add a `keepAliveLimit` configuration example.
- Document cache eviction behavior when the limit is exceeded.
- Update both:
  - `docs/src/content/docs/api-reference/app.md`
  - `docs/src/content/docs/core-concepts/routing.md`

Closes #788.