### PR TITLE
fix: improve AVX_W19 list key evaluation warning

### DIFF
--- a/lib/core/renderer/listManager.js
+++ b/lib/core/renderer/listManager.js
@@ -17,10 +17,11 @@ export class ListManager {
    * @param {TemplateRenderer} renderer - The template renderer.
    * @param {EventBinder} [eventBinder] - The event binder to unbind removed elements.
    */
-  constructor(evaluator, renderer, eventBinder) {
+  constructor(evaluator, renderer, eventBinder, componentName) {
     this.evaluator = evaluator;
     this.renderer = renderer;
     this.eventBinder = eventBinder;
+    this.componentName = componentName;
     this.patcher = new DomPatcher();
     if (typeof document !== 'undefined' && typeof document.createElement === 'function') {
       this.parserDiv = document.createElement('div');
@@ -97,8 +98,8 @@ export class ListManager {
           key = this.evaluator.evaluateExpression(keyExpr, itemScope, state);
         } catch (e) {
           logger.warn(
-            formatMessage(AvenxErrorCodes.RENDER_KEY_EVALUATION_FAILED, keyExpr, e.message || e)
-          );
+            `[AVX_W19] Failed to evaluate key expression "${keyExpr}" in component <${this.componentName}>: ${e.message || e}`
+);
         }
       }
       return { item, key: String(key), itemScope, index };

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -190,7 +190,7 @@ export class AvenxComponent {
     this.#eventBinder = new EventBinder();
     this.#evaluator = new DynamicEvaluator();
     this.#lifecycle = new LifecycleManager();
-    this.#listManager = new ListManager(this.#evaluator, this.#renderer, this.#eventBinder);
+    this.#listManager = new ListManager(this.#evaluator, this.#renderer, this.#eventBinder, this.constructor.name);
 
     /** @type {AvenxWatcher[]} @private */
     this._watchers = [];

--- a/test/integration/list_duplicate_keys.test.js
+++ b/test/integration/list_duplicate_keys.test.js
@@ -372,6 +372,9 @@ global.Node = {
       evaluateExpression: (expr, scope) => {
         if (expr === 'items') return scope.items;
         if (expr === 'item') return scope.item;
+        if (expr === 'item.profile.id') {
+          throw new Error("Cannot read properties of undefined (reading 'id')");
+        }
         return null;
       },
     };
@@ -431,6 +434,36 @@ global.Node = {
 
     assert.strictEqual(listItemsUpdated[0].customState, 'first');
     assert.strictEqual(listItemsUpdated[1].customState, 'second');
+
+    // Test AVX_W19 includes the raw key expression and component name
+  warnings.length = 0;
+
+  const errorListTemplate = createMockElementNode('template', {
+    'data-ax-for': 'items',
+    'data-ax-as': 'item',
+    'data-ax-key': 'item.profile.id',
+  });
+  errorListTemplate.innerHTML = '<li>{%item%}</li>';
+  listContainer.appendChild(errorListTemplate);
+
+  const errorListManager = new ListManager(evaluator, renderer, undefined, 'UserCard');
+
+  errorListManager.process(
+    listContainer,
+    { items: ['apple'] },
+    {}
+  );
+
+  const hasKeyEvaluationWarning = warnings.some((w) =>
+    w.includes(
+      '[AVX_W19] Failed to evaluate key expression "item.profile.id" in component <UserCard>'
+    )
+  );
+
+  assert.ok(
+    hasKeyEvaluationWarning,
+    'Should include the raw key expression and component name in the AVX_W19 warning'
+  );
 
     // Restore original console.warn
     console.warn = originalConsoleWarn;


### PR DESCRIPTION
## Summary

Improves the AVX_W19 warning emitted when a `<@for>` list key expression fails to evaluate.

The warning now includes:
- The raw key expression that failed
- The component name where the failure occurred
- The original error message

## Testing

- Added regression coverage for failed key expression evaluation.
- `git diff --check` passes.
- Full test suite passes: 91/91 tests.