### PR TITLE
feat: add pause and resume to AvenxWatcher

### DIFF
--- a/lib/core/reactive/watcher.js
+++ b/lib/core/reactive/watcher.js
@@ -238,6 +238,8 @@ export class AvenxWatcher {
    * @param {boolean} [options.immediate] - Run the callback immediately with initial value.
    * @param {boolean} [options.lazy] - Postpone the initial evaluation until first accessed.
    */
+  #isPaused = false;
+
   constructor(getter, callback = null, options = {}) {
     /** @type {function(): any} */
     this.getter = getter;
@@ -273,6 +275,14 @@ export class AvenxWatcher {
     if (options.immediate && this.callback) {
       this.callback(this.value, undefined);
     }
+  }
+
+  pause() {
+    this.#isPaused = true;
+  }
+
+  resume() {
+    this.#isPaused = false;
   }
 
   /**
@@ -415,6 +425,7 @@ export class AvenxWatcher {
    * Triggers re-evaluation when a tracked dependency changes, firing the callback if needed.
    */
   update() {
+    if (this.#isPaused) return;
     if (this.options.lazy) {
       this.dirty = true;
       if (this.callback) {

--- a/test/unit/watcher.test.js
+++ b/test/unit/watcher.test.js
@@ -143,6 +143,62 @@ function testWatcherTeardown() {
 }
 
 /**
+ * Tests pause and resume behavior of AvenxWatcher.
+ */
+function testWatcherPauseResume() {
+  console.log('🧪 Testing AvenxWatcher pause/resume...');
+
+  const state = new StateFactory().create({
+    count: 0,
+  });
+
+  let callbackCount = 0;
+  let lastNewValue = null;
+
+  const watcher = new AvenxWatcher(
+    () => state.count,(newVal) =>{
+      callbackCount++;
+      lastNewValue = newVal;
+    },
+  );
+
+  // Watcher should start in active state
+  state.count = 1;
+
+  assert.strictEqual(watcher.value, 1);
+  assert.strictEqual(callbackCount, 1);
+  assert.strictEqual(lastNewValue, 1);
+
+  // Pause the watcher
+  watcher.pause();
+
+  // State mutation should not re-evaluate the watcher or trigger callback
+  state.count = 2;
+
+  assert.strictEqual(
+    watcher.value,
+    1,
+    'Paused watcher should not re-evaluate its value',
+  );
+  assert.strictEqual(
+    callbackCount,
+    1,
+    'Paused watcher should not trigger callback',
+  );
+
+  // Resume the watcher
+  watcher.resume();
+
+  state.count = 3;
+
+  assert.strictEqual(watcher.value, 3);
+  assert.strictEqual(callbackCount, 2);
+  assert.strictEqual(lastNewValue, 3);
+
+  console.log('  ✅ Watcher pause/resume tests passed!');
+}
+
+/**
  * Tests programmatic Component watch method.
  */
 function testComponentWatchAPI() {
@@ -346,6 +402,7 @@ async function runTests() {
     testBasicWatcher();
     testImmediateWatcher();
     testWatcherTeardown();
+    testWatcherPauseResume();
     testComponentWatchAPI();
     testFunctionBasedComputedProperty();
     testDynamicDependencyPruning();


### PR DESCRIPTION
## Summary

Adds `pause()` and `resume()` instance methods to `AvenxWatcher` to temporarily suspend reactive watcher updates.

## Changes

- Added private `#isPaused` flag to `AvenxWatcher`
- Added `pause()` and `resume()` methods
- Added an early pause check in `update()` to prevent dependency re-evaluation and callbacks while paused
- Added unit test coverage for pause/resume behavior

## Testing

Ran:

```bash
node test/unit/watcher.test.js
```
All existing and new watcher tests pass successfully.

Closes #935