### PR TITLE
docs: document programmatic page cache invalidation in AvenxApp API r…

### DIFF
--- a/docs/src/content/docs/api-reference/app.md
+++ b/docs/src/content/docs/api-reference/app.md
@@ -211,3 +211,25 @@ Mounts a registered component onto the specified DOM element, triggering the com
 ```javascript
 app.mount('MyRootComponent', '#app');
 ```
+
+### `clearKeepAliveCache(pageName)`
+
+Programmatically clears cached KeepAlive component instances from memory. Unmounts evicted page instances and destroys their cached DOM trees.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| `pageName` | `string` (optional) | Name of the page component to evict from cache. If omitted, clears all cached page instances. |
+
+**Returns**
+
+`boolean`
+
+Returns `true` if cache entries were evicted, `false` otherwise.
+
+```javascript
+// Evict a specific cached page instance
+const evicted = app.clearKeepAliveCache('UserProfilePage');
+
+// Purge all cached keep-alive pages
+app.clearKeepAliveCache();
+```

--- a/docs/src/content/docs/api-reference/component.md
+++ b/docs/src/content/docs/api-reference/component.md
@@ -453,6 +453,28 @@ comp.$watch('items.length', () => {
 
 Forces a DOM patch and re-evaluates slots. Typically called automatically by the scheduler.
 
+### `clearKeepAliveCache(pageName)`
+
+Helper method available on component instances (`this.clearKeepAliveCache`) to programmatically clear cached KeepAlive component instances. Delegates to `app.clearKeepAliveCache(pageName)`.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| `pageName` | `string` (optional) | Name of the page component to evict from cache. If omitted, clears all cached page instances. |
+
+**Returns**
+
+`boolean`
+
+Returns `true` if cache entries were evicted, `false` otherwise.
+
+```javascript
+// Inside a component action or method
+this.clearKeepAliveCache('UserProfilePage');
+
+// Or purge all cached keep-alive pages
+this.clearKeepAliveCache();
+```
+
 ---
 
 ## Component Style Lifecycle & StyleMountManager

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -63,6 +63,31 @@ const app = new AvenxApp({
 
 With this configuration, navigating among four or more keep-alive pages retains only the three most recently used inactive page instances in memory. Older cached pages are automatically removed as needed.
 
+### Programmatic Page Cache Invalidation
+
+In addition to automatic LRU eviction via `keepAliveLimit`, developers can manually purge cached page instances from memory using `clearKeepAliveCache(pageName?: string)`.
+
+This is useful when page instances hold stale data or user-specific state that must be cleared (e.g. after a user logs out or updates profile data).
+
+Calling `this.clearKeepAliveCache('UserProfilePage')` (or `app.clearKeepAliveCache('UserProfilePage')`) evicts the specified cached page instance from memory and triggers its `onUnmount()` hook. Calling `this.clearKeepAliveCache()` without arguments purges all cached page instances.
+
+```javascript
+// Inside a Component Action (e.g. Logout / Refresh Button)
+export default {
+  actions: {
+    handleLogout() {
+      // Evict specific cached page instance
+      this.clearKeepAliveCache('UserProfilePage');
+
+      // Or purge all cached keep-alive pages
+      this.clearKeepAliveCache();
+
+      // Navigate to login
+      this.$router.navigate('/login');
+    }
+  }
+};
+```
 
 
 ## 3. Dynamic Route Parameters

--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -60,8 +60,14 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
      * Programmatically clear cached KeepAlive component instances.
      */
     readonly $keepAlive: {
-        clear(componentName?: string): void;
+        clear(componentName?: string): boolean;
     };
+
+    /**
+     * Helper method to clear cached KeepAlive component instances.
+     * @param pageName Optional component or page name to clear from cache.
+     */
+    clearKeepAliveCache(pageName?: string): boolean;
 
     /**
      * The active route details.
@@ -478,8 +484,9 @@ export class AvenxApp {
     /**
      * Programmatically clears cached KeepAlive component instances.
      * @param componentName Optional component or page name to purge.
+     * @returns boolean True if cache entries were evicted.
      */
-    clearKeepAliveCache(componentName?: string): void;
+    clearKeepAliveCache(componentName?: string): boolean;
 
     /**
      * Scaffolds hash-change router listeners.

--- a/lib/core/runtime/AvenxApp.js
+++ b/lib/core/runtime/AvenxApp.js
@@ -586,10 +586,12 @@ export class AvenxApp {
    * If omitted, purges all cached entries.
    * Unmounts cached instances and destroys their cached DOM trees.
    * @param {string} [componentName] - Optional name of component/page to clear from cache.
+   * @returns {boolean} True if cache entries were evicted, false otherwise.
    */
   clearKeepAliveCache(componentName) {
-    if (!this.#pageCache) return;
+    if (!this.#pageCache) return false;
 
+    let evicted = false;
     if (componentName !== undefined && componentName !== null && componentName !== '') {
       let keyToRemove = null;
       if (this.#pageCache.has(componentName)) {
@@ -614,9 +616,13 @@ export class AvenxApp {
         if (cached && cached.pageInstance && typeof cached.pageInstance.unmount === 'function') {
           cached.pageInstance.unmount();
         }
+        evicted = true;
       }
     } else {
       const entries = Array.from(this.#pageCache.cache.entries());
+      if (entries.length > 0) {
+        evicted = true;
+      }
       for (const [key, cached] of entries) {
         this.#pageCache.delete(key);
         if (cached && cached.pageInstance && typeof cached.pageInstance.unmount === 'function') {
@@ -625,6 +631,7 @@ export class AvenxApp {
       }
       this.#pageCache.clear();
     }
+    return evicted;
   }
 }
 

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -395,16 +395,29 @@ export class AvenxComponent {
 
   /**
    * KeepAlive invalidation API for clearing cached components.
-   * @returns {{ clear: (componentName?: string) => void }}
+   * @returns {{ clear: (componentName?: string) => boolean }}
    */
   get $keepAlive() {
     return {
       clear: (componentName) => {
         if (this.$app && typeof this.$app.clearKeepAliveCache === 'function') {
-          this.$app.clearKeepAliveCache(componentName);
+          return this.$app.clearKeepAliveCache(componentName);
         }
+        return false;
       },
     };
+  }
+
+  /**
+   * Helper method to clear cached KeepAlive component instances.
+   * @param {string} [pageName] - Optional component or page name to clear from cache.
+   * @returns {boolean} True if cache entries were evicted, false otherwise.
+   */
+  clearKeepAliveCache(pageName) {
+    if (this.$app && typeof this.$app.clearKeepAliveCache === 'function') {
+      return this.$app.clearKeepAliveCache(pageName);
+    }
+    return false;
   }
 
   /**

--- a/test/unit/keepAlive.test.js
+++ b/test/unit/keepAlive.test.js
@@ -301,13 +301,45 @@ async function testComponentKeepAliveClear() {
   assert.strictEqual(typeof activeComp.$keepAlive.clear, 'function');
 
   activeHistory = [];
-  activeComp.$keepAlive.clear('PageA');
+  const res = activeComp.$keepAlive.clear('PageA');
+  assert.strictEqual(res, true, 'this.$keepAlive.clear should return true when cache entry evicted');
 
   const hasPageAUnmounted = activeHistory.some((h) => h.page === 'A' && h.action === 'unmount');
   assert.strictEqual(hasPageAUnmounted, true, 'this.$keepAlive.clear should trigger unmount of cached component');
 
   global.document.body.removeChild(container);
   console.log('  ✅ this.$keepAlive.clear() test passed!');
+}
+
+async function testComponentDirectClearKeepAliveCache() {
+  console.log('🧪 Testing this.clearKeepAliveCache() helper method on component instance...');
+
+  const container = global.document.createElement('div');
+  container.id = 'app';
+  global.document.body.appendChild(container);
+
+  activeHistory = [];
+
+  const app = new AvenxApp({ target: '#app', keepAliveLimit: 5 });
+  app.registerPage('PageA', PageA);
+  app.registerPage('PageB', PageB);
+
+  app.mountPage('PageA', {}, { keepAlive: true });
+  app.mountPage('PageB', {}, { keepAlive: true });
+
+  const activeComp = container.__avenx_comp_instance;
+  assert.ok(activeComp);
+  assert.strictEqual(typeof activeComp.clearKeepAliveCache, 'function');
+
+  activeHistory = [];
+  const evicted = activeComp.clearKeepAliveCache('PageA');
+  assert.strictEqual(evicted, true, 'this.clearKeepAliveCache should return true when cache entry evicted');
+
+  const hasPageAUnmounted = activeHistory.some((h) => h.page === 'A' && h.action === 'unmount');
+  assert.strictEqual(hasPageAUnmounted, true, 'this.clearKeepAliveCache should trigger unmount of cached component');
+
+  global.document.body.removeChild(container);
+  console.log('  ✅ this.clearKeepAliveCache() test passed!');
 }
 
 try {
@@ -317,6 +349,7 @@ try {
   await testClearKeepAliveCacheSpecific();
   await testClearKeepAliveCacheAll();
   await testComponentKeepAliveClear();
+  await testComponentDirectClearKeepAliveCache();
   console.log('✅ All Keep-Alive integration tests successfully completed!');
 } catch (error) {
   console.error('❌ Keep-Alive integration tests failed!');


### PR DESCRIPTION
## Summary
   
    Fixes #905 
    This PR documents and formalizes the programmatic KeepAlive page cache invalidation API

(`clearKeepAliveCache`) across the Avenx-JS documentation and core runtime.

    Developers can now reference complete documentation for purging stale page instances from

memory (e.g. after user logout or profile updates) via `app.clearKeepAliveCache()` and `this.  
  clearKeepAliveCache()`.

    ---

    ## Changes Included

    ### 📖 Documentation Updates
    - **`docs/src/content/docs/api-reference/app.md`**:
      - Documented `app.clearKeepAliveCache(pageName?: string)` under `## Public Methods`.
      - Added parameter descriptions, `boolean` return type (`true` if entries were evicted), and

code examples.  
 - **`docs/src/content/docs/api-reference/component.md`**:  
 - Documented `this.clearKeepAliveCache(pageName?: string)` helper method under `## Core    
  Methods`.  
 - Added parameter descriptions, `boolean` return type, and usage examples inside component
methods/actions.  
 - **`docs/src/content/docs/core-concepts/routing.md`**:  
 - Added `### Programmatic Page Cache Invalidation` subsection under `Keep-Alive Page       
  Caching`.  
 - Included code examples demonstrating single-page (`UserProfilePage`) and all-page cache  
 purging on user logout or refresh.

    ### ⚙️ Core Runtime & Type Updates
    - **`lib/core/runtime/AvenxApp.js`**:
      - Updated `clearKeepAliveCache(componentName)` to return `boolean` (`true` if cache entries

were evicted, `false` otherwise).  
 - **`lib/core/runtime/AvenxComponent.js`**:  
 - Added `this.clearKeepAliveCache(pageName)` helper method directly on `AvenxComponent`.  
 - Updated `this.$keepAlive.clear()` to return `boolean`.  
 - **`lib/core/index.d.ts`**:  
 - Updated TypeScript declarations for `AvenxApp` and `AvenxComponent` to reflect  
 `clearKeepAliveCache(pageName?: string): boolean`.

    ### 🧪 Tests
    - **`test/unit/keepAlive.test.js`**:
      - Added unit tests for `this.clearKeepAliveCache()` helper method on component instances

and verified boolean return value.

    ---

    ## Code Example

    ```javascript
    // Inside a Component Action (e.g. Logout / Refresh Button)
    export default {
      actions: {
        handleLogout() {
          // Evict specific cached page instance
          this.clearKeepAliveCache('UserProfilePage');

          // Or purge all cached keep-alive pages
          this.clearKeepAliveCache();

          // Navigate to login
          this.$router.navigate('/login');
        }
      }
    };
    ──────

## Verification

• Ran full test suite (npm test): 96 / 96 passed (0 failures).
• Ran targeted KeepAlive tests (node test/unit/keepAlive.test.js): All passed.
