### PR TITLE
docs: expand VirtualList API reference

### DIFF
--- a/docs/src/content/docs/api-reference/virtuallist.md
+++ b/docs/src/content/docs/api-reference/virtuallist.md
@@ -3,7 +3,20 @@ title: 'VirtualList'
 description: 'Full API reference and template slot scope documentation for the built-in VirtualList component.'
 ---
 
-The `<VirtualList>` component is a built-in, globally available component designed for high-performance virtualized rendering of large datasets. It dynamically recycles DOM elements and only renders rows currently visible within the viewport scroll area.
+The `<VirtualList>` component is a built-in, globally available component for rendering large datasets without creating a DOM node per item. It keeps one scroll viewport, renders only the rows near the visible window, recycles those elements as the user scrolls, and measures dynamic row heights with a `ResizeObserver`.
+
+```mermaid
+flowchart TB
+    Items["items[]"]
+    Viewport["scroll viewport<br/>(height: 100%)"]
+    Window["visible window + 5-row buffer"]
+    Spacer["spacer<br/>(total list height)"]
+    Items --> Viewport
+    Viewport --> Window
+    Window --> Spacer
+```
+
+The spacer is not a second list. It gives the scrollbar the full dataset height while the viewport only patches the small number of recycled rows needed for the current window.
 
 ## Props
 
@@ -12,27 +25,48 @@ The `<VirtualList>` component is a built-in, globally available component design
 | `items` | `Array` | `[]` | The array of dataset items to render in the virtual list. |
 | `itemHeight` / `item-height` | `Number` | `40` | Default row height in pixels. Supports both camelCase (`itemHeight`) and kebab-case (`item-height`). |
 
-> [!NOTE]
-> `<VirtualList>` incorporates a built-in `ResizeObserver` to monitor item sizes and container dimensions automatically, adjusting scroll offsets when dynamic content resizes.
+> [!IMPORTANT]
+> `bufferSize` and `containerHeight` are not component props. The render buffer is fixed at five rows internally, and the viewport fills its parent with `height: 100%`. If the parent has no resolved height, the viewport falls back to a `clientHeight` of `400px`.
 
 ---
 
-## Template Slot Scope & `index` Variable
+## Scroll container requirements
 
-To define row markup inside `<VirtualList>`, place a `<template data-ax-as="...">` slot tag inside the `<VirtualList>` component element. 
+The component owns its scroll container. The generated viewport uses:
 
-The slot scope automatically exposes two variables during rendering:
+```css
+overflow-y: auto;
+position: relative;
+height: 100%;
+width: 100%;
+```
+
+Give the parent of `<VirtualList>` a definite height:
+
+```css
+.virtual-list-shell {
+  height: 480px;
+}
+```
+
+The component observes the viewport and each rendered row with a single `ResizeObserver`. Row height changes are applied on the next animation frame, so height changes do not force a synchronous full relayout.
+
+Row markup should use `box-sizing: border-box` and avoid relying on vertical margin collapse. Padding inside the row is safer than margins between rows because the measured `offsetHeight` stays predictable.
+
+## Template slot scope and `index`
+
+To define row markup inside `<VirtualList>`, place a `<template data-ax-as="...">` slot tag inside the component element.
+
+The slot scope exposes:
 
 | Variable | Type | Description |
 | :--- | :--- | :--- |
-| `item` *(or custom alias)* | `Object \| any` | The dataset item object for the current row. Customize the variable name using `data-ax-as="alias"`. |
-| `index` | `Number` | The zero-based numerical index of the current item in the `items` array. |
+| `item` *(or custom alias)* | `Object \| any` | The dataset item for the current row. Rename it with `data-ax-as="alias"`. |
+| `index` | `Number` | The zero-based index of the current item in `items`. |
 
----
+## Usage examples
 
-## Usage Examples
-
-### 1. Basic Usage with `index` and Item Properties
+### Basic usage
 
 ```html
 <state items="[
@@ -51,9 +85,9 @@ The slot scope automatically exposes two variables during rendering:
 </VirtualList>
 ```
 
