### PR TITLE
feat(core): resolve data-ax-ref to component instances and type $refs

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -40,6 +40,12 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
     readonly $parent: AvenxComponent<any> | null;
 
     /**
+     * Template refs collected from `data-ax-ref` markers.
+     * Resolves to a component instance when the host element has `__avenx_comp_instance`, otherwise the DOM element.
+     */
+    readonly $refs: Record<string, Element | AvenxComponent<any> | undefined>;
+
+    /**
      * Helpers for inspecting whether the parent provided slot content.
      */
     readonly $slots: {

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -873,7 +873,8 @@ export class AvenxComponent {
       const refName = element.getAttribute('data-ax-ref');
 
       if (refName && refName.trim()) {
-        this.#refsCache[refName.trim()] = element;
+        // Prefer the mounted component instance when present (Vue-like $refs behavior)
+        this.#refsCache[refName.trim()] = element.__avenx_comp_instance || element;
       }
     });
   }

--- a/test/unit/componentRefs.test.js
+++ b/test/unit/componentRefs.test.js
@@ -55,6 +55,33 @@ function testComponentRefScoping() {
 }
 
 /**
+ * Tests that a ref on an element with __avenx_comp_instance resolves to the instance.
+ */
+function testComponentRefResolvesToInstance() {
+  console.log('🧪 Testing data-ax-ref resolving to component instance...');
+
+  const component = new AvenxComponent({}, {}, {}, '<div data-ax-ref="childHost"></div>');
+  const root = document.createElement('div');
+
+  component.__setMountTarget(root);
+  component.runUpdate();
+
+  const host = root.childNodes[0];
+  assert.ok(host, 'Host element should be created');
+
+  const fakeInstance = { __isFakeChild: true };
+  host.__avenx_comp_instance = fakeInstance;
+
+  assert.strictEqual(
+    component.$refs.childHost,
+    fakeInstance,
+    '$refs.childHost should resolve to __avenx_comp_instance.',
+  );
+
+  console.log('  ✅ data-ax-ref on component host resolves to the instance.');
+}
+
+/**
  * Tests that refs are cleared when the component is unmounted.
  */
 function testComponentRefCleanup() {
@@ -131,6 +158,7 @@ function runTests() {
   try {
     testComponentRefCollection();
     testComponentRefScoping();
+    testComponentRefResolvesToInstance();
     testComponentRefCleanup();
     testBatchedRefResolution();
 


### PR DESCRIPTION
## Summary
`$refs` now resolves to the child component instance when `data-ax-ref` is on a component host, and `$refs` is typed on `AvenxComponent`.

Fixes #804.