### PR TITLE
feat(eslint): add component tag naming rule (#940)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,12 @@
 import js from "@eslint/js";
 import jsdoc from "eslint-plugin-jsdoc";
+import avenxTemplateParser from "./lib/core/tooling/avenxTemplateParser.js";
+import { componentTagNamingRule } from "./lib/core/tooling/eslintComponentTagNaming.js";
 
 export default [
   js.configs.recommended,
   jsdoc.configs['flat/recommended'],
+
   {
     ignores: [
       "**/node_modules/",
@@ -12,11 +15,31 @@ export default [
       "dev-docs/",
       "coverage/",
       "bench-results/",
-      "**/*.component.js",
-      "**/*.page.js",
       "vite-plugin-avenx/example/"
     ]
   },
+
+  {
+    files: ["**/*.component.js", "**/*.page.js"],
+
+    languageOptions: {
+      parser: avenxTemplateParser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      avenx: {
+        rules: {
+          "component-tag-naming": componentTagNamingRule
+        }
+      }
+    },
+
+    rules: {
+      "avenx/component-tag-naming": "error"
+    }
+  },
+
   {
     languageOptions: {
       ecmaVersion: "latest",
@@ -63,23 +86,39 @@ export default [
         Buffer: "readonly"
       }
     },
+
     plugins: {
       jsdoc: jsdoc
     },
+
     rules: {
       "indent": ["error", 2, { "SwitchCase": 1 }],
-      "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+      "quotes": ["error", "single", {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }],
       "semi": ["error", "always"],
       "no-var": "error",
       "prefer-const": "error",
       "prefer-arrow-callback": "error",
-      "camelcase": ["error", { "properties": "always", "allow": ["__avenx_comp_instance", "__avenx_routers", "__avenx_enable_profiling", "__avenx_directives"] }],
+
+      "camelcase": ["error", {
+        "properties": "always",
+        "allow": [
+          "__avenx_comp_instance",
+          "__avenx_routers",
+          "__avenx_enable_profiling",
+          "__avenx_directives"
+        ]
+      }],
+
       "jsdoc/require-jsdoc": ["error", {
         "require": {
           "MethodDefinition": true,
           "ClassDeclaration": true
         }
       }],
+
       "jsdoc/require-param": "error",
       "jsdoc/require-returns": "off",
       "jsdoc/require-param-description": "off",
@@ -91,8 +130,10 @@ export default [
       "jsdoc/escape-inline-tags": "off"
     }
   },
+
   {
     files: ["test/**/*.js", "bin/**/*.js", "scripts/**/*.js"],
+
     rules: {
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-param": "off",

--- a/lib/core/tooling/avenxTemplateParser.js
+++ b/lib/core/tooling/avenxTemplateParser.js
@@ -1,0 +1,33 @@
+const parser = {
+  meta: {
+    name: 'avenx-template-parser',
+    version: '0.4.3',
+  },
+
+  parse(text, options = {}) {
+    const lines = text.split(/\r\n|\r|\n/);
+    const lastLine = lines.length;
+    const lastColumn = lines[lastLine - 1].length;
+
+    return {
+      type: 'Program',
+      body: [],
+      sourceType: options.sourceType || 'module',
+      comments: [],
+      tokens: [],
+      range: [0, text.length],
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: lastLine,
+          column: lastColumn,
+        },
+      },
+    };
+  },
+};
+
+export default parser;

--- a/lib/core/tooling/componentTagNaming.js
+++ b/lib/core/tooling/componentTagNaming.js
@@ -1,0 +1,201 @@
+import fs from 'fs';
+import path from 'path';
+
+const registryCache = new Map();
+
+/**
+ * Converts an Avenx component filename into its canonical PascalCase name.
+ *
+ * @param {string} fileName
+ * @returns {string}
+ */
+export function componentNameFromFile(fileName) {
+  return path
+    .basename(fileName, '.component.js')
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+/**
+ * Finds components registered by the Avenx compiler.
+ *
+ * Avenx registers components by scanning src/components for
+ * .component.js files and normalizing their filenames.
+ *
+ * @param {string} projectRoot
+ * @param {string} [componentsDir='src/components']
+ * @returns {Set<string>}
+ */
+export function findRegisteredComponents(projectRoot, componentsDir = 'src/components') {
+  const root = path.resolve(projectRoot);
+  const directory = path.resolve(root, componentsDir);
+  const cacheKey = directory;
+
+  if (registryCache.has(cacheKey)) {
+    return new Set(registryCache.get(cacheKey));
+  }
+
+  const names = new Set();
+
+  const visit = (currentDir) => {
+    if (!fs.existsSync(currentDir) || !fs.statSync(currentDir).isDirectory()) {
+      return;
+    }
+
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.component.js')) {
+        names.add(componentNameFromFile(entry.name));
+      }
+    }
+  };
+
+  visit(directory);
+
+  registryCache.set(cacheKey, new Set(names));
+  return new Set(names);
+}
+
+/**
+ * Resolves the configured Avenx components directory.
+ *
+ * @param {string} projectRoot
+ * @param {string} [componentsDir]
+ * @returns {string}
+ */
+export function resolveComponentsDir(projectRoot, componentsDir) {
+  if (componentsDir) {
+    return componentsDir;
+  }
+
+  const configPath = path.join(path.resolve(projectRoot), 'avenx.config.json');
+
+  if (!fs.existsSync(configPath)) {
+    return 'src/components';
+  }
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+    const srcDir =
+      typeof config.srcDir === 'string' && config.srcDir.trim() !== ''
+        ? config.srcDir.trim()
+        : 'src';
+
+    return path.join(srcDir, 'components');
+  } catch {
+    return 'src/components';
+  }
+}
+
+/**
+ * Masks text while preserving line positions.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function mask(value) {
+  return value.replace(/[^\r\n]/g, ' ');
+}
+
+/**
+ * Removes Avenx metadata blocks that are not part of the template.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function extractLintableTemplate(source) {
+  let template = source;
+
+  const patterns = [
+    /<!--[\s\S]*?-->/g,
+    /<state\b[\s\S]*?\/>/gi,
+    /<computed\b[\s\S]*?\/>/gi,
+    /<action\b[\s\S]*?<\/action>/gi,
+    /<resource\b[\s\S]*?<\/resource>/gi,
+    /<resource\b[\s\S]*?\/>/gi,
+  ];
+
+  for (const pattern of patterns) {
+    template = template.replace(pattern, mask);
+  }
+
+  return template;
+}
+
+/**
+ * Finds registered component tags that are not written in PascalCase.
+ *
+ * @param {string} source
+ * @param {Set<string>} registeredComponents
+ * @returns {Array<{tagName: string, expectedName: string, index: number}>}
+ */
+export function findInvalidComponentTags(source, registeredComponents) {
+  const template = extractLintableTemplate(source);
+  const invalidTags = [];
+  const tagRegex = /<([A-Za-z][A-Za-z0-9:_-]*)\b/g;
+
+  let match;
+
+  while ((match = tagRegex.exec(template)) !== null) {
+    const tagName = match[1];
+
+    if (registeredComponents.has(tagName)) {
+      continue;
+    }
+
+    const comparableTag = tagName.replace(/[-_]/g, '').toLowerCase();
+
+    const normalized = [...registeredComponents].find(
+      (componentName) =>
+        componentName.replace(/[-_]/g, '').toLowerCase() === comparableTag,
+    );
+
+    if (normalized && normalized !== tagName) {
+      invalidTags.push({
+        tagName,
+        expectedName: normalized,
+        index: match.index + 1,
+      });
+    }
+  }
+
+  return invalidTags;
+}
+
+/**
+ * Finds the nearest package root.
+ *
+ * @param {string} filePath
+ * @param {string} fallbackRoot
+ * @returns {string}
+ */
+export function findProjectRoot(filePath, fallbackRoot) {
+  let currentDir = path.dirname(path.resolve(filePath));
+  const fallback = path.resolve(fallbackRoot);
+
+  while (true) {
+    if (fs.existsSync(path.join(currentDir, 'package.json'))) {
+      return currentDir;
+    }
+
+    const parent = path.dirname(currentDir);
+    const relativeToFallback = path.relative(fallback, parent);
+
+    if (
+      parent === currentDir ||
+      relativeToFallback.startsWith('..') ||
+      path.isAbsolute(relativeToFallback)
+    ) {
+      break;
+    }
+
+    currentDir = parent;
+  }
+
+  return fallback;
+}

--- a/lib/core/tooling/eslintComponentTagNaming.js
+++ b/lib/core/tooling/eslintComponentTagNaming.js
@@ -1,0 +1,107 @@
+import {
+  findInvalidComponentTags,
+  findProjectRoot,
+  findRegisteredComponents,
+  resolveComponentsDir,
+} from './componentTagNaming.js';
+
+export const componentTagNamingRule = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description:
+        'Require registered Avenx component tags to use PascalCase.',
+    },
+
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          componentsDir: {
+            type: 'string',
+          },
+
+          componentNames: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+
+    messages: {
+      invalidName:
+        'Avenx component <{{tagName}}> must use PascalCase: <{{expectedName}}>.',
+    },
+  },
+
+  create(context) {
+    const physicalFilename = context.physicalFilename;
+    const options = context.options[0] || {};
+    const sourceCode = context.sourceCode;
+
+    return {
+      Program() {
+        const source = sourceCode.getText();
+
+        let registeredComponents;
+
+        if (Array.isArray(options.componentNames)) {
+          registeredComponents = new Set(options.componentNames);
+        } else {
+          const projectRoot = findProjectRoot(
+            physicalFilename,
+            context.cwd,
+          );
+
+          registeredComponents = findRegisteredComponents(
+            projectRoot,
+            resolveComponentsDir(
+              projectRoot,
+              options.componentsDir,
+            ),
+          );
+        }
+
+        for (const issue of findInvalidComponentTags(
+          source,
+          registeredComponents,
+        )) {
+          const lineStart =
+            source.lastIndexOf('\n', issue.index - 1) + 1;
+
+          const line =
+            source.slice(0, issue.index)
+              .split(/\r\n|\r|\n/)
+              .length;
+
+          const column = issue.index - lineStart;
+
+          context.report({
+            loc: {
+              start: {
+                line,
+                column,
+              },
+              end: {
+                line,
+                column: column + issue.tagName.length,
+              },
+            },
+
+            messageId: 'invalidName',
+
+            data: {
+              tagName: issue.tagName,
+              expectedName: issue.expectedName,
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/test/unit/avenxComponentTagNaming.test.js
+++ b/test/unit/avenxComponentTagNaming.test.js
@@ -1,0 +1,191 @@
+import assert from 'assert';
+import {
+  componentNameFromFile,
+  extractLintableTemplate,
+  findInvalidComponentTags,
+} from '../../lib/core/tooling/componentTagNaming.js';
+
+console.log('Testing Avenx component tag naming...');
+
+// ----------------------------------------------------
+// Test 1: Component filename -> PascalCase
+// ----------------------------------------------------
+
+assert.strictEqual(
+  componentNameFromFile('user-profile.component.js'),
+  'UserProfile',
+);
+
+assert.strictEqual(
+  componentNameFromFile('user_profile.component.js'),
+  'UserProfile',
+);
+
+assert.strictEqual(
+  componentNameFromFile('UserProfile.component.js'),
+  'UserProfile',
+);
+
+console.log('Component filename normalization verified!');
+
+// ----------------------------------------------------
+// Test 2: Correct PascalCase component tags
+// ----------------------------------------------------
+
+const registeredComponents = new Set([
+  'UserProfile',
+  'AdminPanel',
+]);
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<UserProfile />',
+    registeredComponents,
+  ),
+  [],
+);
+
+console.log('Valid PascalCase component tags accepted!');
+
+// ----------------------------------------------------
+// Test 3: kebab-case component tag
+// ----------------------------------------------------
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<user-profile />',
+    registeredComponents,
+  ),
+  [
+    {
+      tagName: 'user-profile',
+      expectedName: 'UserProfile',
+      index: 1,
+    },
+  ],
+);
+
+console.log('Kebab-case component tags detected!');
+
+// ----------------------------------------------------
+// Test 4: lowercase component tag
+// ----------------------------------------------------
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<userprofile />',
+    registeredComponents,
+  ),
+  [
+    {
+      tagName: 'userprofile',
+      expectedName: 'UserProfile',
+      index: 1,
+    },
+  ],
+);
+
+console.log('Lowercase component tags detected!');
+
+// ----------------------------------------------------
+// Test 5: camelCase component tag
+// ----------------------------------------------------
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<userProfile />',
+    registeredComponents,
+  ),
+  [
+    {
+      tagName: 'userProfile',
+      expectedName: 'UserProfile',
+      index: 1,
+    },
+  ],
+);
+
+console.log('camelCase component tags detected!');
+
+// ----------------------------------------------------
+// Test 6: Native HTML and unrelated custom elements
+// ----------------------------------------------------
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<button /><my-web-component />',
+    registeredComponents,
+  ),
+  [],
+);
+
+console.log('Unregistered HTML/custom elements ignored!');
+
+// ----------------------------------------------------
+// Test 7: Component inside a larger template
+// ----------------------------------------------------
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    '<div>\n  <user-profile />\n</div>',
+    registeredComponents,
+  ),
+  [
+    {
+      tagName: 'user-profile',
+      expectedName: 'UserProfile',
+      index: 9,
+    },
+  ],
+);
+
+console.log('Components inside templates detected!');
+
+// ----------------------------------------------------
+// Test 8: Avenx <action> blocks must be ignored
+// ----------------------------------------------------
+
+const actionSource = `
+<action name="render">
+  const html = '<user-profile />';
+</action>
+<UserProfile />
+`;
+
+assert.deepStrictEqual(
+  findInvalidComponentTags(
+    actionSource,
+    registeredComponents,
+  ),
+  [],
+);
+
+console.log('Avenx action blocks ignored!');
+
+// ----------------------------------------------------
+// Test 9: Template masking preserves line positions
+// ----------------------------------------------------
+
+const source = `<action>
+foo
+</action>
+<UserProfile />`;
+
+const masked = extractLintableTemplate(source);
+
+assert.strictEqual(
+  masked.split('\n').length,
+  4,
+);
+
+assert.ok(
+  masked.includes('<UserProfile />'),
+);
+
+assert.ok(
+  !masked.includes('<action>'),
+);
+
+console.log('Template masking preserves line positions!');
+
+console.log('All Avenx component tag naming tests passed!');