-### 2. Custom Item Alias (`data-ax-as`)
+### Custom item alias
 
-By default, the item variable is named `item`. Use `data-ax-as="customName"` on the `<template>` element to rename the item variable while keeping `index` available:
+Use `data-ax-as` to rename the item variable while keeping `index`:
 
 ```html
 <VirtualList :item-height="60" :items="products">
@@ -65,3 +99,77 @@ By default, the item variable is named `item`. Use `data-ax-as="customName"` on 
   </template>
 </VirtualList>
 ```
+
+### Dynamic row heights
+
+Set a conservative default with `item-height`, then let the `ResizeObserver` replace it with the measured height of each row:
+
+```html
+<VirtualList :item-height="48" :items="messages">
+  <template data-ax-as="message">
+    <div class="message-row">
+      <strong>{{ message.author }}</strong>
+      <p>{{ message.body }}</p>
+    </div>
+  </template>
+</VirtualList>
+```
+
+```css
+.message-row {
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+```
+
+The default height is used only until the row is measured. A row that grows or shrinks is re-measured and the spacer offsets are updated.
+
+### Infinite scrolling with a load-more action
+
+`<VirtualList>` does not expose a scroll callback prop. Scroll handling is internal and throttled with `requestAnimationFrame`. For a load-more UX, append to `items` from an action; `onUpdate` recalculates the window automatically.
+
+```html
+<state items="[]" page="0" loading="false" hasMore="true" />
+
+<action name="onMount">
+  this.loadMore()
+</action>
+
+<action name="loadMore">
+  if (this.state.loading || !this.state.hasMore) return
+  this.state.loading = true
+  fetch(`/api/items?page=${this.state.page}`)
+    .then((response) => response.json())
+    .then((next) => {
+      this.state.items = [...this.state.items, ...next.items]
+      this.state.page += 1
+      this.state.hasMore = next.has_more
+      this.state.loading = false
+    })
+</action>
+
+<div class="virtual-list-shell">
+  <VirtualList :item-height="48" :items="items">
+    <template data-ax-as="item">
+      <div class="row">{{ item.title }}</div>
+    </template>
+  </VirtualList>
+  <button @click="loadMore()" data-ax-show="hasMore && !loading">Load more</button>
+  <p data-ax-show="loading">Loading...</p>
+</div>
+```
+
+## Performance tips
+
+- Keep row templates light. The component patches recycled nodes, but a heavy template still costs work on every scroll frame.
+- Prefer a stable `item-height` when rows are uniform. Dynamic heights are supported, but each measured change schedules a relayout.
+- Update `items` with a new array when data changes so the component's update path runs.
+- Do not add another `ResizeObserver` per row. The built-in observer already watches the viewport and every rendered row.
+- Let the fixed five-row buffer handle overscroll. Setting a larger buffer is not supported because the component owns that value internally.
+
+## Troubleshooting
+
+- **The list does not scroll.** The parent has no resolved height. Give it an explicit height or a flex/grid container height.
+- **Rows jump while scrolling.** Dynamic row heights are being re-measured. Keep content heights stable or make the default `item-height` closer to the real first-measurement height.
+- **Nothing renders.** `items` is empty or no `<template>` slot was provided. The component requires a row template to create elements.


### PR DESCRIPTION
## What & why

Expands the VirtualList API reference from the actual component implementation. The docs now explain the windowing model, the real props, scroll container CSS requirements, dynamic row height measurement, slot scope, and complete examples for custom item templates and load-more infinite scrolling.

Closes #814.

## Accuracy notes

- `bufferSize` and `containerHeight` are documented as non-props because the component does not expose them; the buffer is fixed at five rows and the viewport fills its parent.
- Scroll handling is internal and rAF-throttled, so the docs do not invent a scroll callback prop.
- The load-more example appends to `items` and lets the component relayout on update.

## Verification

- `cd docs && npm run build` passes.
- Docs-only change.
