### PR TITLE
feat(vite-plugin-avenx): add version logging banner

### DIFF
--- a/vite-plugin-avenx/src/index.js
+++ b/vite-plugin-avenx/src/index.js
@@ -2,6 +2,7 @@ import { createCompiler } from './compiler.js';
 import { wrapComponent, wrapPage } from './wrapper.js';
 import { handleAvenxHotUpdate } from './hmr.js';
 import { loadStyle } from './css.js';
+import pkg from '../package.json' with { type: 'json' };
 
 import {
   isComponentFile,
@@ -9,6 +10,8 @@ import {
   isComponentStyle,
   isPageStyle,
 } from './utils.js';
+
+const version = pkg.version;
 
 /**
  * Creates the Avenx Vite plugin.
@@ -35,6 +38,14 @@ export default function avenxPlugin(options = {}) {
     name: 'vite-plugin-avenx',
 
     enforce: 'pre',
+
+    /**
+     * Logs the plugin version when the Vite configuration has been resolved.
+     * @returns {void}
+     */
+    configResolved() {
+      console.log(`[vite-plugin-avenx] v${version} initialized`);
+    },
 
     /**
      * Resolves Avenx source files.


### PR DESCRIPTION
## Description

Adds a startup banner showing the loaded vite-plugin-avenx version when the Vite config is resolved.

Example output:

[vite-plugin-avenx] v0.0.1 initialized

## Changes Made

- Imported plugin version from vite-plugin-avenx/package.json
- Added configResolved hook to log initialization message
- Added JSDoc documentation for the new hook

Fixes #820

## Testing

- npm run lint
- npm test