### PR TITLE
docs(agents): refine CLI agent subcommand guidelines with real bin/ paths

### DIFF
--- a/.agents/cli_agent.md
+++ b/.agents/cli_agent.md
@@ -6,7 +6,7 @@ Build and maintain CLI helpers, build configurations, and bundling plugins (like
 
 ## Responsibilities
 
-* **CLI Orchestration**: Core executable terminal commands including project creation (`init`), generators (`g component`, `g bridge`, `g page`), and local serving configuration (`bin/avenx.js`).
+* **CLI Orchestration**: Core executable terminal commands including project creation (`init`), generators (`g component`, `g bridge`, `g page`), and local serving configuration (`bin/avenx.js`, `bin/cli.js`).
 * **Vite Integration**: High-efficiency Vite plugins supporting HMR, asset compilation, and dev server proxying (`vite-plugin-avenx/src`).
 * **Local Development Server**: Serving static files, local routing fallback support, and watch-mode reload events.
 
@@ -20,17 +20,29 @@ Build and maintain CLI helpers, build configurations, and bundling plugins (like
 
 When introducing new CLI subcommands (e.g., code scaffolding, type generators, or utility actions), adhere to the following modular structure rules:
 
-1. **Modular Directory Structure**: 
-   * Avoid monolith files. Place every distinct subcommand or generator module in its own dedicated file under `src/commands/` or `src/generators/`.
+1. **Modular Directory Structure**:
+   * Avoid monolith files. Place every distinct subcommand module in its own dedicated file under `bin/commands/` (for example `bin/commands/build.js`, `bin/commands/generate.js`).
+   * Keep shared filesystem helpers in `bin/utils.js` (or a focused utility module) instead of duplicating logic inside command files.
    * Keep command definitions decoupled from execution logic to ensure fast unit testing and modularity.
 
 2. **Standardized Help Mapping**:
-   * Every subcommand must implement automated or explicit help flags (`-h`, `--help`).
-   * Ensure standard help outputs print usage syntax, descriptions, and all configurable flags clearly.
-   * Map subcommands cleanly in the primary CLI routing table (`bin/avenx.js`) with appropriate aliases where relevant.
+   * Every subcommand must implement automated or explicit help flags (`-h`, `--help`) where applicable, and respect the global `help` command.
+   * Update `bin/commands/help.js` (`printHelp`) whenever you add or rename a command so usage syntax, descriptions, aliases, and flags stay accurate.
+   * Map subcommands in the primary CLI router (`bin/cli.js` → `AvenxCLI.run` `switch`) with aliases where relevant (for example `g` → `generate`, `d` → `destroy`, `b` → `build`).
+   * Keep top-level entry concerns (`Node` version checks, `--version`) in `bin/avenx.js`; keep command dispatch in `bin/cli.js`.
 
 3. **Isolated Logic & Clean Exports**:
    * CLI command handlers should only act as controller shells—delegate core filesystem and generation logic to pure utility modules.
+   * Export named functions from each `bin/commands/*.js` file and import them from `bin/cli.js` rather than inlining large blocks in the router.
+
+### Recipe: Adding a New Subcommand
+
+1. Create `bin/commands/<name>.js` exporting one or more handler functions that accept the CLI context (`this` / `cli` instance) and args.
+2. Import the handler in `bin/cli.js` and add a `case` (plus aliases) inside `AvenxCLI.run`.
+3. Document the command, aliases, and flags in `bin/commands/help.js`.
+4. Support non-interactive use: provide defaults, honor `--dry-run` / `-d` and `--force` / `-f` when the command writes or deletes files.
+5. Exit with non-zero status on failure; avoid interactive prompts unless a flag opts into them.
+6. Add or update unit/integration coverage for argument parsing and help text when practical.
 
 ## Rules
 
@@ -41,11 +53,12 @@ When introducing new CLI subcommands (e.g., code scaffolding, type generators, o
 ## Checklist
 
 * [ ] Validate CLI parsing parameters and ensure help output formatting prints correctly.
+* [ ] Confirm `bin/commands/help.js` lists every public command, alias, and flag introduced by the change.
 * [ ] Verify that HMR triggers on file updates, updating only the modified component without reloading the full browser page.
 * [ ] Check that newly generated components from templates contain standard valid placeholders and correct file paths.
 * [ ] Confirm dev server handles routing fallback gracefully when reloading SPA pages.
 * [ ] Check that build pipeline plugins output minified, ready-to-deploy assets in production mode.
-* [ ] Verify that new subcommands are cleanly modularized and mapped to help listings without cluttering core files.
+* [ ] Verify that new subcommands are cleanly modularized under `bin/commands/` and mapped in `bin/cli.js` without cluttering `bin/avenx.js`.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
Refines .agents/cli_agent.md with accurate in/commands/ / in/cli.js paths, help mapping rules, and a concrete recipe for adding new CLI subcommands.

Fixes #573.