### PR TITLE
fix: improve ListManager error logging

### DIFF
--- a/lib/core/renderer/listManager.js
+++ b/lib/core/renderer/listManager.js
@@ -99,7 +99,7 @@ export class ListManager {
           key = this.evaluator.evaluateExpression(keyExpr, itemScope, state);
         } catch (e) {
           logger.warn(
-            `[AVX_W19] Failed to evaluate key expression "${keyExpr}" in component <${this.componentName}>: ${e.message || e}`
+           `[AVX_W19] Failed to evaluate key expression "${keyExpr}" in component <${this.componentName || 'AnonymousComponent'}>: ${e.message || e}`
           );
         }
       }

--- a/lib/core/renderer/listManager.js
+++ b/lib/core/renderer/listManager.js
@@ -72,7 +72,7 @@ export class ListManager {
       list = this.evaluator.evaluateExpression(listExpr, scope, state);
     } catch (e) {
       logger.warn(
-        formatMessage(AvenxErrorCodes.RENDER_LIST_EVALUATION_FAILED, listExpr, e.message || e)
+        formatMessage(AvenxErrorCodes.RENDER_LIST_EVALUATION_FAILED, listExpr, e.message || e, this.componentName || 'AnonymousComponent')
       );
       return;
     }

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -147,7 +147,7 @@ export const AvenxErrorMessages = {
   [AvenxErrorCodes.COMPONENT_INJECT_KEY_NOT_FOUND]: 'Injected key "{0}" not found in any ancestor component.',
   [AvenxErrorCodes.SECURITY_SANITIZED_TAG]: 'Sanitized tag "<{0}>" when stripping content.',
   [AvenxErrorCodes.SECURITY_SANITIZED_ATTRIBUTE]: 'Sanitized attribute "{0}" when stripping content.',
-  [AvenxErrorCodes.RENDER_LIST_EVALUATION_FAILED]: 'Failed to evaluate list expression: {0}. Error: {1}',
+  [AvenxErrorCodes.RENDER_LIST_EVALUATION_FAILED]: 'Failed to evaluate list expression: {0} in component <{2}>. Error: {1}',
   [AvenxErrorCodes.RENDER_KEY_EVALUATION_FAILED]: 'Failed to evaluate key expression: {0}. Error: {1}',
   [AvenxErrorCodes.RENDER_LIST_DUPLICATE_KEY]:
     'Duplicate key "{0}" detected in list expression "{1}". Appending index suffix to prevent node reuse conflict.',

--- a/test/unit/list_dirty_check.test.js
+++ b/test/unit/list_dirty_check.test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { ListManager } from '../../lib/core/renderer/listManager.js';
+import { logger } from '../../lib/core/runtime/AvenxLogger.js';
 
 // Copy lightweight mock DOM setup from list_reused_nodes.test.js to keep the test self-contained and run in a pure Node environment.
 class MockNode {
@@ -357,6 +358,136 @@ global.DOMParser = class {
     const scope2 = { items: list2 };
     listManager.process(parentEl, scope2, {});
     assert.strictEqual(renderCount, 14, 'Should re-render when list reference changes, even if items are same');
+// 6. List evaluation failure without componentName should use AnonymousComponent
+let warningMessage = null;
+
+const originalLoggerConfig = { ...logger.config };
+
+logger.configure({
+  level: 'warn',
+  silent: false,
+  transports: [
+    {
+      log(level, formattedArgs) {
+        if (level === 'warn') {
+          warningMessage = formattedArgs[0];
+        }
+      },
+    },
+  ],
+});
+
+const failingEvaluator = {
+  evaluateExpression() {
+    throw new Error('list evaluation failed');
+  },
+};
+
+const failingListManager = new ListManager(
+  failingEvaluator,
+  mockRenderer
+);
+
+const failingTemplate = new MockElementNode('template', {
+  'data-ax-for': 'items',
+  'data-ax-as': 'item',
+});
+
+const failingParent = new MockElementNode('div');
+failingParent.appendChild(failingTemplate);
+
+failingListManager.process(failingParent, {}, {});
+
+assert.ok(
+  warningMessage.includes('<AnonymousComponent>'),
+  'Should use AnonymousComponent when componentName is omitted'
+);
+
+logger.configure(originalLoggerConfig);
+// 7. Key evaluation returning undefined or null should not crash
+const keyValues = [undefined, null];
+
+for (const keyValue of keyValues) {
+  const keyEvaluator = {
+    evaluateExpression(expr, scope) {
+      if (expr === 'items') {
+        return scope.items;
+      }
+      if (expr === 'item.id') {
+        return keyValue;
+      }
+      return '';
+    },
+  };
+
+  const keyListManager = new ListManager(
+    keyEvaluator,
+    mockRenderer,
+    undefined,
+    'KeyTestComponent'
+  );
+
+  const keyTemplate = new MockElementNode('template', {
+    'data-ax-for': 'items',
+    'data-ax-as': 'item',
+    'data-ax-key': 'item.id',
+  });
+
+  const keyParent = new MockElementNode('div');
+  keyParent.appendChild(keyTemplate);
+
+  assert.doesNotThrow(
+    () => keyListManager.process(keyParent, { items: [{ id: 1 }] }, {}),
+    `Key evaluation returning ${keyValue} should not throw`
+  );
+}
+// 8. String thrown as an error should be handled correctly
+let stringWarningMessage = null;
+
+const stringErrorLoggerConfig = { ...logger.config };
+
+logger.configure({
+  level: 'warn',
+  silent: false,
+  transports: [
+    {
+      log(level, formattedArgs) {
+        if (level === 'warn') {
+          stringWarningMessage = formattedArgs[0];
+        }
+      },
+    },
+  ],
+});
+
+const stringErrorEvaluator = {
+  evaluateExpression() {
+    throw 'string evaluation failure';
+  },
+};
+
+const stringErrorListManager = new ListManager(
+  stringErrorEvaluator,
+  mockRenderer
+);
+
+const stringErrorTemplate = new MockElementNode('template', {
+  'data-ax-for': 'items',
+  'data-ax-as': 'item',
+});
+
+const stringErrorParent = new MockElementNode('div');
+stringErrorParent.appendChild(stringErrorTemplate);
+
+stringErrorListManager.process(stringErrorParent, {}, {});
+
+assert.ok(
+  stringWarningMessage.includes('string evaluation failure'),
+  'Should include a string thrown as an evaluation error'
+);
+
+logger.configure(stringErrorLoggerConfig);
+
 
     console.log('  ✅ ListManager dirty checking tests passed!');
     process.exit(0);


### PR DESCRIPTION
## Summary

- Add component context to AVX_W18 list evaluation warnings.
- Use `AnonymousComponent` when `componentName` is not provided.
- Add edge-case tests for missing component name, `undefined`/`null` keys, and string-thrown evaluation errors.

## Testing

- `node test/unit/list_dirty_check.test.js` ✅
- `git diff --check` ✅