### PR TITLE
feat(core): add $nextTick for post-DOM update callbacks

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -56,6 +56,19 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
     readonly $route: { hash: string; page: string; params: Record<string, any> };
 
     /**
+     * Runs after the current reactive DOM update flush completes.
+     * With a callback, invokes it after the flush. Without a callback, returns a Promise.
+     */
+    $nextTick(callback: () => void): void;
+    $nextTick(): Promise<void>;
+
+    /**
+     * Alias for {@link AvenxComponent#$nextTick}.
+     */
+    nextTick(callback: () => void): void;
+    nextTick(): Promise<void>;
+
+    /**
      * Keys or mappings to share reactively with descendant components.
      */
     provide?: Record<string, any> | (() => Record<string, any>) | string[];

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -474,6 +474,7 @@ export class AvenxComponent {
       $route: this.$route,
       $emit: (eventName, detail) => this.$emit(eventName, detail),
       $watch: (source, callback, options) => this.$watch(source, callback, options),
+      $nextTick: (callback) => this.$nextTick(callback),
       ...injected,
       ...extras,
     };
@@ -632,8 +633,17 @@ export class AvenxComponent {
    * @param {Function} [callback] - Optional callback to run after the flush.
    * @returns {Promise<void>|void} A promise resolving after the flush, if no callback was given.
    */
-  nextTick(callback) {
+  $nextTick(callback) {
     return schedulerNextTick(callback);
+  }
+
+  /**
+   * Alias for {@link AvenxComponent#$nextTick}.
+   * @param {Function} [callback] - Optional callback to run after the flush.
+   * @returns {Promise<void>|void}
+   */
+  nextTick(callback) {
+    return this.$nextTick(callback);
   }
 
   /**

--- a/test/unit/nextTick.test.js
+++ b/test/unit/nextTick.test.js
@@ -1,0 +1,65 @@
+import assert from 'assert';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+
+const mockElement = {
+  innerHTML: '',
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  dispatchEvent: () => {},
+  attributes: [],
+  hasAttribute: () => false,
+  setAttribute: () => {},
+  removeAttribute: () => {},
+  appendChild: () => {},
+  removeChild: () => {},
+  replaceWith: () => {},
+  childNodes: [],
+  __avenx_comp_instance: null,
+};
+
+global.document = {
+  querySelector: () => mockElement,
+};
+
+global.DOMParser = class {
+  parseFromString() {
+    return { body: mockElement };
+  }
+};
+
+global.Node = { ELEMENT_NODE: 1, TEXT_NODE: 3 };
+
+(async () => {
+  try {
+    console.log('🧪 Testing $nextTick...');
+
+    const comp = new AvenxComponent({ n: 0 }, {}, {}, '<div>{{state.n}}</div>', {});
+    comp.__setMountTarget(mockElement);
+    comp.__afterMount();
+
+    let callbackRan = false;
+    comp.state.n = 1;
+    comp.$nextTick(() => {
+      callbackRan = true;
+    });
+
+    assert.strictEqual(callbackRan, false, 'callback must not run synchronously');
+    await comp.$nextTick();
+    assert.strictEqual(callbackRan, true, 'callback must run after flush');
+
+    // Alias still works
+    let aliasRan = false;
+    await comp.nextTick(() => {
+      aliasRan = true;
+    });
+    // nextTick with callback returns void; wait one more tick to ensure flush completed
+    await comp.$nextTick();
+    assert.strictEqual(aliasRan, true, 'nextTick alias must invoke callback after flush');
+
+    console.log('✅ $nextTick tests passed!');
+    process.exit(0);
+  } catch (err) {
+    console.error('❌ $nextTick tests failed:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
Adds `this.$nextTick()` (callback + Promise) for post-DOM update synchronization, exposes it in template scope, and keeps `nextTick` as an alias. Includes unit coverage.

Fixes #802.