### PR TITLE
feat(events): support .passive and .capture event modifiers

### DIFF
--- a/docs/src/content/docs/core-concepts/events.md
+++ b/docs/src/content/docs/core-concepts/events.md
@@ -58,9 +58,11 @@ Compiled action handlers expose an implicit `args` array containing the argument
 Event bindings support dot-suffixed **modifiers** that adjust how the underlying DOM event is handled before your expression runs. Modifiers are appended directly to the event name, e.g. `@submit.prevent="save"` or `@keydown.enter="submit"`.
 | Modifier | Applies to | Behavior |
 |---|---|---|
-| `.prevent` | Any event | Calls `event.preventDefault()` before invoking the handler. |
+| `.prevent` | Any event | Calls `event.preventDefault()` before invoking the handler. Ignored when combined with `.passive` (browsers disallow `preventDefault` on passive listeners). |
 | `.stop` | Any event | Calls `event.stopPropagation()` before invoking the handler. |
 | `.once` | Any event | Automatically removes the listener after it fires a single time. |
+| `.passive` | Any event | Registers the listener with `{ passive: true }`, improving scroll/touch performance. |
+| `.capture` | Any event | Registers the listener with `{ capture: true }` so it runs in the capture phase. |
 | `.ctrl` | Mouse & Keyboard events | Only invokes handler if the `Control` key (`event.ctrlKey`) is held down. |
 | `.alt` | Mouse & Keyboard events | Only invokes handler if the `Alt` / `Option` key (`event.altKey`) is held down. |
 | `.shift` | Mouse & Keyboard events | Only invokes handler if the `Shift` key (`event.shiftKey`) is held down. |
@@ -72,7 +74,7 @@ Event bindings support dot-suffixed **modifiers** that adjust how the underlying
 | `.tab` | Keyboard events | Only invokes the handler if the pressed key is `Tab`. |
 | `.delete` | Keyboard events | Only invokes the handler if the pressed key is `Delete`. |
 
-### DOM Modifiers (`.prevent`, `.stop`, `.once`)
+### DOM Modifiers (`.prevent`, `.stop`, `.once`, `.passive`, `.capture`)
 
 `.prevent` and `.stop` wrap the handler with the corresponding DOM method call:
 
@@ -89,6 +91,14 @@ Event bindings support dot-suffixed **modifiers** that adjust how the underlying
 
 ```html
 <button @click.once="dismissBanner()">Got it</button>
+```
+
+`.passive` and `.capture` map to `addEventListener` options. Chain them with other modifiers (for example `@scroll.passive.once`):
+
+```html
+<div @scroll.passive="onScroll()">Scroll container</div>
+<div @click.capture="onClickCapture()">Capture-phase click</div>
+<div @touchstart.passive.capture="onTouch()">Passive capture touch</div>
 ```
 
 ### System Key Modifiers (`.ctrl`, `.alt`, `.shift`, `.meta`, `.cmd`)

