### PR TITLE
docs: add AvenxApp.prototype.getRegisteredPages() in avenx-app API re…

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -126,6 +126,22 @@ Registers a page view class for routing.
 app.registerPage('Dashboard', DashboardPage);
 ```
 
+### `getRegisteredPages()`
+
+Returns an array of string identifiers for all page components registered via `app.registerPage(name, pageClass)` from the internal `pages` Map.
+
+**Returns**
+
+`string[]`
+
+Returns an array containing the names of all registered pages.
+
+```javascript
+const registeredPages = app.getRegisteredPages();
+console.log('Registered pages:', registeredPages);
+// Example output: ['Home', 'Dashboard', 'UserProfile']
+```
+
 ### `initRouter(routes)`
 
 Instantiates and starts the hash-based router. Accepts a route mapping configuration object.


### PR DESCRIPTION
### PR Title
**Docs: Add `getRegisteredPages()` to AvenxApp API reference**

### Description
This PR updates the `AvenxApp` API reference documentation to include the missing `getRegisteredPages()` method, as requested in the issue.

### Changes Included
* **Method Description:** Added `### getRegisteredPages()` under the Public Methods section in `docs/src/content/docs/api-reference/app.md`.
* **Return Type:** Documented that the method returns a `string[]` representing the identifiers from the internal `pages` Map.
* **Code Example:** Added the requested JavaScript snippet demonstrating how to retrieve and log the registered pages.

### Related Issue
* Fixes #886 