### PR TITLE
feat: add registered component and page inspection APIs

### DIFF
--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -185,6 +185,26 @@ export class AvenxApp {
   }
 
   /**
+   * Returns the names of all registered components.
+   *
+   * @returns {string[]} Registered component names.
+  */
+  getRegisteredComponents() {
+    return Array.from(this.components.keys());
+  }
+
+  /**
+   * Returns the names of all registered pages.
+   *
+   * @returns {string[]} Registered page names.
+  */
+  getRegisteredPages() {
+    return Array.from(this.pages.keys());
+  }
+
+
+
+  /**
    * Retrieves the currently active page component instance.
    * @returns {AvenxComponent|null}
    */

--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -186,18 +186,16 @@ export class AvenxApp {
 
   /**
    * Returns the names of all registered components.
-   *
    * @returns {string[]} Registered component names.
-  */
+   */
   getRegisteredComponents() {
     return Array.from(this.components.keys());
   }
 
   /**
    * Returns the names of all registered pages.
-   *
    * @returns {string[]} Registered page names.
-  */
+   */
   getRegisteredPages() {
     return Array.from(this.pages.keys());
   }

--- a/test/unit/AvenxApp.test.js
+++ b/test/unit/AvenxApp.test.js
@@ -1,0 +1,48 @@
+import assert from 'assert';
+import '../helpers/register-happy-dom.js';
+import { AvenxApp } from '../../lib/core/runtime/AvenxApp.js';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+
+console.log('Testing AvenxApp registration inspection APIs...');
+
+const container = document.createElement('div');
+container.id = 'app';
+document.body.appendChild(container);
+
+class TestComponent extends AvenxComponent {}
+
+class AnotherComponent extends AvenxComponent {}
+
+class HomePage extends AvenxComponent {}
+
+class AboutPage extends AvenxComponent {}
+
+const app = new AvenxApp({ target: '#app' });
+
+console.log('Testing registered component names...');
+
+app.register('TestComponent', TestComponent);
+app.register('AnotherComponent', AnotherComponent);
+
+assert.deepStrictEqual(
+  app.getRegisteredComponents(),
+  ['VirtualList', 'TestComponent', 'AnotherComponent'],
+  'getRegisteredComponents() should return registered component names',
+);
+
+console.log('Registered component names returned correctly.');
+
+console.log('Testing registered page names...');
+
+app.registerPage('HomePage', HomePage);
+app.registerPage('AboutPage', AboutPage);
+
+assert.deepStrictEqual(
+  app.getRegisteredPages(),
+  ['HomePage', 'AboutPage'],
+  'getRegisteredPages() should return registered page names',
+);
+
+console.log('Registered page names returned correctly.');
+
+console.log('AvenxApp registration inspection tests passed.');


### PR DESCRIPTION
## Summary

Adds public inspection methods to `AvenxApp` for retrieving registered component and page names.

## Changes

- Added `getRegisteredComponents()` to return registered component names.
- Added `getRegisteredPages()` to return registered page names.
- Added unit test coverage for both APIs.

## Testing

- `npm run test:unit`
- 74/74 tests passed.