### PR TITLE
refactor(app): add runtime type validation and helpful warnings

### DIFF
--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -131,6 +131,23 @@ export class AvenxApp {
    * @param {typeof AvenxComponent} compClass - The component class.
    */
   register(name, compClass) {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      const msg = `Component name must be a non-empty string. received: "${JSON.stringify(name)}"`;
+      logger.warn(msg);
+      throw new Error(msg);
+    }
+
+    const isFunction = typeof compClass === 'function';
+    const extendsBase = isFunction && compClass.prototype instanceof AvenxComponent;
+
+    if (!isFunction || !extendsBase) {
+      const receivedType = isFunction ? (compClass.name || 'anonymous function') : typeof compClass;
+      const msg = `Component "${name}" must be a class extending AvenxComponent. received: "${receivedType}"`;
+      logger.warn(msg);
+      throw new Error(msg);
+
+    }
+
     if (this.components.has(name)) {
       throw new AvenxError(AvenxErrorCodes.COMPILER_DUPLICATE_COMPONENT_NAME, `  "${name}"`);
     }
@@ -143,6 +160,23 @@ export class AvenxApp {
    * @param {typeof AvenxPage} pageClass - The page class.
    */
   registerPage(name, pageClass) {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      const msg = `Page name must be a non-empty string. received: "${JSON.stringify(name)}"`;
+      logger.warn(msg);
+      throw new Error(msg);
+    }
+
+    const isFunction = typeof pageClass === 'function';
+    const extendsBase = isFunction && pageClass.prototype instanceof AvenxComponent;
+
+    if (!isFunction || !extendsBase) {
+      const receivedType = isFunction ? (pageClass.name || 'anonymous function') : typeof pageClass;
+      const msg = `Page "${name}" must be a class extending AvenxComponent. received: "${receivedType}"`;
+      logger.warn(msg);
+      throw new Error(msg);
+
+    }
+
     if (this.pages.has(name)) {
       logger.warn(formatMessage(AvenxErrorCodes.PAGE_ALREADY_REGISTERED, name));
     }
@@ -188,6 +222,12 @@ export class AvenxApp {
    * @param {object | Function} bridgeData - The bridge data or constructor.
    */
   registerBridge(name, bridgeData) {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      const msg = `Bridge name must be a non-empty string. received: "${JSON.stringify(name)}"`;
+      logger.warn(msg);
+      throw new Error(msg);
+    }
+
     if (Object.prototype.hasOwnProperty.call(this.bridges, name)) {
       const availableBridges = Object.keys(this.bridges).join(',');
       const suggestion = `Please use a unique name`;
@@ -205,7 +245,7 @@ export class AvenxApp {
     }
 
     const handlerFactory = new ProxyHandlerFactory({
-      onChange: () => {},
+      onChange: () => { },
     });
     const reactiveState = new Proxy(instance, handlerFactory.create());
     this.bridges[name] = reactiveState;
@@ -370,7 +410,7 @@ export class AvenxApp {
             inst.$app = this;
             inst.$pageName = pName;
             inst.$keepAlive = !!options.keepAlive;
-            
+
             inst.params = pParams;
             for (const [key, val] of Object.entries(pParams)) {
               inst.state[key] = val;
@@ -378,7 +418,7 @@ export class AvenxApp {
 
             inst.mount(mTarget);
           }
-          
+
           if (isCached) {
             inst.params = pParams;
             for (const [key, val] of Object.entries(pParams)) {
@@ -402,7 +442,7 @@ export class AvenxApp {
           wrapper.setAttribute('data-ax-router-view', 'true');
           this.#target.appendChild(wrapper);
           const layoutInst = setupPage(LayoutClass, options.layout, params, this.#target, true);
-          
+
           // Re-find wrapper in case it moved to slot
           wrapper = layoutInst.$element ? layoutInst.$element.querySelector('[data-ax-router-view]') : wrapper;
           setupPage(PageClass, name, params, wrapper, false);


### PR DESCRIPTION
Add input validation to `register()`, `registerPage()`, and `registerBridge()` to catch invalid component/page names and non-function component classes early, with clear error messages instead of silent failures or confusing TypeErrors during mount.