### PR TITLE
feat(security): add Sanitizer.sanitizeUrl pseudo-protocol protection

### DIFF
--- a/lib/core/security/sanitize.js
+++ b/lib/core/security/sanitize.js
@@ -320,6 +320,38 @@ export class Sanitizer {
   }
 
   /**
+   * Sanitizes a URL string, returning `about:blank` for disallowed protocols.
+   *
+   * Protects applications that bind user-provided URLs to `href`/`src`
+   * attributes from `javascript:` and other pseudo-protocol XSS vectors.
+   * @param {string} url - The URL to sanitize.
+   * @param {string[]} [allowedProtocols] - Allowed protocols (including the
+   *   trailing colon). Defaults to `['http:', 'https:', 'mailto:', 'tel:']`.
+   * @returns {string} The trimmed URL when its protocol is allowed, or
+   *   `'about:blank'` for disallowed protocols and empty/whitespace input.
+   */
+  static sanitizeUrl(url, allowedProtocols = ['http:', 'https:', 'mailto:', 'tel:']) {
+    if (url == null) return 'about:blank';
+    const value = String(url);
+    const trimmed = value.trim();
+    if (trimmed === '') return 'about:blank';
+
+    // Strip control characters and whitespace before the scheme check so
+    // obfuscated forms like "java\nscript:" cannot bypass it.
+    // eslint-disable-next-line no-control-regex
+    const cleaned = value.replace(/[\u0000-\u001F\u007F-\u009F\s]/g, '');
+    const schemeMatch = cleaned.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+    if (schemeMatch) {
+      const scheme = `${schemeMatch[1].toLowerCase()}:`;
+      const allowed = allowedProtocols.map((protocol) => String(protocol).toLowerCase());
+      if (!allowed.includes(scheme)) {
+        return 'about:blank';
+      }
+    }
+    return trimmed;
+  }
+
+  /**
    * Recursively sanitizes a DOM node and returns the clean HTML string.
    * @param {any} node - The DOM node or mock DOM element to sanitize.
    * @returns {string} The sanitized inner HTML.

--- a/test/unit/sanitize.test.js
+++ b/test/unit/sanitize.test.js
@@ -148,6 +148,42 @@ function testCustomVoidTags() {
   }
 }
 
+function testSanitizeUrl() {
+  console.log('🧪 Testing Sanitizer.sanitizeUrl pseudo-protocol protection...');
+
+  // 1. Disallowed pseudo-protocols are replaced with about:blank
+  assert.strictEqual(Sanitizer.sanitizeUrl('javascript:alert(1)'), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl('JaVaScRiPt:alert(1)'), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl('data:text/html,<script>alert(1)</script>'), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl('vbscript:msgbox(1)'), 'about:blank');
+
+  // 2. Leading whitespace is stripped before the scheme check
+  assert.strictEqual(Sanitizer.sanitizeUrl('  javascript:alert(1)  '), 'about:blank');
+
+  // 3. Allowed protocols pass through unchanged (trimmed)
+  assert.strictEqual(Sanitizer.sanitizeUrl('https://example.com/path'), 'https://example.com/path');
+  assert.strictEqual(Sanitizer.sanitizeUrl('  http://example.com  '), 'http://example.com');
+  assert.strictEqual(Sanitizer.sanitizeUrl('mailto:user@example.com'), 'mailto:user@example.com');
+  assert.strictEqual(Sanitizer.sanitizeUrl('tel:+1234567890'), 'tel:+1234567890');
+
+  // 4. Relative URLs without a scheme are allowed
+  assert.strictEqual(Sanitizer.sanitizeUrl('/relative/path'), '/relative/path');
+  assert.strictEqual(Sanitizer.sanitizeUrl('#fragment'), '#fragment');
+  assert.strictEqual(Sanitizer.sanitizeUrl('example.com'), 'example.com');
+
+  // 5. Empty and nullish input returns about:blank
+  assert.strictEqual(Sanitizer.sanitizeUrl(''), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl('   '), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl(null), 'about:blank');
+  assert.strictEqual(Sanitizer.sanitizeUrl(undefined), 'about:blank');
+
+  // 6. Custom allowed-protocol list
+  assert.strictEqual(Sanitizer.sanitizeUrl('ftp://example.com', ['ftp:', 'https:']), 'ftp://example.com');
+  assert.strictEqual(Sanitizer.sanitizeUrl('https://example.com', ['ftp:']), 'about:blank');
+
+  console.log('  ✅ Sanitizer.sanitizeUrl tests passed!');
+}
+
 function testConfigurablePolicyOptions() {
   console.log('🧪 Testing Sanitizer configurable policy options...');
   setupDOMMock();
@@ -212,6 +248,7 @@ try {
   testSanitizerFallback();
   testCustomVoidTags();
   testConfigurablePolicyOptions();
+  testSanitizeUrl();
   console.log('✅ All Sanitizer tests successfully completed!');
   process.exit(0);
 } catch (error) {


### PR DESCRIPTION
## Problem

Closes #998. User-provided URLs bound to `<a href="...">` or `<iframe src="...">` attributes could contain unsafe `javascript:` or `data:text/html` pseudo-protocol schemes. The `Sanitizer` currently handles HTML tag/attribute sanitization but offers no dedicated URL-value helper.

## Change

- Added `Sanitizer.sanitizeUrl(url, allowedProtocols = ['http:', 'https:', 'mailto:', 'tel:'])` in `lib/core/security/sanitize.js`.
- Trims leading/trailing whitespace, strips control characters before the scheme check (so obfuscated forms like `java\nscript:` cannot bypass it), and returns `about:blank` for any protocol outside the allow-list.
- Relative URLs without a scheme and empty/nullish input are handled (empty/null -> `about:blank`).
- Added security test cases in `test/unit/sanitize.test.js`.

## Why this approach

The issue's proposed contract is followed exactly: a single static helper with an allow-list default, permissive for relative URLs, and `about:blank` as the safe fallback for disallowed pseudo-protocols.

## Testing

```text
node test/unit/sanitize.test.js
result: All Sanitizer tests passed (incl. new sanitizeUrl cases)

npx eslint lib/core/security/sanitize.js test/unit/sanitize.test.js
result: 0 errors, 0 warnings

npm test
result: Total: 109 | Passed: 108 | Failed: 1 (serve.test.js - pre-existing on clean main)
```

## Documentation and release impact

- [x] User-facing documentation updated (JSDoc on the new method)
- [ ] Changelog/release note needed
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: `data:` URLs are rejected unless added to `allowedProtocols`; callers that need `data:image/...` on `<img>` can pass an extended allow-list.
- Follow-up issue, if any: none
- Security/licensing considerations: this is a defensive XSS helper; MIT project
