### PR TITLE
fix: sync select value after dynamic options patch

### DIFF
--- a/lib/core/renderer/domPatch.js
+++ b/lib/core/renderer/domPatch.js
@@ -279,6 +279,19 @@ export class DomPatcher {
       newIndex++;
     }
 
+    // Re-sync select value after dynamic options are patched.
+    if (
+      oldNode.nodeType === Node.ELEMENT_NODE &&
+      oldNode.nodeName === 'SELECT' &&
+      newNode.nodeType === Node.ELEMENT_NODE
+    ) {
+      const valueAttr = newNode.getAttribute('value');
+
+      if (valueAttr !== null && oldNode.value !== valueAttr) {
+        oldNode.value = valueAttr;
+      }
+    }
+
     // Remove remaining old children (that are not managed by ListManager)
     while (oldIndex < oldChildren.length) {
       const oldChild = oldChildren[oldIndex];


### PR DESCRIPTION
## Summary

Fixes dynamic `<select>` value binding when options are updated during DOM patching.

## Changes

* Re-syncs the `<select>` value after dynamic options are patched.
* Reads the expected value from the `value` attribute.
* Updates the DOM select value when it differs from the expected value.

## Testing

* `npm test` — **105/105 tests passed**
* `npm test -- integration` — **18/18 tests passed**
* Dynamic select binding integration test passed successfully.
* Build completed successfully.

## Related Issue

Fixes #531