--- a/lib/core/events/bindEvents.js
+++ b/lib/core/events/bindEvents.js
@@ -38,10 +38,34 @@ function belongsToComponent(element, root) {
 export class EventBinder {
   /**
    * Stores bound events and handlers.
-   * @type {WeakMap<Element, Map<string, Function>>}
+   * @type {WeakMap<Element, Map<string, {handler: Function, options: object}>>}
    * @private
    */
   #boundEvents = new WeakMap();
+
+  /**
+   * Builds addEventListener options from OR'd passive/capture flags.
+   * @param {{passive?: boolean, capture?: boolean}} flags
+   * @returns {{passive?: boolean, capture?: boolean}}
+   * @private
+   */
+  #toListenerOptions(flags) {
+    const options = {};
+    if (flags && flags.passive) options.passive = true;
+    if (flags && flags.capture) options.capture = true;
+    return options;
+  }
+
+  /**
+   * ORs `.passive` / `.capture` modifiers into an options flags object.
+   * @param {{passive: boolean, capture: boolean}} flags
+   * @param {string[]} modifiers
+   * @private
+   */
+  #orListenerFlags(flags, modifiers) {
+    if (modifiers.includes('passive')) flags.passive = true;
+    if (modifiers.includes('capture')) flags.capture = true;
+  }
 
   /**
    * Stores elements and executed modifier keys for once handlers.
@@ -129,14 +153,27 @@ export class EventBinder {
   #bindDelegated(root, dispatcher) {
     const COMMON_EVENTS = ['click', 'input', 'change', 'keydown'];
     const eventNames = new Set(COMMON_EVENTS);
+    /** @type {Map<string, {passive: boolean, capture: boolean}>} */
+    const eventFlags = new Map();
+
+    const ensureFlags = (eventName) => {
+      if (!eventFlags.has(eventName)) {
+        eventFlags.set(eventName, { passive: false, capture: false });
+      }
+      return eventFlags.get(eventName);
+    };
+
+    COMMON_EVENTS.forEach((name) => ensureFlags(name));
 
     const traverse = (node) => {
       if (node.nodeType !== 1) return;
 
       const handlers = this.#getEventHandlers(node);
       handlers.forEach((h) => {
-        const baseEventName = h.fullName.split('.')[0];
+        const parts = h.fullName.split('.');
+        const baseEventName = parts[0];
         eventNames.add(baseEventName);
+        this.#orListenerFlags(ensureFlags(baseEventName), parts.slice(1));
       });
 
       if (node.nodeName === 'SLOT' && node.hasAttribute && node.hasAttribute('data-avenx-transcluded')) {
@@ -167,9 +204,11 @@ export class EventBinder {
 
     eventNames.forEach((eventName) => {
       if (delegatedMap.has(eventName)) {
-        const oldHandler = delegatedMap.get(eventName);
+        const oldEntry = delegatedMap.get(eventName);
+        const oldHandler = typeof oldEntry === 'function' ? oldEntry : oldEntry.handler;
+        const oldOptions = typeof oldEntry === 'function' ? undefined : oldEntry.options;
         if (typeof root.removeEventListener === 'function') {
-          root.removeEventListener(eventName, oldHandler);
+          root.removeEventListener(eventName, oldHandler, oldOptions);
         }
         delegatedMap.delete(eventName);
         existing.delete(eventName);
@@ -206,11 +245,13 @@ export class EventBinder {
         }
       };
 
+      const options = this.#toListenerOptions(eventFlags.get(eventName));
       if (typeof root.addEventListener === 'function') {
-        root.addEventListener(eventName, handler);
+        root.addEventListener(eventName, handler, options);
       }
-      delegatedMap.set(eventName, handler);
-      existing.set(eventName, handler);
+      const entry = { handler, options };
+      delegatedMap.set(eventName, entry);
+      existing.set(eventName, entry);
       this.#boundEvents.set(root, existing);
     });
   }
@@ -220,18 +261,22 @@ export class EventBinder {
    */
   #unbindDelegated(root) {
     if (root.__avenxDelegatedListeners) {
-      root.__avenxDelegatedListeners.forEach((handler, eventName) => {
+      root.__avenxDelegatedListeners.forEach((entry, eventName) => {
+        const handler = typeof entry === 'function' ? entry : entry.handler;
+        const options = typeof entry === 'function' ? undefined : entry.options;
         if (typeof root.removeEventListener === 'function') {
-          root.removeEventListener(eventName, handler);
+          root.removeEventListener(eventName, handler, options);
         }
       });
       delete root.__avenxDelegatedListeners;
     }
     const existing = this.#boundEvents.get(root);
     if (existing) {
-      existing.forEach((handler, eventName) => {
+      existing.forEach((entry, eventName) => {
+        const handler = typeof entry === 'function' ? entry : entry.handler;
+        const options = typeof entry === 'function' ? undefined : entry.options;
         if (typeof root.removeEventListener === 'function') {
-          root.removeEventListener(eventName, handler);
+          root.removeEventListener(eventName, handler, options);
         }
       });
       this.#boundEvents.delete(root);
@@ -270,13 +315,26 @@ export class EventBinder {
       const handlers = this.#getEventHandlers(el);
 
       // Remove any existing direct listeners on el before binding new ones
-      directMap.forEach((oldHandler, baseEventName) => {
+      directMap.forEach((oldEntry, baseEventName) => {
+        const oldHandler = typeof oldEntry === 'function' ? oldEntry : oldEntry.handler;
+        const oldOptions = typeof oldEntry === 'function' ? undefined : oldEntry.options;
         if (typeof el.removeEventListener === 'function') {
-          el.removeEventListener(baseEventName, oldHandler);
+          el.removeEventListener(baseEventName, oldHandler, oldOptions);
         }
       });
       directMap.clear();
       existing.clear();
+
+      /** @type {Map<string, {passive: boolean, capture: boolean}>} */
+      const eventFlags = new Map();
+      handlers.forEach((h) => {
+        const parts = h.fullName.split('.');
+        const baseEventName = parts[0];
+        if (!eventFlags.has(baseEventName)) {
+          eventFlags.set(baseEventName, { passive: false, capture: false });
+        }
+        this.#orListenerFlags(eventFlags.get(baseEventName), parts.slice(1));
+      });
 
       handlers.forEach((h) => {
         const parts = h.fullName.split('.');
@@ -296,11 +354,13 @@ export class EventBinder {
               }
             });
           };
+          const options = this.#toListenerOptions(eventFlags.get(baseEventName));
           if (typeof el.addEventListener === 'function') {
-            el.addEventListener(baseEventName, handler);
+            el.addEventListener(baseEventName, handler, options);
           }
-          directMap.set(baseEventName, handler);
-          existing.set(baseEventName, handler);
+          const entry = { handler, options };
+          directMap.set(baseEventName, entry);
+          existing.set(baseEventName, entry);
           this.#boundEvents.set(el, existing);
         }
       });
@@ -384,7 +444,13 @@ export class EventBinder {
     }
 
     // 4. Apply prevent & stop modifiers
-    if (modifiers.includes('prevent') && event && typeof event.preventDefault === 'function') {
+    // Skip preventDefault when .passive is present — browsers ignore it on passive listeners
+    if (
+      modifiers.includes('prevent') &&
+      !modifiers.includes('passive') &&
+      event &&
+      typeof event.preventDefault === 'function'
+    ) {
       event.preventDefault();
     }
     if (modifiers.includes('stop') && event && typeof event.stopPropagation === 'function') {
@@ -420,9 +486,11 @@ export class EventBinder {
 
     elements.forEach((el) => {
       if (el.__avenxDirectListeners) {
-        el.__avenxDirectListeners.forEach((handler, eventName) => {
+        el.__avenxDirectListeners.forEach((entry, eventName) => {
+          const handler = typeof entry === 'function' ? entry : entry.handler;
+          const options = typeof entry === 'function' ? undefined : entry.options;
           if (typeof el.removeEventListener === 'function') {
-            el.removeEventListener(eventName, handler);
+            el.removeEventListener(eventName, handler, options);
           }
         });
         delete el.__avenxDirectListeners;
@@ -430,9 +498,11 @@ export class EventBinder {
 
       const existing = this.#boundEvents.get(el);
       if (existing) {
-        existing.forEach((handler, eventName) => {
+        existing.forEach((entry, eventName) => {
+          const handler = typeof entry === 'function' ? entry : entry.handler;
+          const options = typeof entry === 'function' ? undefined : entry.options;
           if (typeof el.removeEventListener === 'function') {
-            el.removeEventListener(eventName, handler);
+            el.removeEventListener(eventName, handler, options);
           }
         });
         this.#boundEvents.delete(el);

--- a/test/unit/eventModifiers.test.js
+++ b/test/unit/eventModifiers.test.js
@@ -25,13 +25,16 @@ try {
       getAttribute(name) {
         return attributes[name] !== undefined ? attributes[name] : null;
       },
-      addEventListener(event, callback) {
-        listeners[event] = callback;
+      addEventListener(event, callback, options) {
+        listeners[event] = { callback, options };
       },
-      removeEventListener(event, callback) {
-        if (listeners[event] === callback) {
+      removeEventListener(event, callback, options) {
+        const entry = listeners[event];
+        if (entry && entry.callback === callback) {
           delete listeners[event];
         }
+        if (!this._removes) this._removes = [];
+        this._removes.push({ event, callback, options });
       },
       querySelectorAll(selector) {
         if (selector === '*') {
@@ -60,7 +63,9 @@ try {
         let current = this;
         while (current) {
           if (current.listeners && current.listeners[event]) {
-            current.listeners[event](data);
+            const entry = current.listeners[event];
+            const callback = typeof entry === 'function' ? entry : entry.callback;
+            callback(data);
           }
           if (data.cancelBubble) {
             break;
@@ -277,6 +282,94 @@ try {
   const template = cp.extractTemplate(content, {}, 'TestComp');
   assert.ok(template.includes('data-ax-event="{&quot;click.prevent.once&quot;:&quot;handleClick&quot;}"'), 'Template should compile click.prevent.once to data-ax-event');
   assert.ok(template.includes('@keyup.enter="handleEnter"'), 'Template should compile keyup.enter');
+
+  // 14. Test .passive modifier passes { passive: true } to addEventListener
+  const passiveEl = createMockElement('DIV', { '@scroll.passive': 'handleScroll' });
+  binder.bind(passiveEl, dispatcher);
+  assert.ok(passiveEl.listeners.scroll, '.passive should register a scroll listener');
+  assert.deepStrictEqual(
+    passiveEl.listeners.scroll.options,
+    { passive: true },
+    '.passive should pass { passive: true } to addEventListener'
+  );
+  resetDispatcher();
+  passiveEl.trigger('scroll', { type: 'scroll' });
+  assert.strictEqual(executedSource, 'handleScroll', '.passive handler should still execute');
+
+  // 15. Test .capture modifier passes { capture: true } to addEventListener
+  const captureEl = createMockElement('DIV', { '@click.capture': 'handleCapture' });
+  binder.bind(captureEl, dispatcher);
+  assert.ok(captureEl.listeners.click, '.capture should register a click listener');
+  assert.deepStrictEqual(
+    captureEl.listeners.click.options,
+    { capture: true },
+    '.capture should pass { capture: true } to addEventListener'
+  );
+  resetDispatcher();
+  captureEl.trigger('click', { type: 'click' });
+  assert.strictEqual(executedSource, 'handleCapture', '.capture handler should still execute');
+
+  // 16. Test chaining .passive.once
+  const passiveOnceEl = createMockElement('DIV', { '@scroll.passive.once': 'handleScrollOnce' });
+  binder.bind(passiveOnceEl, dispatcher);
+  assert.deepStrictEqual(
+    passiveOnceEl.listeners.scroll.options,
+    { passive: true },
+    '@scroll.passive.once should pass { passive: true }'
+  );
+  resetDispatcher();
+  passiveOnceEl.trigger('scroll', { type: 'scroll' });
+  assert.strictEqual(executionCount, 1, 'First passive.once trigger should run');
+  passiveOnceEl.trigger('scroll', { type: 'scroll' });
+  assert.strictEqual(executionCount, 1, 'Second passive.once trigger should NOT run');
+
+  // 17. Test .passive + .capture together
+  const bothEl = createMockElement('DIV', { '@touchstart.passive.capture': 'handleTouch' });
+  binder.bind(bothEl, dispatcher);
+  assert.deepStrictEqual(
+    bothEl.listeners.touchstart.options,
+    { passive: true, capture: true },
+    '.passive.capture should OR both options'
+  );
+
+  // 18. Test .passive.prevent skips preventDefault
+  const passivePreventEl = createMockElement('DIV', { '@wheel.passive.prevent': 'handleWheel' });
+  binder.bind(passivePreventEl, dispatcher);
+  resetDispatcher();
+  let passivePreventCalled = false;
+  passivePreventEl.trigger('wheel', {
+    type: 'wheel',
+    preventDefault() {
+      passivePreventCalled = true;
+    },
+  });
+  assert.strictEqual(executedSource, 'handleWheel');
+  assert.strictEqual(passivePreventCalled, false, '.passive.prevent should skip preventDefault()');
+
+  // 19. Test removeEventListener receives matching capture option
+  const captureUnbindEl = createMockElement('DIV', { '@click.capture': 'handleCaptureUnbind' });
+  binder.bind(captureUnbindEl, dispatcher);
+  const captureCallback = captureUnbindEl.listeners.click.callback;
+  binder.unbind(captureUnbindEl);
+  assert.strictEqual(captureUnbindEl.listeners.click, undefined, 'unbind should remove capture listener');
+  const clickRemove = (captureUnbindEl._removes || []).find((r) => r.event === 'click' && r.callback === captureCallback);
+  assert.ok(clickRemove, 'unbind should call removeEventListener for click');
+  assert.deepStrictEqual(
+    clickRemove.options,
+    { capture: true },
+    'removeEventListener must receive matching { capture: true }'
+  );
+
+  // 20. Test data-ax-event JSON keys with .passive / .capture
+  const dataAxEl = createMockElement('DIV', {
+    'data-ax-event': JSON.stringify({
+      'scroll.passive': 'onScroll',
+      'click.capture': 'onClick',
+    }),
+  });
+  binder.bind(dataAxEl, dispatcher);
+  assert.deepStrictEqual(dataAxEl.listeners.scroll.options, { passive: true });
+  assert.deepStrictEqual(dataAxEl.listeners.click.options, { capture: true });
 
   console.log('  ✅ Event Modifiers tests passed!');
 } catch (error) {


### PR DESCRIPTION
## Summary
Adds `.passive` and `.capture` event modifiers so listeners register with matching `addEventListener` options (including chained forms like `@scroll.passive.once`).

Fixes #803.