### PR TITLE
feat(cli): sanitize host and port variables to prevent uncaught errors

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -129,12 +129,13 @@ export class AvenxCLI {
           this.config.server.liveReload = false;
         }
 
-        const port =
-          portIdx !== -1 && args[portIdx + 1]
-            ? parseInt(args[portIdx + 1], 10)
-            : (!args[0]?.startsWith('-') && args[0]) || process.env.PORT || this.config.server.port || 3000;
+        const rawPort = portIdx !== -1 ? args[portIdx + 1]?.replace(/[^0-9]/g, '') : null;
+        const port = rawPort
+          ? parseInt(rawPort, 10)
+          : (!args[0]?.startsWith('-') && args[0]) || process.env.PORT || this.config.server.port || 3000;
 
-        const host = hostIdx !== -1 && args[hostIdx + 1] ? args[hostIdx + 1] : 'localhost';
+        const rawHost = hostIdx !== -1 ? args[hostIdx + 1] : null;
+        const host = rawHost ? rawHost.trim().replace(/\/$/g, '') : 'localhost';
 
         serveProject(this, port, host);
         break;


### PR DESCRIPTION
When starting the dev server via avenx serve, trailing slashes or accidental whitespace in command-line arguments (like --port or --host) previously caused uncaught initialization errors.

This PR implements the proposed string trimming and numeric sanitization in bin/cli.js while maintaining the existing fallback logic.

 ### Specific changes:

Added a regex replacement (/[^0-9]/g) to the port variable to strip all non-numeric characters.

Chained .trim() and a regex replacement (/\/$/g) to the host variable to remove leading/trailing spaces and trailing forward slashes.

Preserved the original fallback chain (process.env.PORT, this.config.server.port, etc.).

### How to Test
Pull down this branch.

Run the server with a messy port argument: node bin/avenx.js serve --port 3000/

Verify the server successfully starts on port 3000 without throwing an uncaught initialization error.

Run the server with a messy host argument: node bin/avenx.js serve --host localhost/