### PR TITLE
feat(testing): add AvenxMock.createMockRouter for isolated page tests

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -662,6 +662,26 @@ export class AvenxMock {
 
     static createSandbox(): AvenxSandbox;
 
+    static createMockRouter(options?: {
+        currentRoute?: { hash?: string; page?: string; params?: Record<string, any> };
+        hash?: string;
+        page?: string;
+        params?: Record<string, any>;
+        queryParams?: Record<string, any>;
+        guards?: Array<
+            | ((to: any, from: any) => boolean | string | void)
+            | { canActivate: (to: any, from: any) => boolean | string | void }
+        >;
+    }): {
+        currentRoute: { hash: string; page: string; params: Record<string, any> };
+        push(path: string): boolean;
+        replace(path: string): boolean;
+        getParams(): Record<string, any>;
+        $calls: Array<{ method: string; args: any[]; blocked?: boolean }>;
+        $reset(): void;
+        readonly $isMock: true;
+    };
+
     static trigger(element: any, eventName: string, eventData?: Record<string, any>): void;
 }
 

--- a/lib/core/runtime/AvenxMock.js
+++ b/lib/core/runtime/AvenxMock.js
@@ -155,6 +155,106 @@ export class AvenxMock {
   }
 
   /**
+   * Creates a lightweight mock router for isolated page / route-dependent tests.
+   * Attaches itself to `window.__avenx_routers` so component `$route` works.
+   *
+   * @param {object} [options]
+   * @param {object} [options.currentRoute] - Full route object override.
+   * @param {string} [options.hash] - Initial hash (default `#/`).
+   * @param {string} [options.page] - Active page name.
+   * @param {object} [options.params] - Path params.
+   * @param {object} [options.queryParams] - Query params (merged into `params.query`).
+   * @param {Array<Function|object>} [options.guards] - Optional guards run on push/replace.
+   * @returns {object} Mock router with `push`, `replace`, `getParams`, and `currentRoute`.
+   */
+  static createMockRouter(options = {}) {
+    const queryFromOptions =
+      options.queryParams ||
+      (options.currentRoute && options.currentRoute.params && options.currentRoute.params.query) ||
+      {};
+    const pathParams = {
+      ...(options.params || {}),
+      ...(options.currentRoute && options.currentRoute.params ? { ...options.currentRoute.params } : {}),
+    };
+    delete pathParams.query;
+    if (queryFromOptions && Object.keys(queryFromOptions).length > 0) {
+      pathParams.query = { ...queryFromOptions };
+    }
+
+    const currentRoute = {
+      hash:
+        (options.currentRoute && options.currentRoute.hash) ||
+        options.hash ||
+        '#/',
+      page: (options.currentRoute && options.currentRoute.page) || options.page || '',
+      params: pathParams,
+    };
+
+    const guards = Array.isArray(options.guards) ? options.guards.slice() : [];
+    const calls = [];
+
+    /**
+     * @param {string} path
+     * @param {'push'|'replace'} method
+     */
+    const navigate = (path, method) => {
+      const hash = path.startsWith('#') ? path : `#${path.startsWith('/') ? path : `/${path}`}`;
+      const nextRoute = {
+        hash,
+        page: currentRoute.page,
+        params: { ...currentRoute.params },
+      };
+
+      for (const guard of guards) {
+        const result =
+          typeof guard === 'function'
+            ? guard(nextRoute, { ...currentRoute })
+            : guard && typeof guard.canActivate === 'function'
+              ? guard.canActivate(nextRoute, { ...currentRoute })
+              : true;
+        if (result === false) {
+          calls.push({ method, args: [path], blocked: true });
+          return false;
+        }
+        if (typeof result === 'string') {
+          return navigate(result, method);
+        }
+      }
+
+      currentRoute.hash = nextRoute.hash;
+      currentRoute.params = nextRoute.params;
+      calls.push({ method, args: [path], blocked: false });
+      return true;
+    };
+
+    const mockRouter = {
+      currentRoute,
+      guards,
+      $calls: calls,
+      $isMock: true,
+      push(path) {
+        return navigate(path, 'push');
+      },
+      replace(path) {
+        return navigate(path, 'replace');
+      },
+      getParams() {
+        return { ...currentRoute.params };
+      },
+      $reset() {
+        calls.length = 0;
+      },
+    };
+
+    if (typeof window === 'undefined') {
+      global.window = global.window || {};
+    }
+    window.__avenx_routers = [mockRouter];
+
+    return mockRouter;
+  }
+
+  /**
    * Triggers an event on an element.
    * Supports standard DOM Event/CustomEvent and custom MockNode trigger method.
    * @param {Element} element
@@ -241,14 +341,13 @@ export class AvenxSandbox {
    * @returns {AvenxSandbox}
    */
   setRoute(route) {
-    if (typeof window === 'undefined') {
-      global.window = {};
-    }
-    window.__avenx_routers = [
-      {
-        currentRoute: route,
-      },
-    ];
+    AvenxMock.createMockRouter({
+      currentRoute: route,
+      hash: route && route.hash,
+      page: route && route.page,
+      params: route && route.params,
+      queryParams: route && route.params && route.params.query,
+    });
     return this;
   }
 

--- a/test/unit/mock.test.js
+++ b/test/unit/mock.test.js
@@ -146,6 +146,40 @@ class CounterComponent extends AvenxComponent {
     sandbox.setRoute({ hash: '#/users', page: 'users', params: { id: '99' } });
     assert.deepStrictEqual(mounted.instance.$route, { hash: '#/users', page: 'users', params: { id: '99' } });
 
+    // ==========================================
+    // 3. createMockRouter
+    // ==========================================
+    console.log('  Testing createMockRouter...');
+
+    const mockRouter = AvenxMock.createMockRouter({
+      hash: '#/dashboard',
+      page: 'Dashboard',
+      params: { id: '1' },
+      queryParams: { tab: 'overview' },
+    });
+
+    assert.strictEqual(mockRouter.$isMock, true);
+    assert.strictEqual(mockRouter.currentRoute.hash, '#/dashboard');
+    assert.strictEqual(mockRouter.getParams().id, '1');
+    assert.strictEqual(mockRouter.getParams().query.tab, 'overview');
+    assert.deepStrictEqual(mounted.instance.$route.hash, '#/dashboard');
+
+    mockRouter.push('#/settings');
+    assert.strictEqual(mockRouter.currentRoute.hash, '#/settings');
+    assert.strictEqual(mounted.instance.$route.hash, '#/settings');
+    assert.ok(mockRouter.$calls.some((c) => c.method === 'push' && c.args[0] === '#/settings'));
+
+    mockRouter.replace('/profile');
+    assert.strictEqual(mockRouter.currentRoute.hash, '#/profile');
+
+    const guarded = AvenxMock.createMockRouter({
+      hash: '#/private',
+      guards: [() => false],
+    });
+    const blocked = guarded.push('#/elsewhere');
+    assert.strictEqual(blocked, false);
+    assert.strictEqual(guarded.currentRoute.hash, '#/private');
+
     // Clean up global DOM mock
     teardownDOMMock();
 


### PR DESCRIPTION
## Summary
Adds `AvenxMock.createMockRouter()` with `push`/`replace`/`getParams`, optional guards, and automatic `$route` wiring via `window.__avenx_routers`. `setRoute` now reuses the helper.

Fixes #811.