### PR TITLE
feat(router): add route-level redirects

### DIFF
--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -4,6 +4,9 @@ import { ProxyHandlerFactory } from '../reactive/proxyHandler.js';
 import { RouteMatcher } from './RouteMatcher.js';
 import { createNavigationDelegate } from './navigation/index.js';
 
+//This is declared for controlling the depth of a redirected loop
+const MAX_REDIRECT = 10;
+
 /**
  * AvenxRouter handles routing for the application.
  * Matches URL route definitions to specific Page components using pluggable navigation delegates.
@@ -25,6 +28,8 @@ export class AvenxRouter {
     /** @type {object} */
     this.options = options;
     this.currentRoute = null;
+    /** @type {{ chain: string[], count: number } | null} */
+    this.redirectContext = null; //  The context that is used to prevent the redirect loop using redirect chain and a maxRedirect limit
     /** @type {string|null} @private */
     this.hashToIgnore = null;
 
@@ -98,10 +103,9 @@ export class AvenxRouter {
    * Navigates to a specific hash route.
    * @param {string} hash - The target hash (e.g., '#/about').
    */
-  navigate(hash) {
+  navigate(hash, options = {}) {
     // Force clean paths like '/profile' into hash paths like '#/profile'
     let targetHash = hash.startsWith('#') ? decodeURIComponent(hash) : '#' + decodeURIComponent(hash);
-
 
     if (this.options && this.options.prefix) {
       const prefix = this.options.prefix;
@@ -111,7 +115,7 @@ export class AvenxRouter {
         targetHash = '#' + prefix + '/' + targetHash.substring(1);
       }
     }
-    this.delegate.setHash(targetHash);
+    this.delegate.setHash(targetHash, options);
   }
 
   /**
@@ -269,15 +273,87 @@ export class AvenxRouter {
     }
 
     const def = matchedRoute.definition;
+
+    if (def && typeof def === 'object' && def.redirect) {
+      // Create a new redirect context when the redirect starts
+      if (!this.redirectContext) {
+        this.redirectContext = {
+          chain: [normalizedHash],
+          count: 0,
+        };
+      }
+
+      Promise.resolve()
+        .then(() => {
+          // If redirect is function then execute it with params
+          if (typeof def.redirect === 'function') {
+            return def.redirect(params);
+          }
+
+          return def.redirect;
+        })
+        .then((target) => {
+          if (typeof target !== 'string' || target.length === 0) {
+            logger.error('Invalid redirect target');
+            this.redirectContext = null;
+            return;
+          }
+
+          // Check the maximum redirect limit
+          if (this.redirectContext.count >= MAX_REDIRECT) {
+            logger.error('Maximum redirect limit exceeded');
+            this.redirectContext = null;
+            return;
+          }
+
+          // Normalize the target hash same like navigate does
+          let targetHash = target.startsWith('#') ? decodeURIComponent(target) : '#' + decodeURIComponent(target);
+
+          if (this.options && this.options.prefix) {
+            const prefix = this.options.prefix;
+
+            if (targetHash.startsWith('#/')) {
+              targetHash = '#' + prefix + targetHash.substring(1);
+            } else if (targetHash.startsWith('#')) {
+              targetHash = '#' + prefix + '/' + targetHash.substring(1);
+            }
+          }
+
+          // Check whether the target is already in the redirect chain
+          if (this.redirectContext.chain.includes(targetHash)) {
+            logger.error(`Redirect loop detected: ${[...this.redirectContext.chain, targetHash].join(' → ')}`);
+
+            this.redirectContext = null;
+            return;
+          }
+
+          this.redirectContext.chain.push(targetHash);
+          this.redirectContext.count++;
+
+          this.navigate(targetHash, { replace: true });
+        })
+        .catch((err) => {
+          logger.error(err);
+          this.redirectContext = null;
+        });
+
+      // Do not continue to page, guards or mountPage for redirect route
+      return;
+    }
+
     const parentDef = matchedRoute.parent;
     const pageName = typeof def === 'string' ? def : def.page;
     const childGuards = typeof def === 'object' ? def.guards || [] : [];
-    const parentGuards = (parentDef && typeof parentDef === 'object') ? parentDef.guards || [] : [];
+    const parentGuards = parentDef && typeof parentDef === 'object' ? parentDef.guards || [] : [];
     const guards = [...this.beforeHooks, ...parentGuards, ...childGuards];
 
     const to = { hash: normalizedHash, page: pageName, params };
     const from = this.currentRoute
-      ? { hash: this.currentRoute.hash, page: this.currentRoute.page, params: { ...this.currentRoute.params } }
+      ? {
+          hash: this.currentRoute.hash,
+          page: this.currentRoute.page,
+          params: { ...this.currentRoute.params },
+        }
       : null;
 
     this.#runGuards(guards, to, from)
@@ -319,12 +395,14 @@ export class AvenxRouter {
             this.navigate(redirectPath);
           }
         } else {
+          this.redirectContext = null;
           this.currentRoute = to;
           this.#applyTitle(def, params);
           const transitionName = (typeof def === 'object' && def.transition) || this.options.transition;
-          const keepAlive = (typeof def === 'object' && def.keepAlive !== undefined) ? !!def.keepAlive : !!this.options.keepAlive;
+          const keepAlive =
+            typeof def === 'object' && def.keepAlive !== undefined ? !!def.keepAlive : !!this.options.keepAlive;
           if (this.app && typeof this.app.mountPage === 'function') {
-            const layoutName = (parentDef && typeof parentDef === 'object') ? parentDef.page : null;
+            const layoutName = parentDef && typeof parentDef === 'object' ? parentDef.page : null;
             this.app.mountPage(pageName, params, { transition: transitionName, keepAlive, layout: layoutName });
           }
           this.#runAfterHooks(to, from);

--- a/lib/core/runtime/navigation/BrowserNavigationDelegate.js
+++ b/lib/core/runtime/navigation/BrowserNavigationDelegate.js
@@ -54,9 +54,14 @@ export class BrowserNavigationDelegate extends NavigationDelegate {
   }
 
   /** @override */
-  setHash(hash) {
+  setHash(hash, options = {}) {
     if (typeof window !== 'undefined' && window.location) {
-      window.location.hash = hash;
+      // window.location.hash = hash;
+      if (options.replace) {
+        window.location.replace(hash);
+      } else {
+        window.location.hash = hash;
+      }
     }
   }
 

--- a/lib/core/runtime/navigation/MemoryNavigationDelegate.js
+++ b/lib/core/runtime/navigation/MemoryNavigationDelegate.js
@@ -24,7 +24,7 @@ export class MemoryNavigationDelegate extends NavigationDelegate {
   }
 
   /** @override */
-  setHash(hash) {
+  setHash(hash, options = {}) {
     this.currentHash = hash;
     for (const listener of this.hashListeners) {
       listener(this.currentHash);

--- a/lib/core/runtime/navigation/NavigationDelegate.js
+++ b/lib/core/runtime/navigation/NavigationDelegate.js
@@ -14,9 +14,10 @@ export class NavigationDelegate {
 
   /**
    * Navigates/sets the current location hash string.
+   * @param {string} hash - The target hash.
+   * @param {object} [options] - Navigation options such as replace.
    */
-  setHash() {}
-
+  setHash(hash, options = {}) {}
   /**
    * Subscribes to location/hash change events.
    * @returns {Function} Unsubscribe function.

--- a/test/unit/router_redirect.test.js
+++ b/test/unit/router_redirect.test.js
@@ -1,0 +1,414 @@
+import assert from 'assert';
+
+import { AvenxApp } from '../../lib/core/runtime/AvenxApp.js';
+import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
+import { setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ *
+ */
+class PageHome extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>Home Page</div>';
+  }
+}
+
+/**
+ *
+ */
+class PageProfile extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>Profile Page</div>';
+  }
+}
+
+/**
+ *
+ */
+class PageUser extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>User Page</div>';
+  }
+}
+
+let hashListeners = [];
+let replaceCalls = [];
+let hashSetCalls = [];
+
+/**
+ *
+ */
+function setupWindowMock() {
+  hashListeners = [];
+  replaceCalls = [];
+  hashSetCalls = [];
+
+  const applyHash = (value) => {
+    // Apply the new hash and call all the listeners
+    window.location._hash = value;
+    hashListeners.forEach((listener) => listener());
+  };
+
+  global.window = {
+    addEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners.push(cb);
+      }
+    },
+
+    removeEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners = hashListeners.filter((listener) => listener !== cb);
+      }
+    },
+
+    location: {
+      _hash: '#/',
+
+      get hash() {
+        return this._hash;
+      },
+
+      set hash(value) {
+        // Store the normal hash changes for testing
+        hashSetCalls.push(value);
+        applyHash(value);
+      },
+
+      replace(value) {
+        // Store the replace calls for testing
+        replaceCalls.push(value);
+        applyHash(value);
+      },
+    },
+  };
+}
+
+/**
+ *
+ */
+function teardownWindowMock() {
+  delete global.window;
+}
+
+/**
+ *
+ */
+function waitForRoute() {
+  // Wait for the router to complete the route change
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+(async () => {
+  try {
+    console.log('🧪 Testing route-level redirects...');
+
+    setupDOMMock();
+    setupWindowMock();
+
+    /*
+     * 1. Testing static redirect
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+      app.registerPage('Profile', PageProfile);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/old-home': {
+          redirect: '#/profile',
+        },
+        '#/profile': 'Profile',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/old-home';
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(window.location.hash, '#/profile', 'Static redirect should navigate to the target route');
+
+      assert.strictEqual(
+        router.currentRoute.page,
+        'Profile',
+        'Destination page should be mounted after static redirect',
+      );
+
+      router.destroy();
+    }
+
+    /*
+     * 2. Testing dynamic redirect with params
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+      app.registerPage('User', PageUser);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/old-user/:id': {
+          redirect: (params) => `#/user/${params.id}`,
+        },
+        '#/user/:id': 'User',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/old-user/123';
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(
+        window.location.hash,
+        '#/user/123',
+        'Dynamic redirect should build the target using route params',
+      );
+
+      assert.strictEqual(router.currentRoute.page, 'User', 'Dynamic redirect should mount the destination page');
+
+      assert.strictEqual(
+        router.currentRoute.params.id,
+        '123',
+        'Destination route should receive the correct parameter',
+      );
+
+      router.destroy();
+    }
+
+    /*
+     * 3. Testing async redirect
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+      app.registerPage('Profile', PageProfile);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/async-old': {
+          redirect: async () => {
+            await Promise.resolve();
+            return '#/profile';
+          },
+        },
+        '#/profile': 'Profile',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/async-old';
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(
+        window.location.hash,
+        '#/profile',
+        'Async redirect should navigate after the Promise resolves',
+      );
+
+      assert.strictEqual(router.currentRoute.page, 'Profile', 'Async redirect should mount the destination page');
+
+      router.destroy();
+    }
+
+    /*
+     * 4. Testing redirect with replace navigation
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+      app.registerPage('Profile', PageProfile);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/old-home': {
+          redirect: '#/profile',
+        },
+        '#/profile': 'Profile',
+      });
+
+      await waitForRoute();
+
+      // Clear the old calls before testing the redirect
+      replaceCalls = [];
+      hashSetCalls = [];
+
+      window.location.hash = '#/old-home';
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.ok(replaceCalls.includes('#/profile'), 'Route-level redirect should use replace navigation');
+
+      router.destroy();
+    }
+
+    /*
+     * 5. Testing redirect chain
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/a': {
+          redirect: '#/b',
+        },
+        '#/b': {
+          redirect: '#/c',
+        },
+        '#/c': 'Home',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/a';
+      await waitForRoute();
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(window.location.hash, '#/c', 'Redirect chain should reach the final destination');
+
+      assert.strictEqual(router.currentRoute.page, 'Home', 'Final route in a redirect chain should be mounted');
+
+      router.destroy();
+    }
+
+    /*
+     * 6. Testing redirect loop
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/a': {
+          redirect: '#/b',
+        },
+        '#/b': {
+          redirect: '#/a',
+        },
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/a';
+      await waitForRoute();
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(window.location.hash, '#/b', 'Router should stop before navigating to already visited route');
+
+      assert.strictEqual(router.redirectContext, null, 'Redirect context should be cleared after detecting a loop');
+
+      router.destroy();
+    }
+
+    /*
+     * 7. Testing maximum redirect limit
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/a': { redirect: '#/b' },
+        '#/b': { redirect: '#/c' },
+        '#/c': { redirect: '#/d' },
+        '#/d': { redirect: '#/e' },
+        '#/e': { redirect: '#/f' },
+        '#/f': { redirect: '#/g' },
+        '#/g': { redirect: '#/h' },
+        '#/h': { redirect: '#/i' },
+        '#/i': { redirect: '#/j' },
+        '#/j': { redirect: '#/k' },
+        '#/k': { redirect: '#/l' },
+        '#/l': 'Home',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/a';
+
+      for (let index = 0; index < 12; index++) {
+        await waitForRoute();
+      }
+
+      assert.strictEqual(
+        window.location.hash,
+        '#/k',
+        'Redirect chain should stop when the maximum redirect limit is reached',
+      );
+
+      assert.strictEqual(
+        router.redirectContext,
+        null,
+        'Redirect context should be cleared after reaching the maximum limit',
+      );
+
+      router.destroy();
+    }
+
+    /*
+     * 8. Testing redirect context reset
+     */
+    {
+      const app = new AvenxApp({ target: 'div' });
+
+      app.registerPage('Home', PageHome);
+      app.registerPage('Profile', PageProfile);
+
+      const router = app.initRouter({
+        '#/': 'Home',
+        '#/old-home': {
+          redirect: '#/profile',
+        },
+        '#/profile': 'Profile',
+      });
+
+      await waitForRoute();
+
+      window.location.hash = '#/old-home';
+      await waitForRoute();
+      await waitForRoute();
+
+      assert.strictEqual(router.redirectContext, null, 'Redirect context should reset after reaching a normal route');
+
+      router.destroy();
+    }
+
+    teardownWindowMock();
+    teardownDOMMock();
+
+    console.log('  ✅ All route-level redirect tests passed!');
+  } catch (error) {
+    console.error('❌ Route-level redirect tests failed!');
+    console.error(error);
+
+    teardownWindowMock();
+    teardownDOMMock();
+
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## What does this PR do?

Adds route-level redirect support to the Avenx router.

## Changes

- Add static route redirects
- Add dynamic and async redirect support
- Add redirect chain tracking
- Add redirect cycle detection
- Add maximum redirect limit as a safety fallback
- Add replace navigation support
- Add tests for redirect behavior and edge cases

## Testing

- `npm test`
- 107 tests passed
- 0 tests failed

## Related Issue

Closes #931