### PR TITLE
docs: expand React migration guide Section 5 (Data Fetching and Async Patterns)

### DIFF
--- a/docs/src/content/docs/migration/react.md
+++ b/docs/src/content/docs/migration/react.md
@@ -41,4 +41,186 @@ React components are JavaScript functions returning JSX elements, where state up
 
 ## 5. Data Fetching and Async Patterns
 
-*This section will document migrating fetching logic to `<resource>` tags, `<@suspense>`, and `<@errorBoundary>`.*
+React data fetching typically combines `useEffect` with manual `loading` / `error` state flags, or delegates to a library like TanStack Query. Avenx-JS provides built-in reactive data fetching through the [`<resource>` SFC tag & `Resource` API](/core-concepts/resources): a resource declares *what* to fetch, tracks the reactive state it reads, and re-fetches automatically when that state changes — with `<@suspense>` and `<@errorBoundary>` handling loading and failure declaratively. See the [Migration Overview](/migration/overview) for where fetching fits in the overall paradigm map.
+
+### 5.1 Replacing Manual Fetch Effects
+
+React's canonical pattern is a `useEffect` with manual flags:
+
+```jsx
+// React: manual loading/error flags + effect + cleanup
+import { useState, useEffect } from 'react';
+
+export function UserProfile({ userId }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/users/${userId}`)
+      .then(res => res.json())
+      .then(data => {
+        setUser(data);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err);
+        setLoading(false);
+      });
+  }, [userId]);
+
+  if (loading) return <div>Loading user...</div>;
+  if (error) return <div>Failed to load user: {error.message}</div>;
+
+  return <div>Welcome, {user.name}!</div>;
+}
+```
+
+The `<resource>` tag replaces the effect, the manual flags, and the `return`-based conditional rendering in one step:
+
+```html
+<!-- Avenx-JS: src/components/user-profile/user-profile.component.js -->
+<state userId="1" />
+<resource name="userData">
+  return fetch(`/api/users/${state.userId}`).then(res => res.json());
+</resource>
+
+<@errorBoundary>
+  <@suspense>
+    <div>
+      Welcome, {{ userData.value.name }}!
+    </div>
+    <@fallback>
+      <div>Loading user...</div>
+    </@fallback>
+  </@suspense>
+  <@fallback as="err">
+    <div>Failed to load user: {{ err.message }}</div>
+  </@fallback>
+</@errorBoundary>
+```
+
+> [!NOTE]
+> `useEffect`'s dependency array (`[userId]`) has no Avenx equivalent — it isn't needed. The resource reads `state.userId` during its handler, so `AvenxWatcher` registers it as a dependency automatically (see [5.2](#52-automatic-dependency-tracking)).
+
+### 5.2 Automatic Dependency Tracking
+
+When a `<resource>` handler reads reactive state (like `state.userId` or `state.filter`), that property is registered as a dependency. The next time it mutates, the resource **re-fetches automatically** — no effect, no dependency array, no manual re-trigger:
+
+```jsx
+// React: effect + deps + manual state to retrigger
+function UserPosts({ userId }) {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    fetch(`/api/users/${userId}/posts`).then(r => r.json()).then(setPosts);
+  }, [userId]);
+
+  return <ul>{posts.map(p => <li key={p.id}>{p.title}</li>)}</ul>;
+}
+```
+
+```html
+<!-- Avenx-JS: changing state.userId re-fetches automatically -->
+<state userId="1" />
+<resource name="posts">
+  return fetch(`/api/users/${state.userId}/posts`).then(r => r.json());
+</resource>
+
+<ul>
+  <li data-ax-for="post in posts.value" key="post.id">
+    {{ post.title }}
+  </li>
+</ul>
+```
+
+> [!TIP]
+> A single resource can track many dependencies. Reading `state.filter`, `state.page`, and `state.search` in one handler means updating any of them re-fetches with the current values — the equivalent of a React effect with a multi-entry dependency array.
+
+### 5.3 Suspense Loading Boundaries
+
+React Suspense needs a fallback on the nearest boundary and a throwing promise to suspend on. Avenx-JS does the same with `<@suspense>` and `<@fallback>` — the resource's `.read()` semantics (see the [`<resource>` guide](/core-concepts/resources)) throw while pending, and the boundary renders the fallback until the data resolves:
+
+```jsx
+// React: <Suspense fallback={<div>Loading user...</div>}>
+```
+
+```html
+<!-- Avenx-JS -->
+<@suspense>
+  <div>Welcome, {{ userData.value.name }}!</div>
+  <@fallback>
+    <div>Loading user...</div>
+  </@fallback>
+</@suspense>
+```
+
+### 5.4 Error Boundary Wrapping
+
+Wrapping `<@suspense>` in `<@errorBoundary>` keeps the loading fallback and the error UI in one place. The boundary's `<@fallback as="err">` receives the rejection reason, mirroring React's `componentDidCatch` / `errorElement`:
+
+```jsx
+// React: error boundary class + fallback UI per boundary
+```
+
+```html
+<!-- Avenx-JS -->
+<@errorBoundary>
+  <@suspense>
+    <div>Welcome, {{ userData.value.name }}!</div>
+    <@fallback>
+      <div>Loading user...</div>
+    </@fallback>
+  </@suspense>
+  <@fallback as="err">
+    <div>Failed to load user: {{ err.message }}</div>
+  </@fallback>
+</@errorBoundary>
+```
+
+### 5.5 No Manual State Flags
+
+React's `isLoading` / `error` booleans are redundant in Avenx-JS. Every resource exposes reactive `status`, `value`, and `error` properties that the template reads directly — e.g. `data-ax-show` for status-driven UI, or the Suspense/Error boundary pattern above:
+
+| React flag | Avenx-JS reactive property |
+| :--- | :--- |
+| `loading === true` | `resource.status === 'pending'` |
+| `data` | `resource.value` |
+| `error` | `resource.error` |
+
+```html
+<!-- Status-driven rendering without <@suspense> (e.g. inline spinners) -->
+<div data-ax-show="userData.status === 'pending'">Loading user...</div>
+<div data-ax-show="userData.status === 'rejected'">{{ userData.error.message }}</div>
+<div data-ax-show="userData.status === 'resolved'">Welcome, {{ userData.value.name }}!</div>
+```
+
+### 5.6 Background Polling
+
+React polling means `setInterval` + cleanup inside an effect. Set `pollInterval` (milliseconds) on the `<resource>` tag instead — the framework owns the timer and clears it on unmount (`resource.teardown()`):
+
+```jsx
+// React: setInterval + clearInterval cleanup
+useEffect(() => {
+  const id = setInterval(() => {
+    fetch('/api/metrics').then(r => r.json()).then(setMetrics);
+  }, 5000);
+  return () => clearInterval(id);
+}, []);
+```
+
+```html
+<!-- Avenx-JS: re-fetches every 5s in the background -->
+<resource name="metrics" pollInterval="5000">
+  return fetch('/api/metrics').then(r => r.json());
+</resource>
+```
+
+### 5.7 Key Conceptual Differences & Pitfalls
+
+- **No manual `isLoading` / `error` flags**: the resource's reactive `status`, `value`, and `error` replace them; prefer `<@suspense>` / `<@errorBoundary>` over hand-rolled conditionals.
+- **No dependency arrays**: dependencies are *observed*, not declared. Refs to `state.*` inside the handler are tracked by `AvenxWatcher`; mutating one re-fetches automatically.
+- **Fallbacks nest, they don't wrap**: the loading fallback goes *inside* `<@suspense>`, the error fallback goes *inside* `<@errorBoundary>` — not the other way around.
+- **`value` vs `error` by status**: `resource.value` is `undefined` until `resolved`; `resource.error` is set only on `rejected`. Guard template reads with the status or a boundary rather than assuming `value` is populated.
+- **Polling cleans itself up**: `pollInterval` timers are cleared by `teardown()` on unmount; there is no effect cleanup to forget.


### PR DESCRIPTION
## Expand Section 5: Data Fetching and Async Patterns

Closes #1025

`docs/src/content/docs/migration/react.md` Section 5 was a stub. This
expands it into the async data-fetching migration guide:

- **5.1 Replacing Manual Fetch Effects** — `useEffect` + manual
  `loading`/`error` flags → `<resource>` block syntax (the issue's
  UserProfile example, Before/After).
- **5.2 Automatic Dependency Tracking** — how reads of `state.userId`
  inside the resource handler register with `AvenxWatcher` and re-fetch on
  mutation; multi-dependency tip.
- **5.3 Suspense Loading Boundaries** — `<@suspense>` + `<@fallback>`
  declarative loading.
- **5.4 Error Boundary Wrapping** — `<@errorBoundary>` +
  `<@fallback as="err">` isolated error handling.
- **5.5 No Manual State Flags** — React flag → Avenx reactive property
  mapping table plus status-driven `data-ax-show` rendering.
- **5.6 Background Polling** — `pollInterval` replacing
  `setInterval`/`clearInterval` effect cleanup.
- **5.7 Key Conceptual Differences & Pitfalls** — no dependency arrays,
  nested (not wrapped) fallbacks, `value`/`error` availability by status,
  polling teardown.

Includes five Before/After code example pairs and links to
[`/core-concepts/resources`](/core-concepts/resources) and
[`/migration/overview`](/migration/overview), per the acceptance criteria.

Validation: `astro build` succeeds cleanly (44 pages); all seven subsections
render in the built page.
