### PR TITLE
docs(styling): document :deep() and ::v-deep scoped selectors

### DIFF
--- a/docs/src/content/docs/core-concepts/styling.md
+++ b/docs/src/content/docs/core-concepts/styling.md
@@ -135,6 +135,55 @@ The `&` nesting reference behaves the same way inside nested at-rules such as `@
 </@css>
 ```
 
+## 4b. Deep Scoped Selectors (`:deep()` & `::v-deep`)
+
+Scoped CSS keeps rules inside the component. Use **deep selectors** when a parent stylesheet must style child-component DOM or slotted content across that boundary—without switching the whole block to `<@global>`.
+
+`StyleProcessor` strips `:deep(...)` / `::v-deep(...)` (and bare `:deep` / `::v-deep`) at compile time, then applies the component scope hash only to the outer part of the selector. Descendants inside the deep wrapper stay unscoped.
+
+### Supported syntax
+
+| Form | Example | Idea |
+| :--- | :--- | :--- |
+| Parenthesized modern | `.card :deep(.badge)` | Prefer this form |
+| Parenthesized Vue-style | `.card ::v-deep(.badge)` | Same behavior |
+| Combinator form | `.card :deep .badge` | Space/`>`/`+`/`~` after `:deep` |
+
+Conceptually:
+
+```css
+/* Source (scoped component) */
+.card :deep(.badge) {
+  color: #6366f1;
+}
+```
+
+compiles like:
+
+```css
+.card[data-ax-scope-a1b2c3] .badge {
+  color: #6366f1;
+}
+```
+
+instead of attaching the scope attribute to `.badge` itself.
+
+### Example
+
+```css
+<@css>
+    card {
+        padding: 1rem;
+
+        & :deep(.child-title) {
+            font-weight: 600;
+        }
+    }
+</@css>
+```
+
+Use deep selectors sparingly: they intentionally pierce encapsulation. Prefer props, slots, or CSS variables when a child can own its own styles.
+
 ## 4. Global CSS & Custom Variables (`<@global>`)
 
 Declare global styles or design token variables using the `<@global>` block. Use the `@def` directive to define custom color codes or measurements. The compiler replaces these variables statically at build time.
@@ -219,7 +268,7 @@ This automatic renaming only applies to custom properties declared **inside** a 
 | | Declared in `<@global>` / `:root` | Declared inside `<@css>` |
 | --- | --- | --- |
 | Renamed at compile time | No | Yes, to `--ax-<hashId>-<name>` |
-| Visible outside the component | Yes | No — effectively private to that component |
+| Visible outside the component | Yes | No â€” effectively private to that component |
 | Typical use | Design tokens / theme variables shared across the app | Component-local values, including ones derived from props or state |
 
 ### Native Variables vs. `@def` Macros
@@ -227,7 +276,7 @@ This automatic renaming only applies to custom properties declared **inside** a 
 It's worth distinguishing the two variable systems available inside `<@css>` and `<@global>` blocks:
 
 - **`@def` macros** (e.g. `@def primary-color #6366f1;`, referenced as `@primary-color`) are resolved by simple text substitution at compile time. The `@primary-color` reference is replaced with its literal value before the CSS is emitted, so it produces no runtime CSS variable at all.
-- **Native custom properties** (e.g. `--color-primary: #6366f1;`, referenced as `var(--color-primary)`) remain real CSS custom properties in the compiled output. They are only renamed to avoid cross-component collisions — they still behave like normal CSS variables at runtime, including being overridable via inline styles or JavaScript.
+- **Native custom properties** (e.g. `--color-primary: #6366f1;`, referenced as `var(--color-primary)`) remain real CSS custom properties in the compiled output. They are only renamed to avoid cross-component collisions â€” they still behave like normal CSS variables at runtime, including being overridable via inline styles or JavaScript.
 
 Use `@def` macros for static design tokens that never need to change at runtime, and native custom properties when you need actual runtime-computed or overridable CSS variables scoped to a component.
 


### PR DESCRIPTION
Documents `:deep()` / `::v-deep` deep scoped CSS selectors in the styling guide. Fixes #904.
