### PR TITLE
docs: document global environment variable interpolation in configura…

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -395,3 +395,88 @@ Promoting specific warnings to `"error"` is a powerful tool for enforcing code q
 
 By setting critical warnings (such as undeclared variables `AVX_W03` or invalid preprocessor configs `AVX_W25`) to `"error"`, your automated build checks (e.g. `avenx build` or `npm run build`) fail automatically if any component contains template errors, preventing buggy code from being merged or deployed to production.
 
+---
+
+## Environment Variable Interpolation
+
+Avenx-JS supports global environment variable interpolation in `avenx.config.json`. This feature allows developers to parameterize project configurations — such as dev server ports, hostnames, output directories, and bundle budgets — dynamically using environment variables from your shell, `.env` files, or CI/CD pipelines.
+
+### Interpolation Syntax
+
+Environment variable expansion supports both basic variable replacement and fallback default values:
+
+| Syntax Pattern | Description | Example | Resolved Value |
+| :--- | :--- | :--- | :--- |
+| **Basic Syntax**<br>`${VAR_NAME}` or `$VAR_NAME` | Expands to `process.env.VAR_NAME`. If the environment variable is not defined, it resolves to an empty string (`""`). | `"${HOST}"` | `"localhost"` (or `""` if unset) |
+| **Fallback Syntax**<br>`${VAR_NAME:-default_value}` | Expands to `process.env.VAR_NAME` if set. If `VAR_NAME` is unset or empty, it uses `default_value`. | `"${PORT:-3000}"` | `"3000"` (if `PORT` is unset) |
+
+### Supported Configuration Fields & Type Conversion
+
+Environment variable expansion is recursively applied across string and numeric values in `avenx.config.json`, including:
+- **Server Options**: `server.port`, `server.host`
+- **Build & Path Options**: `srcDir`, `distDir`, `templatesDir`, `outputName`
+- **Compiler & Style Options**: `style.preprocessor`, `voidTags`, bundle budget limits, and logging settings
+
+#### Automatic Numeric Type Conversion
+Config options that expect numeric values (such as `server.port`) are automatically converted to JavaScript `number` types after interpolation if the resolved string contains a numeric value. For instance, `"${PORT:-3000}"` resolves to the numeric value `3000`.
+
+### Sample Parameterized Configuration
+
+The following `avenx.config.json` snippet illustrates how to parameterize server, build outDir, and bundle budget settings with fallback values:
+
+```json
+{
+  "server": {
+    "port": "${PORT:-3000}",
+    "host": "${HOST:-localhost}",
+    "open": false
+  },
+  "build": {
+    "outDir": "${BUILD_OUT_DIR:-dist}",
+    "bundleBudget": {
+      "javascript": "${MAX_JS_SIZE:-500}",
+      "css": "${MAX_CSS_SIZE:-100}"
+    }
+  }
+}
+```
+
+---
+
+### Multi-Environment Setup Examples
+
+Using environment variable interpolation allows a single `avenx.config.json` file to adapt seamlessly across local development, containerized deployments, and automated CI/CD pipelines without modifying configuration source files.
+
+#### 1. Local Development
+For day-to-day local development, no environment variables need to be set manually if default fallbacks are provided:
+```bash
+# Uses fallbacks: port 3000, host localhost, outDir dist
+avenx dev
+```
+
+#### 2. Docker Containers
+When running inside Docker, inject container environment variables via `docker run` or Docker Compose:
+```bash
+docker run -e HOST=0.0.0.0 -e PORT=8080 -p 8080:8080 my-avenx-app
+```
+
+#### 3. Continuous Integration (CI/CD) Pipelines
+In CI pipelines (e.g. GitHub Actions, GitLab CI), override build output directories and enforce stricter bundle budgets during automated build checks:
+```yaml
+# GitHub Actions workflow example
+- name: Run Build with Custom Settings
+  env:
+    BUILD_OUT_DIR: "dist/release"
+    MAX_JS_SIZE: "250"
+  run: npm run build
+```
+
+---
+
+### Security & Best Practices
+
+1. **Do Not Commit Secrets in `avenx.config.json`**: Avoid hardcoding sensitive keys, API credentials, or private tokens in `avenx.config.json` or fallback values.
+2. **Use `.env` Files Responsibly**: Store environment secrets in `.env` files and ensure `.env` is included in your `.gitignore`.
+3. **Always Provide Default Fallbacks**: Use the `${VAR_NAME:-fallback}` syntax for non-critical options so local development works out of the box without requiring manual environment exports.
+
+


### PR DESCRIPTION
## 📝 Description
Fixes #907 
This PR adds comprehensive documentation for **Environment Variable Interpolation** to `docs/src/content/docs/getting-started/configuration.md`.

It documents the interpolation syntax (`${VAR_NAME}` and `${VAR_NAME:-default}`), details automatic numeric type conversions, and provides a sample parameterized `avenx.config.json` configuration snippet.

---

## 🛠️ Changes Made

- **Added New Section:** Introduced `## Environment Variable Interpolation` in `configuration.md`.
- **Documented Syntax Patterns:**
  - **Basic Syntax:** `${VAR_NAME}` / `$VAR_NAME` (resolves to `process.env.VAR_NAME` or empty string if unset).
  - **Fallback Syntax:** `${VAR_NAME:-default_value}` (resolves to `default_value` if variable is unset or empty).
- **Type Conversion:** Explained automatic numeric type conversion for fields expecting numbers (e.g., `server.port`).
- **Sample Configuration:** Added a sample parameterized `avenx.config.json` snippet covering `server` and `build.bundleBudget` settings.

---

## ✅ Acceptance Criteria Checklist

- [x] Added `## Environment Variable Interpolation` section to `docs/src/content/docs/getting-started/configuration.md`.
- [x] Documented basic `${VAR_NAME}` and fallback `${VAR_NAME:-fallback}` syntax forms.
- [x] Included sample parameterized `avenx.config.json` snippet.
- [x] Verified documentation builds cleanly without Astro/MDX errors.