### PR TITLE
docs(defer): improve deferred loading documentation

### DIFF
--- a/docs/src/content/docs/core-concepts/defer.md
+++ b/docs/src/content/docs/core-concepts/defer.md
@@ -1,11 +1,11 @@
 ---
 title: Deferred Loading (<@defer>)
-description: Deklaratives Verzögern von schweren Komponenten und DOM-Subbäumen für optimale Core Web Vitals.
+description: Deklaratives Verzögern von Komponenten und DOM-Subbäumen bis ein definierter Trigger ausgelöst wird.
 ---
 
-Das `<@defer>`-Compiler-Tag ermöglicht das **deklarative Verzögern** (Lazy Loading & Deferred Hydration) von schweren Komponenten, Bildern, Diagrammen oder Template-Abschnitten in Avenx.js.
+Das `<@defer>`-Compiler-Tag ermöglicht das **deklarative Verzögern** von Komponenten und DOM-Subbäumen in Avenx.js. Der Inhalt wird nicht sofort gerendert, sondern erst dann geladen, wenn der konfigurierte Trigger ausgelöst wird.
 
-Dadurch werden der initiale JavaScript-Ausführungsaufwand und das DOM-Rendering drastisch reduziert, was zu hervorragenden **Core Web Vitals** (insbesondere LCP, TBT und FID/INP) führt.
+Dies kann dazu beitragen, die anfängliche Rendering- und JavaScript-Arbeitslast zu reduzieren, indem nicht benötigte Inhalte erst bei Bedarf verarbeitet werden.
 
 ---
 
@@ -19,82 +19,165 @@ Um einen Template-Bereich zu verzögern, umhülle ihn einfach mit dem `<@defer>`
 </@defer>
 ```
 
-Standardmäßig lädt `<@defer>` den Inhalt während der Leerlaufzeit des Browsers (`requestIdleCallback`).
+Wenn kein `when`-Attribut angegeben wird, verwendet `<@defer>` standardmäßig den `idle`-Trigger. Dabei wird `requestIdleCallback` verwendet, sofern diese Browser-API verfügbar ist. Andernfalls wird auf einen kurzen Timer zurückgegriffen.
 
 ---
 
 ## Trigger-Modi (`when="..."`)
 
-Über das `when`-Attribut lassen sich verschiedene Lade-Auslöser festlegen:
+Über das `when`-Attribut lässt sich festlegen, wann der verzögerte Inhalt geladen werden soll:
 
-| Trigger | Syntax | Beschreibung |
-|---|---|---|
-| **`idle`** (Default) | `<@defer when="idle">` | Lädt den Inhalt, sobald der Browser leerläuft (`requestIdleCallback`). |
-| **`visible`** | `<@defer when="visible">` | Lädt erst, wenn das Element im Viewport sichtbar wird (`IntersectionObserver`). |
-| **`interaction`** | `<@defer when="interaction">` | Lädt beim Klick oder Hover (`click` / `mouseenter`) auf den Platzhalter. |
-| **`timer(ms)`** | `<@defer when="timer(1000)">` | Lädt nach Ablauf einer Verzögerung in Millisekunden. |
-| **`expression`** | `<@defer when="state.showDetails">` | Lädt, sobald der reaktive State-Ausdruck zu `true` evaluiert. |
+| Trigger               | Syntax                              | Beschreibung                                                                                          |
+| --------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **`idle`** (Standard) | `<@defer when="idle">`              | Lädt den Inhalt während der Browser-Leerlaufzeit.                                                     |
+| **`visible`**         | `<@defer when="visible">`           | Lädt den Inhalt, sobald der Defer-Container im Viewport sichtbar wird.                                |
+| **`interaction`**     | `<@defer when="interaction">`       | Lädt den Inhalt bei einer Benutzerinteraktion. Aktuell lösen `click` oder `mouseenter` das Laden aus. |
+| **`timer(ms)`**       | `<@defer when="timer(1000)">`       | Lädt den Inhalt nach der angegebenen Verzögerung in Millisekunden.                                    |
+| **Ausdruck**          | `<@defer when="state.showDetails">` | Wertet den angegebenen Ausdruck aus und lädt den Inhalt, wenn das Ergebnis wahr ist.                  |
 
-### Beispiele
+---
 
-#### 1. Sichtbarkeit im Viewport (`when="visible"`)
+### `idle`
+
+Der `idle`-Trigger lädt den verzögerten Inhalt, sobald der Browser Leerlaufzeit zur Verfügung hat.
+
+```html
+<@defer when="idle">
+  <HeavyChart />
+</@defer>
+```
+
+Avenx.js verwendet dafür `requestIdleCallback`, sofern diese Browser-API verfügbar ist. Andernfalls wird ein kurzer Timer als Fallback verwendet.
+
+### `visible`
+
+Der `visible`-Trigger lädt den Inhalt, sobald der Defer-Container im Viewport sichtbar wird.
+
 ```html
 <@defer when="visible">
