### PR TITLE
docs: document this..has() helper

### DIFF
--- a/docs/src/content/docs/api-reference/component.md
+++ b/docs/src/content/docs/api-reference/component.md
@@ -33,7 +33,37 @@ interface AvenxComponent {
 - **Lifecycle Availability:** `$refs` entries are populated once the component is mounted into the DOM (`onMount`, `onUpdate`). Accessing `$refs` prior to DOM mounting (`onBeforeMount`) returns an empty object (`{}`).
 - **Automatic Teardown Cleanup:** When a component is unmounted (`unmount()`), `this.$refs` is automatically cleared and reset to `{}` to prevent memory leaks and dangling DOM references.
 
+## `this.$slots`
 
+The `this.$slots` object provides access to slots passed by the parent component. You can use `this.$slots.has()` to determine whether a specific slot was provided before rendering conditional content.
+
+### `this.$slots.has(slotName = 'default')`
+
+Checks whether a slot with the specified name exists.
+
+#### Returns
+
+- `true` if the slot is present.
+- `false` otherwise.
+
+#### Examples
+
+```javascript
+if (this.$slots.has()) {
+  console.log("Default slot provided");
+}
+
+if (this.$slots.has("default")) {
+  console.log("Default slot provided");
+}
+
+if (this.$slots.has("header")) {
+  console.log("Header slot provided");
+}
+
+if (this.$slots.has("footer")) {
+  console.log("Footer slot provided");
+}
 
 ## Lifecycle Hooks
 

--- a/docs/src/content/docs/core-concepts/templates.md
+++ b/docs/src/content/docs/core-concepts/templates.md
@@ -340,6 +340,29 @@ Components can receive child HTML blocks using `<slot>` elements. Both default a
 
 If a component's caller does not provide content for a given slot, Avenx-JS automatically falls back to rendering the default content defined inside that `<slot>` element in the component's template. This applies to both named and default slots. For example, in the `Card` component above, if no `slot="header"` element is passed in, the header slot will render its fallback text, `Default Header`, instead of being left empty. This makes it easy to define sensible defaults for optional component content without requiring the caller to always supply every slot.
 
+### Checking Slot Presence (`this.$slots.has()`)
+
+Components can determine whether a slot was provided by the parent using
+`this.$slots.has(slotName)`.
+
+#### Default Slot
+
+```javascript
+if (this.$slots.has('default')) {
+  console.log('Default slot provided');
+}
+```
+
+#### Named Slot
+
+```javascript
+if (this.$slots.has('header')) {
+  console.log('Header slot provided');
+}
+```
+
+If the slot is not provided, `this.$slots.has()` returns `false`, allowing components to conditionally render fallback content.
+
 ## 9. Passing Props to Child Components (`data-props-*`)
 
 Custom child components can receive props from a parent page or component using the `data-props-<propName>` attribute syntax. The parser evaluates the attribute's value as an expression in the parent's scope and passes the resulting value into the child component as a prop.


### PR DESCRIPTION
## Summary

This PR adds documentation for the `this.$slots.has()` helper, making it easier to understand how to check for slot presence and conditionally render fallback content.

## Changes

- Document `this.$slots.has(slotName = 'default')`.
- Explain its behavior and return values.
- Add examples for:
  - Default slot detection.
  - Named slot detection (`header`, `footer`).
- Update:
  - `docs/src/content/docs/api-reference/component.md`
  - `docs/src/content/docs/core-concepts/templates.md`

Closes #887.