### PR TITLE
Add triggerEvent helper to AvenxMock

### DIFF
--- a/lib/core/runtime/AvenxMock.js
+++ b/lib/core/runtime/AvenxMock.js
@@ -255,6 +255,103 @@ export class AvenxMock {
   }
 
   /**
+   * Triggers a DOM or custom event on an element.
+   * Uses native event constructors for common DOM events and CustomEvent
+   * for custom component events.
+   *
+   * @param {Element|object} target - Target element.
+   * @param {string} eventName - Event name.
+   * @param {object} [detailOrOptions={}] - Event detail or event options.
+   * @returns {Event|object}
+   */
+  static triggerEvent(target, eventName, detailOrOptions = {}) {
+    if (!target) {
+      throw new Error('triggerEvent requires a target element.');
+    }
+
+    const options =
+      detailOrOptions && typeof detailOrOptions === 'object'
+        ? detailOrOptions
+        : {};
+
+    // Real DOM element
+    if (typeof target.dispatchEvent === 'function') {
+      if ('value' in options && 'value' in target) {
+        target.value = options.value;
+      }
+
+      let event;
+
+      switch (eventName) {
+        case 'click':
+          if (typeof MouseEvent !== 'undefined') {
+            event = new MouseEvent(eventName, {
+              bubbles: true,
+              cancelable: true,
+              ...options,
+            });
+          }
+          break;
+
+        case 'input':
+          if (typeof InputEvent !== 'undefined') {
+            event = new InputEvent(eventName, {
+              bubbles: true,
+              cancelable: true,
+              ...options,
+            });
+          }
+          break;
+
+        case 'keyup':
+          if (typeof KeyboardEvent !== 'undefined') {
+            event = new KeyboardEvent(eventName, {
+              bubbles: true,
+              cancelable: true,
+              ...options,
+            });
+          }
+          break;
+
+        default:
+          break;
+      }
+
+      // Fallback for unsupported/missing native event constructors
+      if (!event) {
+        if (typeof CustomEvent !== 'undefined') {
+          event = new CustomEvent(eventName, {
+            bubbles: true,
+            cancelable: true,
+            detail: detailOrOptions,
+          });
+        } else if (typeof Event !== 'undefined') {
+          event = new Event(eventName, {
+            bubbles: true,
+            cancelable: true,
+          });
+        }
+      }
+
+      if (!event) {
+        throw new Error('No supported Event constructor available.');
+      }
+
+      target.dispatchEvent(event);
+      return event;
+    }
+
+    // Mock element
+    AvenxMock.trigger(target, eventName, detailOrOptions);
+
+    return {
+      type: eventName,
+      target,
+      ...options,
+    };
+  }
+
+  /**
    * Triggers an event on an element.
    * Supports standard DOM Event/CustomEvent and custom MockNode trigger method.
    * @param {Element} element


### PR DESCRIPTION
## Summary

Added a new `AvenxMock.triggerEvent()` helper to simplify event triggering in tests.

## Changes

- Added `AvenxMock.triggerEvent()` in `lib/core/runtime/AvenxMock.js`
- Supports common DOM events:
  - `click`
  - `input`
  - `keyup`
- Supports custom events through `CustomEvent`
- Supports both real DOM elements and mock elements
- Supports event options/details
- Handles environments where native event constructors may not be available
- Keeps the existing `AvenxMock.trigger()` behavior unchanged

## Validation

- All existing tests passed: **111/111**
- `git diff --check` passed
- No other files were modified

## Commit

`65f09af` — Add triggerEvent helper to AvenxMock