### PR TITLE
docs: expand the React Effects and Lifecycle migration section (#1014)

### DIFF
--- a/docs/src/content/docs/migration/react.md
+++ b/docs/src/content/docs/migration/react.md
@@ -35,7 +35,112 @@ React components are JavaScript functions returning JSX elements, where state up
 
 ## 4. Effects and Lifecycle
 
-*This section will document replacing `useEffect` hooks with `onMount()` and `onUnmount()` class methods.*
+React runs side effects with `useEffect` and tears them down with the function it returns. Avenx-JS replaces both with explicit class lifecycle hooks: `onMount()` runs **once**, right after the component element is mounted to the document DOM, and `onUnmount()` runs right before the instance is detached. There is no dependency array and no returned cleanup function — teardown logic lives in its own hook.
+
+### Replacing `useEffect(fn, [])` with `onMount()`
+
+Initial DOM setup, timer initialization, and global event listeners belong in `onMount()`. Because the component is already attached to the document, you can query the DOM through `this.el` and safely reach `window` / `document`.
+
+#### Before — React `useEffect` with Cleanup
+
+```jsx
+import { useState, useEffect } from 'react';
+
+export function TimerComponent() {
+  const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setSeconds((s) => s + 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return <div>Active for: {seconds}s</div>;
+}
+```
+
+#### After — Avenx-JS Lifecycle Hooks
+
+```html
+<!-- src/components/timer/timer.component.js -->
+<state seconds="0" />
+
+<action name="onMount">
+  this.timer = setInterval(() => {
+    state.seconds++;
+  }, 1000);
+</action>
+
+<action name="onUnmount">
+  if (this.timer) clearInterval(this.timer);
+</action>
+
+<div>Active for: {{ state.seconds }}s</div>
+```
+
+State mutated inside `onMount()` flows into the template automatically — `{{ state.seconds }}` re-evaluates on every tick without any `setSeconds` call or effect re-run.
+
+### Moving Teardown Logic into `onUnmount()`
+
+React's cleanup function (`clearInterval`, `removeEventListener`, ...) maps directly to `onUnmount()`. Store every handle you create during `onMount()` as a property on `this` so the teardown hook can reach it.
+
+#### Before — React Event Listener with Cleanup
+
+```jsx
+import { useEffect } from 'react';
+
+export function WindowSizeTracker() {
+  useEffect(() => {
+    const handleResize = () => {
+      console.log('Window resized:', window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return <div>Resize the window</div>;
+}
+```
+
+#### After — Avenx-JS Listener Lifecycle
+
+```html
+<!-- src/components/window-size/window-size.component.js -->
+<action name="onMount">
+  this.handleResize = () => {
+    console.log('Window resized:', window.innerWidth);
+  };
+  window.addEventListener('resize', this.handleResize);
+</action>
+
+<action name="onUnmount">
+  if (this.handleResize) {
+    window.removeEventListener('resize', this.handleResize);
+  }
+</action>
+
+<div>Resize the window</div>
+```
+
+### Why There Are No Dependency Arrays
+
+In React, `useEffect(fn, [dep])` re-runs the effect when `dep` changes, and forgetting a dependency closes over stale values. Avenx-JS never re-runs side-effect hooks on state changes: `onMount()` runs strictly once per mount, and template expressions re-evaluate automatically whenever reactive `state` mutates. There is nothing to synchronize — the template is already reactive, so the stale-closure class of bugs disappears.
+
+### Pitfalls
+
+:::caution
+**No hook teardowns.** React `useEffect` returns a cleanup function that runs before the next effect run or on unmount. Avenx-JS isolates teardown inside the `onUnmount()` lifecycle hook — a returned function inside `onMount()` is ignored, so write the cleanup explicitly.
+:::
+
+- **Instance storage.** Keep timers, controllers, and event handlers as properties on `this` (e.g. `this.timer`, `this.handleResize`) so `onUnmount()` can reach them — do not rely on closure variables.
+- **Guard against partial mounts.** Check truthiness (`if (this.timer)`) before tearing down, in case `onMount()` threw before assigning the handle.
+- **Idempotent teardown.** `onUnmount()` can run for a component that never fully mounted; clearing a missing handle must be a no-op.
+- **Don't mutate state in update hooks.** Mutating reactive state synchronously inside `onBeforeUpdate()` / `onUpdate()` triggers another update cycle (`AVX_R11`).
+
+See the [Component Lifecycle Hooks](/core-concepts/lifecycle-hooks) reference for the full hook list and execution order, and the [Migration Overview](/migration/overview) for the high-level conceptual mapping from React.
 
 ---
 


### PR DESCRIPTION
## What

Fixes #1014 — expands **Section 4 (Effects and Lifecycle)** of the React migration guide (`docs/src/content/docs/migration/react.md`) from a stub into a comprehensive reference.

## Content

- **`useEffect(fn, [])` → `onMount()`** — initial DOM setup, timers, and global listeners, with the issue's Timer Before/After example pair.
- **Teardown → `onUnmount()`** — React's returned cleanup maps to the dedicated hook; a second Before/After pair covers event-listener lifecycle.
- **No dependency arrays** — explains that `onMount()` runs strictly once and template expressions re-evaluate automatically on `state` mutation, so there's nothing to synchronize and no stale-closure class of bugs.
- **Instance storage on `this`** — timers/listeners stored in `onMount()` are reachable from `onUnmount()`.
- **Pitfalls** — no hook teardowns (a returned function in `onMount()` is ignored), guarding against partial mounts, idempotent teardown, and the `AVX_R11` update-loop caution.
- Links to [Component Lifecycle Hooks](/core-concepts/lifecycle-hooks) and the [Migration Overview](/migration/overview), matching the guide's existing link conventions.

## Validation

- `npm run build` in `docs/` succeeds (44 pages, search index built); the new section renders in the built output.
- Only `react.md` modified.
