### PR TITLE
Add Documentation for AVX_W24 Warning

### DIFF
--- a/docs/src/content/docs/troubleshooting/errors.md
+++ b/docs/src/content/docs/troubleshooting/errors.md
@@ -93,6 +93,9 @@ console.warn(formatMessage(AvenxErrorCodes.SANDBOX_VIOLATION, 'disallowed eval()
 
 Unlike the error codes above, which halt compilation, Avenx-JS also emits **warnings** during the build step. Warnings do not stop the build, but they flag potential mistakes in your templates that are worth fixing.
 
+### COMPILER_PREPROCESSOR_MISSING Warning
+The `[AVX_W24]` warning occurs when a CSS preprocessor is configured but the required preprocessor package is not installed.
+
 ### Undeclared Variable or Method Warning
 
 ```text


### PR DESCRIPTION
I noticed that the AVX_W24 warning was missing from our documentation, so I've added it to the errors.md file to ensure we have a comprehensive list of warning codes. To verify this change, you can check that the AVX_W24 warning is now correctly documented in the errors.md file.