### PR TITLE
feat(compiler): attach line and column numbers to parsed HTML nodes (…

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -1449,17 +1449,13 @@ class ${name} extends AvenxComponent {
  * A lightweight node representation for parsing HTML templates.
  */
 class HTMLNode {
-  /**
-   * @param {'element'|'text'|'comment'} type
-   * @param {string} [tagName]
-   * @param {Object<string, string|null>} [attrs]
-   * @param {boolean} [isSelfClosing]
-   */
   constructor(type, tagName = '', attrs = {}, isSelfClosing = false) {
     this.type = type;
     this.tagName = tagName;
     this.attrs = attrs;
     this.isSelfClosing = isSelfClosing;
+    this.line = null;
+    this.column = null;
     /** @type {HTMLNode[]} */
     this.children = [];
     this.content = '';
@@ -1559,6 +1555,31 @@ function parseAttributes(attrStr) {
  *   treated as void so it never requires a matching closing tag.
  * @returns {HTMLNode[]}
  */
+/**
+ * Calculates 1-based line and column numbers for a character offset in a source string.
+ * @param {string} source - The original source code string.
+ * @param {number} offset - The zero-based character index.
+ * @returns {{ line: number, column: number }}
+ */
+function getLineAndColumn(source, offset) {
+  let line = 1;
+  let lastNewline = -1;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source[i] === '\n') {
+      line++;
+      lastNewline = i;
+    }
+  }
+  const column = offset - lastNewline;
+  return { line, column };
+}
+
+/**
+ * Parses an HTML string into a tree of HTMLNode elements with positional metadata.
+ * @param {string} html
+ * @param {string[]} [customVoidTags]
+ * @returns {HTMLNode[]}
+ */
 function parseHTML(html, customVoidTags = []) {
   const root = new HTMLNode('element', 'root');
   const stack = [root];
@@ -1569,15 +1590,20 @@ function parseHTML(html, customVoidTags = []) {
   while (i < html.length) {
     // 1. Check for comment
     if (html.startsWith('<!--', i)) {
+      const pos = getLineAndColumn(html, i);
       const endIdx = html.indexOf('-->', i + 4);
       if (endIdx === -1) {
         const node = new HTMLNode('comment');
         node.content = html.substring(i + 4);
+        node.line = pos.line;
+        node.column = pos.column;
         stack[stack.length - 1].children.push(node);
         break;
       } else {
         const node = new HTMLNode('comment');
         node.content = html.substring(i + 4, endIdx);
+        node.line = pos.line;
+        node.column = pos.column;
         stack[stack.length - 1].children.push(node);
         i = endIdx + 3;
         continue;
@@ -1586,10 +1612,13 @@ function parseHTML(html, customVoidTags = []) {
 
     // 2. Check for closing tag
     if (html.startsWith('</', i)) {
+      const pos = getLineAndColumn(html, i);
       const endIdx = html.indexOf('>', i + 2);
       if (endIdx === -1) {
         const textNode = new HTMLNode('text');
         textNode.content = html.substring(i);
+        textNode.line = pos.line;
+        textNode.column = pos.column;
         stack[stack.length - 1].children.push(textNode);
         break;
       } else {
@@ -1606,6 +1635,8 @@ function parseHTML(html, customVoidTags = []) {
             stack.pop();
           }
         }
+        // If foundIdx === -1, silently skip unmatched closing tag
+        // to maintain backward compatibility with permissive template transforms
         i = endIdx + 1;
         continue;
       }
@@ -1613,6 +1644,7 @@ function parseHTML(html, customVoidTags = []) {
 
     // 3. Check for opening/self-closing tag
     if (html[i] === '<') {
+      const pos = getLineAndColumn(html, i);
       let tagEndIdx = -1;
       let inQuote = null;
       let tempIdx = i + 1;
@@ -1646,6 +1678,9 @@ function parseHTML(html, customVoidTags = []) {
           const attrs = parseAttributes(attrsStr);
           const isVoid = voidTags.has(tagName.toLowerCase());
           const node = new HTMLNode('element', tagName, attrs, isSelfClosing || isVoid);
+          node.line = pos.line;
+          node.column = pos.column;
+
           stack[stack.length - 1].children.push(node);
 
           if (!isSelfClosing && !isVoid) {
@@ -1658,6 +1693,7 @@ function parseHTML(html, customVoidTags = []) {
     }
 
     // 4. Text node
+    const textPos = getLineAndColumn(html, i);
     let nextTagIdx = html.indexOf('<', i + 1);
     if (nextTagIdx === -1) {
       nextTagIdx = html.length;
@@ -1665,7 +1701,6 @@ function parseHTML(html, customVoidTags = []) {
     const text = html.substring(i, nextTagIdx);
     if (text) {
       const parentNode = stack[stack.length - 1];
-      // Split text on interpolations (e.g. {{ ... }} and {{{ ... }}} or {% ... %})
       const parts = text.split(/(\{\{\{[\s\S]*?\}\}\}|\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\})/g);
       for (const part of parts) {
         if (!part) continue;
@@ -1681,6 +1716,8 @@ function parseHTML(html, customVoidTags = []) {
         } else {
           const textNode = new HTMLNode('text');
           textNode.content = part;
+          textNode.line = textPos.line;
+          textNode.column = textPos.column;
           parentNode.children.push(textNode);
         }
       }

--- a/test/unit/componentparser.test.js
+++ b/test/unit/componentparser.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import ComponentParser from '../../lib/compiler/ComponentParser.js';
+
+console.log('🧪 Testing ComponentParser line and column tracking (#810)...');
+
+const html = `<div>\n  <span>Hello</span>\n</div>`;
+const nodes = ComponentParser.parseHTML(html);
+
+// 1. Root <div> tag (line 1, col 1)
+assert.strictEqual(nodes[0].tagName, 'div', 'Root tag should be div');
+assert.strictEqual(nodes[0].line, 1, 'Root <div> should be on line 1');
+assert.strictEqual(nodes[0].column, 1, 'Root <div> should be at column 1');
+
+// 2. Nested <span> tag (line 2, col 3)
+const spanNode = nodes[0].children.find((c) => c.tagName === 'span');
+assert.ok(spanNode, 'span child node should exist');
+assert.strictEqual(spanNode.line, 2, 'Nested <span> should be on line 2');
+assert.strictEqual(spanNode.column, 3, 'Nested <span> should be at column 3');
+
+console.log('  ✅ Line and column tracking unit tests passed!');


### PR DESCRIPTION
## Description
Resolves #810

This PR enhances `ComponentParser` by attaching 1-based `line` and `column` numbers to parsed HTML nodes in template compilation.

### Edits
- Added `getLineAndColumn` utility function to map character string offsets to exact line and column numbers.
- Updated `HTMLNode` model to store `line` and `column` properties.
- Updated `parseHTML` in `lib/compiler/ComponentParser.js` to set positional metadata on element, text, and comment nodes.
- Added unit tests in `test/unit/componentparser.test.js` to ensure coordinate accuracy across multi-line templates.

### Checklist
- [x] Code builds clean (`npm run build`)
- [x] Unit tests added and passing (`npm test`)
- [x] Branch synced with upstream `main`