### PR TITLE
feat(core): add $slots.has() for conditional slot checks

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -40,6 +40,17 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
     readonly $parent: AvenxComponent<any> | null;
 
     /**
+     * Helpers for inspecting whether the parent provided slot content.
+     */
+    readonly $slots: {
+        /**
+         * Returns true when content was provided for the named slot (or the default slot).
+         * @param slotName Named slot, or `default` / omitted for the default slot.
+         */
+        has(slotName?: string): boolean;
+    };
+
+    /**
      * The active route details.
      */
     readonly $route: { hash: string; page: string; params: Record<string, any> };

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -355,6 +355,30 @@ export class AvenxComponent {
   }
 
   /**
+   * Slot helpers for checking whether the parent provided content for a slot.
+   * Available after mount target setup populates `#transcludedGroups`.
+   * @returns {{ has: (slotName?: string) => boolean }}
+   */
+  get $slots() {
+    const groups = this.#transcludedGroups;
+    return {
+      /**
+       * @param {string} [slotName='default'] Named slot, or `default` / empty for the default slot.
+       * @returns {boolean}
+       */
+      has(slotName = 'default') {
+        if (!groups) return false;
+        const name = !slotName || slotName === 'default' ? null : slotName;
+        if (!name) {
+          return Array.isArray(groups.default) && groups.default.length > 0;
+        }
+        const nodes = groups.named?.[name];
+        return Array.isArray(nodes) && nodes.length > 0;
+      },
+    };
+  }
+
+  /**
    * Emits a custom event up to parent components with unified bubble options.
    * @param {string} eventName - Name of the event to emit.
    * @param {object} [detail] - Event details payload.

--- a/test/unit/componentSlotsHas.test.js
+++ b/test/unit/componentSlotsHas.test.js
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import '../helpers/register-happy-dom.js';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+
+/**
+ * Tests this.$slots.has() against transcluded default and named slot content.
+ */
+function testSlotsHasDefaultAndNamed() {
+  console.log('🧪 Testing $slots.has()...');
+
+  const component = new AvenxComponent(
+    {},
+    {},
+    {},
+    '<div><slot></slot><slot name="footer"></slot></div>',
+  );
+  const root = document.createElement('div');
+  const defaultNode = document.createElement('span');
+  defaultNode.textContent = 'body';
+  const footerNode = document.createElement('span');
+  footerNode.setAttribute('slot', 'footer');
+  footerNode.textContent = 'footer';
+  root.appendChild(defaultNode);
+  root.appendChild(footerNode);
+
+  component.__setMountTarget(root);
+
+  assert.strictEqual(component.$slots.has('default'), true, 'default slot should be present');
+  assert.strictEqual(component.$slots.has(), true, 'has() with no args should check default');
+  assert.strictEqual(component.$slots.has('footer'), true, 'named footer slot should be present');
+  assert.strictEqual(component.$slots.has('missing'), false, 'missing named slot should be false');
+
+  console.log('  ✅ $slots.has() reports default and named slot presence.');
+}
+
+function testSlotsHasEmpty() {
+  console.log('🧪 Testing $slots.has() with no slot content...');
+
+  const component = new AvenxComponent({}, {}, {}, '<div><slot></slot></div>');
+  const root = document.createElement('div');
+  component.__setMountTarget(root);
+
+  assert.strictEqual(component.$slots.has('default'), false);
+  assert.strictEqual(component.$slots.has('footer'), false);
+
+  console.log('  ✅ $slots.has() is false when no content was passed.');
+}
+
+testSlotsHasDefaultAndNamed();
+testSlotsHasEmpty();
+
+console.log('✅ All $slots.has() tests passed.');


### PR DESCRIPTION
Adds `this.$slots.has(slotName)` so components can detect whether default or named slot content was provided before rendering wrappers.
Fixes #818
