### PR TITLE
fix(compiler): escape backticks in template interpolations

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -490,6 +490,74 @@ class ${name} extends AvenxComponent {
    * @returns {string} The cleaned and processed HTML template.
    * @private
    */
+
+  escapeInterpolationBackticks(template) {
+    if (!template) return template;
+
+    return template.replace(/\{\{([\s\S]*?)\}\}/g, (match, expression) => {
+      const escapedExpression = expression.replace(/(?<!\\)`/g, '\\`');
+
+      return `{{${escapedExpression}}}`;
+    });
+  }
+
+  extractTemplate(content, desBlocks, name, filePath, state, computed, methods, resources = {}) {
+    let template = content
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/<state.*? \/>/g, '')
+      .replace(/<computed.*? \/>/g, '')
+      .replace(/<action.*?>[\s\S]*?<\/action>/g, '')
+      .replace(/<resource.*?>[\s\S]*?<\/resource>/g, '')
+      .replace(/<resource\s+[\s\S]*?\/>/gi, '')
+      .trim();
+
+    template = this.preprocessTemplate(template, filePath);
+
+    const isPage = filePath && filePath.endsWith('.page.js');
+
+    const desPath = filePath
+      ? filePath.replace(
+        isPage ? '.page.js' : '.component.js',
+        isPage ? '.page.css' : '.component.css'
+      )
+      : '';
+
+    template = this.styleProcessor.process(
+      template,
+      desBlocks,
+      name,
+      desPath
+    );
+
+    template = this.processBindDirectives(template);
+
+    if (filePath && state && computed && methods) {
+      this.validateTemplate(
+        template,
+        state,
+        computed,
+        methods,
+        resources,
+        filePath,
+        name
+      );
+    }
+
+    template = this.processForLoops(template);
+    template = this.processSuspense(template);
+    template = this.processErrorBoundary(template);
+    template = this.processDefer(template);
+    template = this.processTransitionTags(template, filePath);
+    template = this.processEventDelegation(template, filePath);
+
+    // Escape backticks inside template interpolations.
+    template = this.escapeInterpolationBackticks(template);
+
+    return template
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .join('\n');
+  }
   extractTemplate(content, desBlocks, name, filePath, state, computed, methods, resources = {}) {
     let template = content
       .replace(/<!--[\s\S]*?-->/g, '')
@@ -1149,10 +1217,10 @@ class ${name} extends AvenxComponent {
     while (true) {
       const match = currentTemplate.match(/<@suspense>([\s\S]*?)<\/ ?@suspense>/i);
       if (!match) break;
-      
+
       const fullMatch = match[0];
       const inner = match[1];
-      
+
       // Extract <@fallback>
       let fallbackContent = '';
       let suspenseContent = inner;
@@ -1161,7 +1229,7 @@ class ${name} extends AvenxComponent {
         fallbackContent = fallbackMatch[1].replace(/\{\{/g, '{%').replace(/\}\}/g, '%}'); // Escape fallback template logic
         suspenseContent = inner.replace(fallbackMatch[0], '');
       }
-      
+
       const replacement = `<div data-ax-suspense="true"><template data-ax-fallback>${fallbackContent}</template>${suspenseContent}</div>`;
       currentTemplate = currentTemplate.replace(fullMatch, replacement);
     }
@@ -1179,10 +1247,10 @@ class ${name} extends AvenxComponent {
     while (true) {
       const match = currentTemplate.match(/<@errorBoundary>([\s\S]*?)<\/ ?@errorBoundary>/i);
       if (!match) break;
-      
+
       const fullMatch = match[0];
       const inner = match[1];
-      
+
       // Extract <@fallback as="...">
       let fallbackContent = '';
       let errorAs = 'error';
@@ -1193,7 +1261,7 @@ class ${name} extends AvenxComponent {
         fallbackContent = fallbackMatch[2].replace(/\{\{/g, '{%').replace(/\}\}/g, '%}'); // Escape fallback logic
         boundaryContent = inner.replace(fallbackMatch[0], '');
       }
-      
+
       const replacement = `<div data-ax-error-boundary="true" data-ax-error-as="${errorAs}"><template data-ax-error-fallback><div class="ax-error-boundary">${fallbackContent}</div></template>${boundaryContent}</div>`;
       currentTemplate = currentTemplate.replace(fullMatch, replacement);
     }

--- a/test/unit/componentParser.test.js
+++ b/test/unit/componentParser.test.js
@@ -156,20 +156,54 @@ try {
   const contentWithComments = `
     <!-- This is a single line comment -->
     <div class="test">
-      <!-- 
+      <!--
         This is a multi-line
         comment
       -->
       <p>Hello <!-- inline comment --> World</p>
     </div>
   `;
-  const templateWithComments = cp.extractTemplate(contentWithComments, {}, 'TestComp');
+
+  const templateWithComments = cp.extractTemplate(
+    contentWithComments,
+    {},
+    'TestComp',
+  );
+
   assert.ok(!templateWithComments.includes('comment'));
   assert.ok(!templateWithComments.includes('<!--'));
   assert.ok(!templateWithComments.includes('-->'));
   assert.ok(templateWithComments.includes('<div class="test">'));
   assert.ok(templateWithComments.includes('<p>Hello  World</p>'));
+
   console.log('  ✅ HTML Comments Stripping tests passed!');
+
+  // Test 9: Backticks inside template interpolations
+  console.log('🧪 Testing backticks inside template interpolations...');
+
+  const contentWithBackticks = `
+    <div class="{{ state.active ? \`active\` : \`\` }}">
+      {{ state.active ? \`active\` : \`\` }}
+    </div>
+  `;
+
+  const templateWithBackticks = cp.extractTemplate(
+    contentWithBackticks,
+    {},
+    'TestComp',
+  );
+
+  assert.ok(
+    templateWithBackticks.includes('\\`active\\`'),
+    'Backticks inside interpolations should be escaped',
+  );
+
+  assert.ok(
+    templateWithBackticks.includes('\\`\\`'),
+    'Empty backtick template literals inside interpolations should be escaped',
+  );
+
+  console.log('  ✅ Backticks inside template interpolations tests passed!');
   console.log('🧪 Testing custom void tags from config...');
   const cpWithVoidTags = new ComponentParser(sp, ['my-video', 'custom-icon']);
 


### PR DESCRIPTION
Fixes #197

Backticks inside template interpolations were not escaped before being inserted into the generated component template.

For example:
```html
<div class="{{ state.active ? `active` : `` }}">

##Changes
Added escapeInterpolationBackticks() to ComponentParser.
Escape unescaped backticks inside {{ ... }} template interpolations.
Added a regression test covering backticks and empty template literals inside interpolations.