### PR TITLE
fix(event-executor): standardize event error logging

### DIFF
--- a/lib/core/events/eventExecutor.js
+++ b/lib/core/events/eventExecutor.js
@@ -46,8 +46,16 @@ export class EventExecutor {
           } catch (err) {
             const elTag = evt?.target?.tagName || 'UNKNOWN';
             const eType = evt?.type || 'unknown';
-            
+            /**
+             * Error wrapper for event execution failures.
+             * @private
+             */
             class AvenxEventExecutionError extends Error {
+              /**
+               * @param {Error} originalError - The original error thrown during execution
+               * @param {string} elTag - The element tag name
+               * @param {string} eType - The event type
+               */
               constructor(originalError, elTag, eType) {
                 super(originalError.message || String(originalError));
                 this.name = originalError.name || 'Error';
@@ -56,6 +64,10 @@ export class EventExecutor {
                 this.elTag = elTag;
                 this.eType = eType;
               }
+              /**
+               * Returns a formatted error message with context
+               * @returns {string} Formatted error string
+               */
               toString() {
                 return `${this.name}: ${this.message} \n[Context] Element: <${this.elTag}>, Event: '${this.eType}'`;
               }

--- a/lib/core/events/eventExecutor.js
+++ b/lib/core/events/eventExecutor.js
@@ -1,4 +1,6 @@
 import { AvenxSandbox } from '../security/sandbox.js';
+import { logger } from '../runtime/AvenxLogger.js';
+import { AvenxErrorCodes, formatMessage } from '../runtime/AvenxError.js';
 
 /**
  * Handles the execution of event handlers.
@@ -32,15 +34,51 @@ export class EventExecutor {
       throw new TypeError('Handler is not configured or has been torn down.');
     }
 
-    let fn = this.#compiledHandlerCache.get(source);
-    if (!fn) {
-      AvenxSandbox.validateSource(source);
-      fn = new Function('state', 'methods', 'event', 'args', `with(state) { with(methods) { ${source} } }`);
-      fn.source = source;
-      this.#compiledHandlerCache.set(source, fn);
-    }
+    try {
+      let fn = this.#compiledHandlerCache.get(source);
+      if (!fn) {
+        AvenxSandbox.validateSource(source);
+        const originalFn = new Function('state', 'methods', 'event', 'args', `with(state) { with(methods) { ${source} } }`);
+        
+        fn = function(state, methods, evt, args) {
+          try {
+            return originalFn(state, methods, evt, args);
+          } catch (err) {
+            const elTag = evt?.target?.tagName || 'UNKNOWN';
+            const eType = evt?.type || 'unknown';
+            
+            class AvenxEventExecutionError extends Error {
+              constructor(originalError, elTag, eType) {
+                super(originalError.message || String(originalError));
+                this.name = originalError.name || 'Error';
+                this.cause = originalError;
+                this.stack = originalError.stack;
+                this.elTag = elTag;
+                this.eType = eType;
+              }
+              toString() {
+                return `${this.name}: ${this.message} \n[Context] Element: <${this.elTag}>, Event: '${this.eType}'`;
+              }
+            }
 
-    return this.runHandler(fn, event, slotScope);
+            throw new AvenxEventExecutionError(err, elTag, eType);
+          }
+        };
+        
+        fn.source = source;
+        this.#compiledHandlerCache.set(source, fn);
+      }
+
+      return this.runHandler(fn, event, slotScope);
+    } catch (error) {
+      const compContext = event?.target?.__avenx_comp_instance?.$logContext || {};
+      const elTag = event?.target?.tagName || 'UNKNOWN';
+      const eType = event?.type || 'unknown';
+      const msg = formatMessage(AvenxErrorCodes.EVENT_HANDLER_ERROR, source, error);
+      const extendedMsg = `${msg} \n[Context] Element: <${elTag}>, Event: '${eType}'`;
+      logger.error(extendedMsg, compContext);
+      throw error;
+    }
   }
 
   /**

--- a/test/unit/eventExecutor.test.js
+++ b/test/unit/eventExecutor.test.js
@@ -20,14 +20,14 @@ try {
   // 1. Existing successful event execution still works
   {
     let executeCount = 0;
-    const runHandler = (fn, event, scope) => {
+    const runHandler = (fn, event) => {
       executeCount++;
       return fn({ count: 0 }, {}, event, []);
     };
     const executor = new EventExecutor(runHandler);
     const mockEvent = createMockEvent('BUTTON', 'click', 'TestComp');
     
-    const result = executor.execute('state.count++', mockEvent);
+    executor.execute('state.count++', mockEvent);
     
     assert.strictEqual(executeCount, 1, 'runHandler should execute successfully');
   }
@@ -35,13 +35,13 @@ try {
   // 2. Runtime Error Execution path
   {
     const originalLoggerError = logger.error;
-    let loggedMessages = [];
+    const loggedMessages = [];
     logger.error = (msg, ctx) => {
       loggedMessages.push({ msg, ctx });
     };
 
     let caughtError = null;
-    const runHandler = (fn, event, scope) => {
+    const runHandler = (fn, event) => {
       // Simulate AvenxComponent's catch block logic
       try {
         fn({ state: {} }, {}, event, []);
@@ -76,7 +76,7 @@ try {
   // 3. Compilation Error path (Syntax Error)
   {
     const originalLoggerError = logger.error;
-    let loggedMessages = [];
+    const loggedMessages = [];
     logger.error = (msg, ctx) => {
       loggedMessages.push({ msg, ctx });
     };
@@ -88,7 +88,7 @@ try {
     try {
       let errorThrown = null;
       try {
-        executor.execute("class { foo() {", mockEvent);
+        executor.execute('class { foo() {', mockEvent);
       } catch (e) {
         errorThrown = e;
       }
@@ -100,7 +100,7 @@ try {
       assert.strictEqual(log.ctx.componentName, 'ErrorComp', 'Component name should be present in context');
       assert.ok(log.msg.includes('<SPAN>'), 'Element tag should be present in log message');
       assert.ok(log.msg.includes("'click'"), 'Event type should be present in log message');
-      assert.ok(log.msg.includes("class { foo() {"), 'Action string should be present in log message');
+      assert.ok(log.msg.includes('class { foo() {'), 'Action string should be present in log message');
       assert.ok(log.msg.includes('[AVX_R09]'), 'Should have AVX_R09');
     } finally {
       logger.error = originalLoggerError;
@@ -112,7 +112,7 @@ try {
     const executor = new EventExecutor(null);
     let errorThrown = false;
     try {
-      executor.execute("state.x = 1");
+      executor.execute('state.x = 1');
     } catch (err) {
       errorThrown = true;
       assert.ok(err instanceof TypeError, 'Should throw TypeError if handler torn down');

--- a/test/unit/eventExecutor.test.js
+++ b/test/unit/eventExecutor.test.js
@@ -1,0 +1,127 @@
+import assert from 'assert';
+import { EventExecutor } from '../../lib/core/events/eventExecutor.js';
+import { logger } from '../../lib/core/runtime/AvenxLogger.js';
+
+try {
+  console.log('🧪 Testing EventExecutor...');
+
+  const createMockEvent = (tagName, eventType, componentName) => {
+    return {
+      type: eventType,
+      target: {
+        tagName,
+        __avenx_comp_instance: {
+          $logContext: { componentName }
+        }
+      }
+    };
+  };
+
+  // 1. Existing successful event execution still works
+  {
+    let executeCount = 0;
+    const runHandler = (fn, event, scope) => {
+      executeCount++;
+      return fn({ count: 0 }, {}, event, []);
+    };
+    const executor = new EventExecutor(runHandler);
+    const mockEvent = createMockEvent('BUTTON', 'click', 'TestComp');
+    
+    const result = executor.execute('state.count++', mockEvent);
+    
+    assert.strictEqual(executeCount, 1, 'runHandler should execute successfully');
+  }
+
+  // 2. Runtime Error Execution path
+  {
+    const originalLoggerError = logger.error;
+    let loggedMessages = [];
+    logger.error = (msg, ctx) => {
+      loggedMessages.push({ msg, ctx });
+    };
+
+    let caughtError = null;
+    const runHandler = (fn, event, scope) => {
+      // Simulate AvenxComponent's catch block logic
+      try {
+        fn({ state: {} }, {}, event, []);
+      } catch (err) {
+        caughtError = err;
+        // Simulate AvenxComponent logging the stringified error
+        logger.error(`[AVX_R09] Event handler execution failed for statement "throw new Error('boom')". Error: ${err}`, { componentName: 'TestComp' });
+      }
+    };
+    
+    const executor = new EventExecutor(runHandler);
+    const mockEvent = createMockEvent('DIV', 'mouseover', 'TestComp');
+    
+    try {
+      executor.execute("throw new Error('boom')", mockEvent);
+      
+      assert.ok(caughtError, 'Error should be thrown and caught by runHandler simulator');
+      assert.strictEqual(caughtError.cause.message, 'boom', 'Original error should be preserved as cause');
+      
+      const log = loggedMessages[0];
+      assert.ok(log, 'Logger should be called');
+      assert.strictEqual(log.ctx.componentName, 'TestComp', 'Component name should be present in context');
+      assert.ok(log.msg.includes('<DIV>'), 'Element tag should be present in stringified error message');
+      assert.ok(log.msg.includes("'mouseover'"), 'Event type should be present in stringified error message');
+      assert.ok(log.msg.includes("throw new Error('boom')"), 'Action string should be present');
+      assert.ok(log.msg.includes('[AVX_R09]'), 'Should have AVX_R09');
+    } finally {
+      logger.error = originalLoggerError;
+    }
+  }
+
+  // 3. Compilation Error path (Syntax Error)
+  {
+    const originalLoggerError = logger.error;
+    let loggedMessages = [];
+    logger.error = (msg, ctx) => {
+      loggedMessages.push({ msg, ctx });
+    };
+
+    const runHandler = () => {};
+    const executor = new EventExecutor(runHandler);
+    const mockEvent = createMockEvent('SPAN', 'click', 'ErrorComp');
+    
+    try {
+      let errorThrown = null;
+      try {
+        executor.execute("class { foo() {", mockEvent);
+      } catch (e) {
+        errorThrown = e;
+      }
+      
+      assert.ok(errorThrown instanceof SyntaxError, 'Execute should throw on compilation error');
+      
+      const log = loggedMessages[0];
+      assert.ok(log, 'Logger should be called for compilation error');
+      assert.strictEqual(log.ctx.componentName, 'ErrorComp', 'Component name should be present in context');
+      assert.ok(log.msg.includes('<SPAN>'), 'Element tag should be present in log message');
+      assert.ok(log.msg.includes("'click'"), 'Event type should be present in log message');
+      assert.ok(log.msg.includes("class { foo() {"), 'Action string should be present in log message');
+      assert.ok(log.msg.includes('[AVX_R09]'), 'Should have AVX_R09');
+    } finally {
+      logger.error = originalLoggerError;
+    }
+  }
+
+  // 4. Missing Handler (Torn down state)
+  {
+    const executor = new EventExecutor(null);
+    let errorThrown = false;
+    try {
+      executor.execute("state.x = 1");
+    } catch (err) {
+      errorThrown = true;
+      assert.ok(err instanceof TypeError, 'Should throw TypeError if handler torn down');
+    }
+    assert.ok(errorThrown, 'Should preserve existing error behavior for unconfigured handler');
+  }
+
+  console.log('✅ EventExecutor tests passed.');
+} catch (e) {
+  console.error(`❌ EventExecutor test failed: ${e.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

fix #999 
Standardizes error handling and diagnostic logging for inline event expression failures in `EventExecutor`.

## Changes

- Standardized `AvenxLogger.error` dispatch for event handler failures.
- Added consistent component, element, event, and action context to diagnostics.
- Preserved `AVX_R09` error handling and original exception details.
- Added unit test coverage for runtime and compilation error paths.
- Preserved existing successful event execution and teardown behavior.

## Testing

- Updated `test/unit/eventExecutor.test.js`
- Verified runtime event-handler errors.
- Verified compilation/error handling.
- Verified diagnostic context metadata.
- Verified existing successful event behavior.

## Scope

This change is limited to EventExecutor error handling and its corresponding unit tests.