--- a/test/unit/eslintComponentTagNaming.test.js
+++ b/test/unit/eslintComponentTagNaming.test.js
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { ESLint } from 'eslint';
+import avenxTemplateParser from '../../lib/core/tooling/avenxTemplateParser.js';
+import { componentTagNamingRule } from '../../lib/core/tooling/eslintComponentTagNaming.js';
+
+const eslint = new ESLint({
+  overrideConfigFile: true,
+  overrideConfig: [
+    {
+      files: ['**/*.component.js', '**/*.page.js'],
+
+      languageOptions: {
+        parser: avenxTemplateParser,
+      },
+
+      plugins: {
+        avenx: {
+          rules: {
+            'component-tag-naming': componentTagNamingRule,
+          },
+        },
+      },
+
+      rules: {
+        'avenx/component-tag-naming': [
+          'error',
+          {
+            componentNames: [
+              'UserProfile',
+              'AdminPanel',
+            ],
+          },
+        ],
+      },
+    },
+  ],
+});
+
+async function lint(source) {
+  return eslint.lintText(source, {
+    filePath: 'src/components/test.component.js',
+  });
+}
+
+// ----------------------------------------------------
+// Test 1: Correct PascalCase component
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <UserProfile />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 0);
+
+  console.log('Valid PascalCase component accepted!');
+}
+
+// ----------------------------------------------------
+// Test 2: kebab-case component
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <user-profile />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 1);
+
+  assert.strictEqual(
+    result.messages[0].ruleId,
+    'avenx/component-tag-naming',
+  );
+
+  assert.match(
+    result.messages[0].message,
+    /UserProfile/,
+  );
+
+  console.log('Kebab-case component rejected!');
+}
+
+// ----------------------------------------------------
+// Test 3: lowercase component
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <userprofile />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 1);
+
+  assert.strictEqual(
+    result.messages[0].ruleId,
+    'avenx/component-tag-naming',
+  );
+
+  console.log('Lowercase component rejected!');
+}
+
+// ----------------------------------------------------
+// Test 4: camelCase component
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <userProfile />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 1);
+
+  assert.strictEqual(
+    result.messages[0].ruleId,
+    'avenx/component-tag-naming',
+  );
+
+  console.log('camelCase component rejected!');
+}
+
+// ----------------------------------------------------
+// Test 5: Native HTML elements are ignored
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <button />
+    <input />
+    <span />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 0);
+
+  console.log('Native HTML elements ignored!');
+}
+
+// ----------------------------------------------------
+// Test 6: Unregistered custom elements are ignored
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<div>
+    <my-web-component />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 0);
+
+  console.log('Unregistered custom elements ignored!');
+}
+
+// ----------------------------------------------------
+// Test 7: Avenx metadata blocks are ignored
+// ----------------------------------------------------
+
+{
+  const [result] = await lint(`
+<state name="Test" />
+
+<action name="render">
+    <user-profile />
+</action>
+
+<div>
+    <UserProfile />
+</div>
+`);
+
+  assert.strictEqual(result.errorCount, 0);
+
+  console.log('Avenx metadata blocks ignored!');
+}
+
+console.log('All ESLint component tag naming tests passed!');


### PR DESCRIPTION
Adds an ESLint rule for validating registered Avenx component tag naming.

The rule detects registered components written in lowercase, kebab-case, or camelCase and requires PascalCase naming.

Changes:

- Added component name normalization and registry discovery.
- Added ESLint rule for component tag naming.
- Added support for configurable component directories.
- Added unit tests for component detection and ESLint integration.
- Updated ESLint configuration for `.component.js` and `.page.js` files.

Testing:

`npm.cmd test` — 97/97 passed
 `npm.cmd run lint` — 0 errors, 8 warnings

Closes #940