### PR TITLE
docs(cli): add avenx doctor to README command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ my-avenx-app/
 | `avenx build` (or `b`)    | Compiles the project into `dist/`.                     |
 | `avenx clean`             | Clears build output directory.                         |
 | `avenx check` (or `lint`) | Validates component templates without building.        |
+| `avenx doctor`            | Runs environment and project health diagnostics.       |
 | `avenx serve [port]`      | Starts the dev server with hot-reload (default: 3000). |
 | `avenx watch` (or `w`)    | Watch for file changes and rebuild automatically.      |
 


### PR DESCRIPTION
Adds `avenx doctor` to the README CLI commands table. Fixes #925.
