### PR TITLE
feat: sanitize trailing slashes and spaces in CLI server options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,6 +33,15 @@ export class AvenxCLI {
   }
 
   /**
+   * Serves the project on specified port and host.
+   * @param {number} port
+   * @param {string} host
+   */
+  serveProject(port, host) {
+    return serveProject(this, port, host);
+  }
+
+  /**
    * Executes a given CLI command with provided arguments.
    * @param {string} command - The command to run (e.g., 'init', 'generate', 'build', 'serve', 'help').
    * @param {string[]} args - Additional arguments for the command.
@@ -122,22 +131,27 @@ export class AvenxCLI {
         runInspect(this);
         break;
       case 'serve': {
-        const portIdx = args.findIndex((a) => a === '--port' || a === '-p');
-        const hostIdx = args.findIndex((a) => a === '--host' || a === '-h');
+        const portIdx = args.findIndex((a) => a === '--port' || a === '-p' || a.startsWith('--port=') || a.startsWith('-p='));
+        const hostIdx = args.findIndex((a) => a === '--host' || a === '-h' || a.startsWith('--host=') || a.startsWith('-h='));
 
         if (args.includes('--no-live-reload') || args.includes('--live-reload=false')) {
           this.config.server.liveReload = false;
         }
 
-        const rawPort = portIdx !== -1 ? args[portIdx + 1]?.replace(/[^0-9]/g, '') : null;
+        const rawPortVal = portIdx !== -1
+          ? (args[portIdx].includes('=') ? args[portIdx].split('=').slice(1).join('=') : args[portIdx + 1])
+          : (!args[0]?.startsWith('-') ? args[0] : null);
+        const rawPort = rawPortVal?.replace(/[^0-9]/g, '');
         const port = rawPort
           ? parseInt(rawPort, 10)
-          : (!args[0]?.startsWith('-') && args[0]) || process.env.PORT || this.config.server.port || 3000;
+          : (process.env.PORT ? parseInt(String(process.env.PORT).replace(/[^0-9]/g, ''), 10) : null) || this.config.server?.port || 3000;
 
-        const rawHost = hostIdx !== -1 ? args[hostIdx + 1] : null;
-        const host = rawHost ? rawHost.trim().replace(/\/$/g, '') : 'localhost';
+        const rawHostVal = hostIdx !== -1
+          ? (args[hostIdx].includes('=') ? args[hostIdx].split('=').slice(1).join('=') : args[hostIdx + 1])
+          : null;
+        const host = rawHostVal ? rawHostVal.trim().replace(/\/+$/g, '') : 'localhost';
 
-        serveProject(this, port, host);
+        this.serveProject(port, host);
         break;
       }
       case 'watch':

--- a/test/unit/serve.test.js
+++ b/test/unit/serve.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { EventEmitter } from 'events';
 import { listenWithPortFallback } from '../../bin/commands/serve.js';
+import { AvenxCLI } from '../../bin/cli.js';
 
 class OccupiedPortServer extends EventEmitter {
   constructor() {
@@ -45,11 +46,43 @@ function runTests() {
   assert.ok(warnings[0].includes('Trying 3001'));
 }
 
+async function testCliServeParsing() {
+  let lastCall = null;
+  class TestCLI extends AvenxCLI {
+    serveProject(port, host) {
+      lastCall = { port, host };
+    }
+  }
+
+  const cli = new TestCLI();
+
+  // Test --port 3000/
+  await cli.run('serve', ['--port', '3000/']);
+  assert.deepStrictEqual(lastCall, { port: 3000, host: 'localhost' });
+
+  // Test --host localhost/
+  await cli.run('serve', ['--host', 'localhost/']);
+  assert.deepStrictEqual(lastCall, { port: 3000, host: 'localhost' });
+
+  // Test trailing slashes and accidental whitespace
+  await cli.run('serve', ['--port', ' 3000/ ', '--host', ' 127.0.0.1/ ']);
+  assert.deepStrictEqual(lastCall, { port: 3000, host: '127.0.0.1' });
+
+  // Test positional port 3000/
+  await cli.run('serve', ['3000/']);
+  assert.deepStrictEqual(lastCall, { port: 3000, host: 'localhost' });
+
+  // Test flag assignments --port=8080/ --host=localhost/
+  await cli.run('serve', ['--port=8080/', '--host=localhost/']);
+  assert.deepStrictEqual(lastCall, { port: 8080, host: 'localhost' });
+}
+
 try {
   runTests();
-  console.log('Dev server port fallback tests passed!');
+  await testCliServeParsing();
+  console.log('Dev server port fallback and CLI serve sanitization tests passed!');
 } catch (error) {
-  console.error('Dev server port fallback tests failed!');
+  console.error('Dev server tests failed!');
   console.error(error);
   process.exit(1);
 }


### PR DESCRIPTION
# Fix: Sanitize CLI arguments for `serve` command to prevent startup crashes

## Description
When starting the dev server via `avenx serve`, accidental trailing slashes (e.g., `3000/`) or whitespaces in command-line arguments would previously cause Node's `net.listen` or URL constructors to throw uncaught initialization errors. 

This PR resolves the issue by adding strict string trimming and numeric sanitization when parsing the CLI flags for the `serve` command.

## Technical Details & Changes
* **Port Sanitization:** Implemented a regex `.replace(/[^0-9]/g, '')` to strip any non-numeric characters from the port argument, ensuring `parseInt` receives clean data. This protection was also extended to `process.env.PORT`.
* **Host Sanitization:** Added `.trim().replace(/\/+$/g, '')` to safely strip accidental trailing whitespaces and slashes from the host argument without breaking internal URL structures.
* **Syntax Support:** Upgraded the parsing logic to properly support `=` assignment syntax for flags (e.g., `--port=3000` and `--host=localhost`).
* **Fallback Handling:** Improved fallback logic for positional arguments.

## Testing
Added comprehensive unit tests in the test suite to verify the parsing logic handles the following edge cases correctly:
* `--port 3000/` (Trailing slashes)
* `--host localhost/` (Trailing slashes on string values)
* `3000/ ` and `127.0.0.1/ ` (Combined whitespaces and slashes)
* Positional arguments containing slashes.

## Related Issue
* Fixes #873