### PR TITLE
feat(config): support custom path alias mapping in avenx.config.json …

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -7,6 +7,7 @@ import { TemplateValidationError, BuildError } from './errors/index.js';
 import { reportWarning } from './utils/warningReporter.js';
 import { replaceEnvVariables } from '../env.js';
 import { processBindDirectives } from '../core/utils/templateUtils.js';
+import loadConfig, { resolvePathAlias } from '../config.js';
 
 /**
  * The set of HTML tags that are void (self-closing / no children) by
@@ -141,6 +142,10 @@ class ComponentParser {
    * @returns {string} The generated JavaScript class.
    */
   parse(filePath, type = 'component') {
+    const config = this.config || (filePath ? loadAvenxConfig(path.dirname(filePath)) : null);
+    const rootDir = filePath ? loadConfig.findProjectRoot(path.dirname(filePath)) : process.cwd();
+    filePath = resolvePathAlias(filePath, config, rootDir);
+
     const isPage = type === 'page';
     const suffix = isPage ? '.page.js' : '.component.js';
     const content = replaceEnvVariables(fs.readFileSync(filePath, 'utf-8'));
@@ -171,7 +176,6 @@ class ComponentParser {
       this.extractStylesAndVars(desContent, desBlocks, desPath);
     }
 
-    const config = this.config || (filePath ? loadAvenxConfig(path.dirname(filePath)) : null);
     const state = this.extractState(content, filePath, config);
     const computed = this.extractComputed(content);
     const methods = this.extractMethods(content);

--- a/lib/config.js
+++ b/lib/config.js
@@ -100,6 +100,7 @@ function loadConfig(baseDir) {
     srcDir: 'src',
     distDir: 'dist',
     templatesDir: '.avenxtemplates',
+    alias: {}, // <--- ALIAS DEFAULT
     server: {
       port: 3000,
       host: 'localhost',
@@ -141,6 +142,7 @@ function loadConfig(baseDir) {
         'warnings',
         'treeShakeComponents',
         'preprocessors',
+        'alias'
       ];
       for (const key of Object.keys(userConfig)) {
         if (!allowedTopLevel.includes(key)) {
@@ -195,6 +197,12 @@ function loadConfig(baseDir) {
     if (userConfig.warnings !== undefined) {
       if (typeof userConfig.warnings !== 'object' || userConfig.warnings === null || Array.isArray(userConfig.warnings)) {
         throw new Error('warnings must be an object');
+      }
+    }
+
+    if (userConfig.alias !== undefined) {
+      if (typeof userConfig.alias !== 'object' || userConfig.alias === null || Array.isArray(userConfig.alias)) {
+        throw new Error('alias must be an object');
       }
     }
 
@@ -303,3 +311,26 @@ function loadConfig(baseDir) {
 loadConfig.findProjectRoot = findProjectRoot;
 
 export default loadConfig;
+
+/**
+ * Resolves a path alias (e.g., "@/components/Header") to its absolute or root-relative path.
+ * @param {string} importPath - The import string to resolve.
+ * @param {object} [config] - The parsed Avenx config object.
+ * @param {string} [rootDir] - The root project directory.
+ * @returns {string} The resolved file path or original string if no alias matched.
+ */
+export function resolvePathAlias(importPath, config = {}, rootDir = process.cwd()) {
+  if (!importPath || typeof importPath !== 'string') return importPath;
+  const safeConfig = config || {};
+  const aliases = safeConfig.alias || {};
+
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (importPath === alias || importPath.startsWith(alias + '/')) {
+      const relativePart = importPath.slice(alias.length);
+      const targetPath = path.isAbsolute(target) ? target : path.join(rootDir, target);
+      return path.normalize(path.join(targetPath, relativePart));
+    }
+  }
+
+  return importPath;
+}

--- a/test/unit/cliConfig.test.js
+++ b/test/unit/cliConfig.test.js
@@ -152,8 +152,8 @@ try {
         `Unexpected warning: ${warnings[0]}`
       );
       assert.ok(
-        warnings[0].includes('Supported top-level options are: srcDir, distDir, templatesDir, server, style, debug, outputName, logging, voidTags, warnings, treeShakeComponents, preprocessors.'),
-        `Unexpected warning: ${warnings[0]}`
+        warnings[0].includes('Supported top-level options are: srcDir, distDir, templatesDir, server, style, debug, outputName, logging, voidTags, warnings, treeShakeComponents, preprocessors, alias.'),
+        `Unexpected warning options list: ${warnings[0]}`
       );
       warnings.length = 0;
 

--- a/test/unit/pathAlias.test.js
+++ b/test/unit/pathAlias.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import path from 'path';
+import loadConfig, { resolvePathAlias } from '../../lib/config.js';
+
+console.log('🧪 Testing Path Alias Resolution (#821)...');
+
+const mockConfig = {
+  alias: {
+    '@': './src',
+    '@components': './src/components'
+  }
+};
+const mockRootDir = '/workspace/project';
+
+// Test `@/` mapping
+const resolved1 = resolvePathAlias('@/components/Header.js', mockConfig, mockRootDir);
+assert.strictEqual(resolved1, path.normalize('/workspace/project/src/components/Header.js'));
+
+// Test custom alias mapping
+const resolved2 = resolvePathAlias('@components/Button.js', mockConfig, mockRootDir);
+assert.strictEqual(resolved2, path.normalize('/workspace/project/src/components/Button.js'));
+
+// Test relative path remains untouched
+const resolved3 = resolvePathAlias('./relative/path.js', mockConfig, mockRootDir);
+assert.strictEqual(resolved3, './relative/path.js');
+
+console.log('  ✅ Path Alias unit tests passed!');


### PR DESCRIPTION
## Description

Adds support for custom path alias mapping (e.g., `@/` imports) configured via `avenx.config.json`.

### Edits
- Added `alias` configuration key support and validation to `loadConfig` in `lib/config.js`.
- Implemented `resolvePathAlias()` helper function to map aliased imports/paths to absolute or root-relative paths.
- Integrated `resolvePathAlias()` into `ComponentParser.js` for template and component import resolution.
- Added unit test suite in `test/unit/pathAlias.test.js`.
- Updated CLI configuration warning test assertions in `test/unit/cliConfig.test.js`.

### Checklist
- [x] Code builds clean (`npm run build`)
- [x] All unit and integration tests passing (`npm test`)
- [x] Branch synced with upstream `main`