-  <HeavyChart data="{{ state.chartData }}" />
-  
-  <@placeholder>
-    <div class="skeleton-loader">Diagramm wird geladen, sobald sichtbar...</div>
-  </@placeholder>
+  <HeavyChart />
 </@defer>
 ```
 
-#### 2. Benutzer-Interaktion (`when="interaction"`)
+Avenx.js verwendet dafür `IntersectionObserver`. Sobald der Container sichtbar wird, wird der Observer beendet und der verzögerte Inhalt geladen.
+
+### `interaction`
+
+Der `interaction`-Trigger lädt den Inhalt, sobald der Benutzer mit dem Defer-Container interagiert.
+
+Aktuell lösen sowohl `click` als auch `mouseenter` das Laden des Inhalts aus. Die Trigger-Werte `click` und `hover` werden ebenfalls als Interaktions-Trigger unterstützt.
 ```html
-<@defer when="interaction">
-  <RichTextEditor content="{{ state.body }}" />
+<@defer when="click">
+  <HeavyChart />
+</@defer>
 
-  <@placeholder>
-    <button class="btn">Hier klicken, um Editor zu laden</button>
-  </@placeholder>
+<@defer when="hover">
+  <HeavyChart />
 </@defer>
 ```
 
-#### 3. Timer-Verzögerung (`when="timer(2000)"`)
+### `timer`
+
+Der `timer`-Trigger lädt den verzögerten Inhalt nach Ablauf einer angegebenen Verzögerung in Millisekunden.
+
 ```html
 <@defer when="timer(2000)">
   <BannerAd />
 </@defer>
 ```
 
----
+In diesem Beispiel wird der Inhalt nach 2000 Millisekunden (2 Sekunden) geladen. Avenx.js unterstützt auch Zeitangaben im Format `1000ms`.
+
+### `Ausdruck`
+
+Ein Ausdruck kann als Trigger verwendet werden, um den verzögerten Inhalt abhängig vom aktuellen Zustand zu laden.
+
+```html
+<@defer when="state.isReady">
+  <HeavyComponent />
+</@defer>
+```
+
+Der Ausdruck wird ausgewertet, wenn der Defer-Container verarbeitet wird. Wenn das Ergebnis wahr ist, wird der verzögerte Inhalt geladen. Wird der Container später erneut verarbeitet, wird der Ausdruck erneut ausgewertet.
+
+
 
 ## Platzhalter & Ladezustände (`<@placeholder>` & `<@loading>`)
 
-Innerhalb von `<@defer>` können optionale Sub-Tags deklariert werden:
+Innerhalb von `<@defer>` können optionale Sub-Tags verwendet werden.
 
-* **`<@placeholder>`**: Der Platzhalter-Inhalt, der sofort gerendert wird, bevor der Trigger auslöst.
-* **`<@loading>`**: Zeigt einen optionalen Ladezustand (z. B. Spinner) während des Nachladens an.
+### `<@placeholder>`
+
+`<@placeholder>` definiert den Inhalt, der angezeigt wird, während auf den konfigurierten Trigger gewartet wird.
 
 ```html
 <@defer when="visible">
-  <!-- Eigentlicher schwerer Inhalt -->
-  <UserProfileDetails user="{{ state.user }}" />
-
-  <!-- Platzhalter vor dem Trigger -->
   <@placeholder>
-    <div class="user-card-skeleton">Profile Skeleton...</div>
+    <div class="skeleton-loader">
+      Diagramm wird geladen, sobald es sichtbar ist...
+    </div>
   </@placeholder>
 
-  <!-- Ladezustand beim Nachladen -->
+  <HeavyChart data="{{ state.chartData }}" />
+</@defer>
+```
+
+### `<@loading>`
+
+`<@loading>` wird vom Compiler erkannt und als separates Lade-Template vorbereitet.
+
+```html
+<@defer when="visible">
   <@loading>
     <div class="spinner">Profil wird geladen...</div>
   </@loading>
