### PR TITLE
fix(renderer): skip redundant class attribute writes during DOM diffing

### DIFF
--- a/lib/core/renderer/domPatch.js
+++ b/lib/core/renderer/domPatch.js
@@ -7,6 +7,27 @@ import { profile, getComponentProfilingInfo } from '../utils/profiler.js';
 const escaper = new HtmlEscaper();
 
 /**
+ * Compares two class attribute strings as unordered token sets, ignoring extra
+ * whitespace and token order, so redundant DOM mutations are skipped when the
+ * effective class list is unchanged.
+ * @param {string|null} a
+ * @param {string|null} b
+ * @returns {boolean}
+ */
+function classTokensEqual(a, b) {
+  const tokensOf = (value) => {
+    if (value == null) return [];
+    return Array.from(new Set(String(value).trim().split(/\s+/).filter(Boolean))).sort();
+  };
+  const aTokens = tokensOf(a);
+  const bTokens = tokensOf(b);
+  if (aTokens.length !== bTokens.length) {
+    return false;
+  }
+  return aTokens.every((token, index) => token === bTokens[index]);
+}
+
+/**
  * Helper to compute transition/animation duration from element computed styles.
  * @param {Element} el
  * @returns {number} duration in ms
@@ -359,7 +380,10 @@ export class DomPatcher {
           oldNode[attr.name] = true;
         }
       } else {
-        if (oldNode.getAttribute(attr.name) !== attr.value) {
+        const oldValue = oldNode.getAttribute(attr.name);
+        const shouldUpdate =
+          attr.name === 'class' ? !classTokensEqual(oldValue, attr.value) : oldValue !== attr.value;
+        if (shouldUpdate) {
           oldNode.setAttribute(attr.name, attr.value);
         }
         if (attr.name === 'value' && ['INPUT', 'TEXTAREA', 'SELECT'].includes(oldNode.nodeName)) {

--- a/test/unit/domPatch.test.js
+++ b/test/unit/domPatch.test.js
@@ -1,0 +1,114 @@
+import assert from 'assert';
+import { DomPatcher } from '../../lib/core/renderer/domPatch.js';
+import { MockDOMElement, setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ * Wraps an element's setAttribute with a call recorder so tests can assert
+ * whether a redundant class write happened.
+ * @param {MockDOMElement} element
+ * @returns {{ calls: string[], restore: () => void }}
+ */
+function spySetAttribute(element) {
+  const calls = [];
+  const original = element.setAttribute.bind(element);
+  element.setAttribute = (name, value) => {
+    calls.push(name);
+    return original(name, value);
+  };
+  return {
+    calls,
+    restore: () => {
+      element.setAttribute = original;
+    },
+  };
+}
+
+/**
+ * Patches `html` into a fresh target and returns the patched container div.
+ * @param {DomPatcher} patcher
+ * @param {string} html
+ * @returns {MockDOMElement}
+ */
+function patchContainer(patcher, html) {
+  const target = new MockDOMElement('div');
+  patcher.patch(target, html);
+  return target.childNodes[0];
+}
+
+function testClassTokenEqualitySkipsRedundantWrites() {
+  console.log('🧪 Testing DomPatcher class token equality skips redundant writes...');
+  setupDOMMock();
+
+  try {
+    const patcher = new DomPatcher();
+    const container = patchContainer(patcher, '<div class="btn active"><span>x</span></div>');
+
+    // 1. Same tokens, different order: no class write.
+    let spy = spySetAttribute(container);
+    patcher.patch(container.parentNode || container, '<div class="active btn"><span>x</span></div>');
+    assert.ok(
+      !spy.calls.includes('class'),
+      'Reordering identical class tokens should not trigger a class write',
+    );
+    spy.restore();
+
+    // 2. Extra whitespace: no class write.
+    spy = spySetAttribute(container);
+    patcher.patch(container.parentNode || container, '<div class="btn   active"><span>x</span></div>');
+    assert.ok(
+      !spy.calls.includes('class'),
+      'Extra whitespace between identical class tokens should not trigger a class write',
+    );
+    spy.restore();
+
+    // 3. Genuine class change: write happens.
+    spy = spySetAttribute(container);
+    patcher.patch(container.parentNode || container, '<div class="btn primary"><span>x</span></div>');
+    assert.ok(spy.calls.includes('class'), 'A real class change should trigger a class write');
+    assert.strictEqual(container.getAttribute('class'), 'btn primary', 'Class should be updated to new value');
+    spy.restore();
+
+    // 4. Duplicate tokens normalize to the same set: no write.
+    spy = spySetAttribute(container);
+    patcher.patch(container.parentNode || container, '<div class="primary primary btn btn"><span>x</span></div>');
+    assert.ok(
+      !spy.calls.includes('class'),
+      'Duplicate tokens should normalize to the same class set without a write',
+    );
+    spy.restore();
+
+    console.log('  ✅ DomPatcher class token equality tests passed!');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+function testClassRemovalStillWorks() {
+  console.log('🧪 Testing DomPatcher class attribute removal...');
+  setupDOMMock();
+
+  try {
+    const patcher = new DomPatcher();
+    const container = patchContainer(patcher, '<div class="btn active"><span>x</span></div>');
+    patcher.patch(container.parentNode || container, '<div><span>x</span></div>');
+
+    assert.strictEqual(
+      container.hasAttribute('class'),
+      false,
+      'Class attribute should be removed when absent from the new markup',
+    );
+
+    console.log('  ✅ DomPatcher class removal test passed!');
+  } finally {
+    teardownDOMMock();
+  }
+}
+
+try {
+  testClassTokenEqualitySkipsRedundantWrites();
+  testClassRemovalStillWorks();
+  console.log('✅ domPatch class-token comparison tests passed!');
+} catch (err) {
+  console.error('❌ domPatch class-token comparison tests FAILED:', err.message);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Fixes #996 — `DomPatcher` no longer issues redundant `setAttribute('class', ...)` calls when the effective class list is unchanged.

## Changes

- `lib/core/renderer/domPatch.js`: added a `classTokensEqual` helper that normalizes class attribute strings into sorted, de-duplicated token sets. In `#patchAttributes`, class attributes are now compared with token-set equality instead of raw string equality.
- `test/unit/domPatch.test.js`: new unit tests covering:
  - identical tokens in a different order → no class write
  - extra whitespace between tokens → no class write
  - duplicate tokens normalizing to the same set → no class write
  - a genuine class change → write happens
  - class attribute removal when absent from new markup

## Validation

- `node test/run-tests.js unit`: 89/90 pass (the sole failure, `serve.test.js`, also fails on clean `main` without these changes)
- `npx eslint` on changed files: clean

## Performance benefit

Skipping redundant DOM class writes reduces mutations during dynamic component updates and list re-renders, per the issue's motivation.