+
+  <UserProfileDetails user="{{ state.user }}" />
 </@defer>
 ```
+
+**Aktueller Status:** In der aktuellen synchronen Laufzeit wird das `<@loading>`-Template noch nicht angezeigt. Sobald der Trigger ausgelöst wird, wird der verzögerte Inhalt direkt gerendert. Eine aktive Anzeige des Ladezustands kann mit zukünftiger asynchroner Ladeunterstützung ergänzt werden.
+
+---
+
+## Mehrere Trigger
+
+Das Kombinieren mehrerer Trigger wird derzeit noch nicht unterstützt.
+
+Beispielsweise kann folgende Syntax aktuell nicht verwendet werden:
+
+```html
+<@defer when="visible; interaction">
+  <HeavyComponent />
+</@defer>
+```
+
+Aktuell kann für einen `<@defer>`-Block nur ein Trigger angegeben werden. Die Unterstützung für mehrere kombinierte Trigger ist für eine zukünftige Erweiterung vorgesehen.
+
+## Cleanup und Lebenszyklus
+
+Avenx.js registriert für aktive Trigger entsprechende Cleanup-Funktionen.
+
+Je nach verwendetem Trigger werden beispielsweise:
+
+- Event-Listener für `click` und `mouseenter` entfernt.
+- Timer mit `clearTimeout()` abgebrochen.
+- Idle-Callbacks mit `cancelIdleCallback()` abgebrochen, sofern verfügbar.
+- `IntersectionObserver`-Instanzen mit `disconnect()` beendet.
+
+Wenn der Trigger ausgelöst wird und der verzögerte Inhalt geladen wird, wird die zugehörige Trigger-Cleanup-Funktion ausgeführt.
+
+> **Hinweis:** Die vollständige Bereinigung beim Unmount eines übergeordneten Components ist derzeit noch nicht garantiert. Die `DeferManager.destroy()`-Methode ist momentan noch ein Platzhalter und wird beim Component-Teardown noch nicht aufgerufen. Eine vollständige Unmount-Bereinigung ist für eine zukünftige Erweiterung vorgesehen.
+
 
 ---
 
 ## Technische Funktionsweise
 
-1. **Kompilier-Schritt ([ComponentParser](file:///Users/nathanschmid/Documents/git_local/avenx-js/lib/compiler/ComponentParser.js))**: Der Compiler übersetzt den `<@defer>`-Tag in ein leichtes DOM-Gerüst mit `<template data-ax-defer-placeholder>` und `<template data-ax-defer-content>`.
-2. **Laufzeit-Schritt ([DeferManager](file:///Users/nathanschmid/Documents/git_local/avenx-js/lib/core/renderer/deferManager.js))**: Der `DeferManager` verwaltet die Event-Listener und Observer (`IntersectionObserver`, `requestIdleCallback`, `setTimeout`). Sobald die Bedingung erfüllt ist, wird der Platzhalter durch den echten Inhalt ausgetauscht und reaktiv hydriert.
+Die Verarbeitung von `<@defer>` erfolgt in zwei wesentlichen Schritten:
+
+1. **Kompilier-Schritt:** Der `ComponentParser` erkennt `<@defer>` und wandelt es in einen speziellen Defer-Container um. Abhängig vom verwendeten Inhalt können darin Templates für `<@placeholder>`, `<@loading>` und den eigentlichen verzögerten Inhalt gespeichert werden.
+
+2. **Laufzeit-Schritt:** Der `DeferManager` verarbeitet die Defer-Container und richtet den konfigurierten Trigger ein. Je nach Trigger verwendet er beispielsweise `requestIdleCallback`, `IntersectionObserver`, Event-Listener oder `setTimeout`.
+
+Sobald der Trigger ausgelöst wird, rendert der `DeferManager` den verzögerten Inhalt und entfernt zuvor gerenderten Placeholder-Inhalt.


### PR DESCRIPTION
## Summary

- Expanded the `<@defer>` documentation with all currently supported trigger modes.
- Documented `@placeholder` and the current `@loading` runtime behavior.
- Documented the current limitations around multiple triggers and unmount cleanup.
- Added details about the compiler and runtime processing of deferred content.

## Testing

- `npm test`

Closes #995