### PR TITLE
docs: expand Vue migration guide Section 2 (component structure and templates) (#1015)

### DIFF
--- a/docs/src/content/docs/migration/vue.md
+++ b/docs/src/content/docs/migration/vue.md
@@ -23,7 +23,179 @@ Vue single file components (`.vue`) encapsulate `<template>`, `<script>`, and `<
 
 ## 2. Component Structure and Templates
 
-*This section will document SFC to companion file mapping, `<@for>` loop tags with implicit `index`, and `<slot>` transclusion.*
+A Vue SFC wraps three concerns in one file: `<template>` (markup), `<script setup>` (logic), and `<style scoped>` (styles). Avenx-JS splits those same three concerns into **companion files**: a `.component.js` file that holds the HTML template plus top-level compiler tags for state and computed properties, and a `.component.css` file holding scoped styles. The template engine is plain HTML with a few compiler tags — see [Templates](/core-concepts/templates) for the full language, and the [Migration Overview](/migration/overview) for where companion files sit in the paradigm map.
+
+### SFC to Companion File Mapping
+
+| Vue SFC (`.vue`) | Avenx-JS |
+| :--- | :--- |
+| `<template>` | `.component.js` — the template IS the file's HTML |
+| `<script setup>` | `.component.js` — `data-props-*` attributes, `<state />`, `<computed />`, `<@for>`, actions |
+| `<style scoped>` | `.component.css` — `<@css>` named blocks bound via the `@css` attribute |
+| `defineProps([...])` | `data-props-*` attributes on the component tag in the parent; read via `this.props.*` |
+
+#### Before — Vue Single File Component (`.vue`)
+
+```html
+<!-- ItemList.vue -->
+<template>
+  <div class="list-container">
+    <header>
+      <slot name="header">Default Header</slot>
+    </header>
+    <ul>
+      <li v-for="(item, idx) in items" :key="item.id">
+        <span>{{ idx + 1 }}. {{ item.name }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+defineProps(['items']);
+</script>
+
+<style scoped>
+.list-container { padding: 1rem; }
+</style>
+```
+
+#### After — Avenx.js Companion Files
+
+```html
+<!-- src/components/item-list/item-list.component.js -->
+<div class="list-container" @css container>
+  <header>
+    <slot name="header">Default Header</slot>
+  </header>
+  <ul>
+    <@for item in this.props.items key="item.id">
+      <li>
+        <span>{{ index + 1 }}. {{ item.name }}</span>
+      </li>
+    </@for>
+  </ul>
+</div>
+```
+
+```css
+/* src/components/item-list/item-list.component.css */
+<@css>
+  container {
+    padding: 1rem;
+  }
+</@css>
+```
+
+Note the three changes that matter:
+
+1. **The template is the file.** There is no `<template>` wrapper — the component's root element is whatever the `.component.js` file returns.
+2. **Styles are scoped by name.** `<@css>` blocks are extracted, hashed into unique class suffixes, and bound to elements with the `@css` attribute (see [Styling](/core-concepts/styling)).
+3. **Props come through `this.props`.** The parent passes `items` with `data-props-items="..."`, and the child reads `this.props.items` — no `defineProps` declaration needed.
+
+### Loops: `v-for` → `<@for>`
+
+Vue's `v-for` is an element directive; Avenx's `<@for>` is a **compiler tag** that wraps the repeated block. Loop blocks are translated to `<template>` tags and managed by the `ListManager` for efficient DOM list updates.
+
+#### Before — Vue `v-for`
+
+```html
+<ul>
+  <li v-for="(item, idx) in items" :key="item.id">
+    <span>{{ idx + 1 }}. {{ item.name }}</span>
+  </li>
+</ul>
+```
+
+#### After — Avenx `<@for>`
+
+```html
+<ul>
+  <@for item in this.props.items key="item.id">
+    <li>
+      <span>{{ index + 1 }}. {{ item.name }}</span>
+    </li>
+  </@for>
+</ul>
+```
+
+### The Implicit `index` Variable
+
+Every `<@for>` loop automatically injects a **zero-indexed `index` variable** into the loop template scope — `ListManager` adds it for you on each iteration. You never declare it:
+
+```html
+<@for item in this.props.items key="item.id">
+  <span>{{ index + 1 }}. {{ item.name }}</span>
+</@for>
+```
+
+:::caution
+Do **not** write `(item, index) in list` inside `<@for>` like you would in Vue. `<@for>` takes exactly one item variable; the index is implicit and starts at `0`, so add `1` (as above) for a human-readable 1-based count.
+:::
+
+### Slots: Default and Named
+
+Avenx supports both Vue-style **default** and **named** slots. The child component declares a `<slot>` element (with a fallback body); the parent supplies content with a `slot="name"` attribute. If the parent provides no content for a slot, the child's fallback content renders instead.
+
+#### Before — Vue Named Slot
+
+```html
+<!-- Card.vue -->
+<div class="card">
+  <header>
+    <slot name="header">Default Header</slot>
+  </header>
+  <main>
+    <slot></slot>
+  </main>
+</div>
+```
+
+```html
+<!-- Parent.vue -->
+<Card>
+  <h2 slot="header">Special Title</h2>
+  <p>This content goes into the default slot!</p>
+</Card>
+```
+
+#### After — Avenx Slots
+
+```html
+<!-- src/components/card/card.component.js -->
+<div class="card" @css card>
+  <header>
+    <slot name="header">Default Header</slot>
+  </header>
+  <main>
+    <slot></slot>
+  </main>
+</div>
+```
+
+```html
+<!-- Parent template -->
+<Card>
+  <h2 slot="header">Special Title</h2>
+  <p>This content goes into the default slot!</p>
+</Card>
+```
+
+Named and default slot markup is identical between Vue and Avenx — only the file layout changes.
+
+### Checking Slot Presence (`this.$slots.has()`)
+
+A component can decide whether the parent actually supplied content for a slot using `this.$slots.has(slotName)` inside an action or logic block. This is the direct replacement for Vue's `this.$slots.header` checks:
+
+```html
+<!-- src/components/card/card.component.js -->
+<div class="card">
+  <h2 data-ax-show="this.$slots.has('header')">This card has a custom header</h2>
+  <slot name="header">Default Header</slot>
+</div>
+```
+
+`this.$slots.has()` returns `true` only when the parent passed matching content, letting you conditionally render fallback UI without emitting empty containers — pair it with `data-ax-show` (Avenx's conditional-visibility directive, the `v-if`/`v-show` replacement) as above. See [Slots and `$slots.has()`](/core-concepts/templates) in the Templates guide for the full details.
 
 ---
 


### PR DESCRIPTION
## What

Expands **Section 2 (Component Structure and Templates)** of the Vue migration guide per #1015's spec.

- **SFC → companion files**: a mapping table (`.vue` `<template>`/`<script setup>`/`<style scoped>` → `.component.js` / `.component.css` / `<@css>` blocks) plus the issue's required `ItemList.vue` → `item-list.component.js` + `item-list.component.css` Before/After pair.
- **`v-for` → `<@for>`**: Before/After, with the implicit zero-indexed `index` variable explained and a caution not to write `(item, index)` (index is injected by `ListManager`, never declared).
- **Slots**: default and named slot transclusion with a Before/After pair — markup is identical between Vue and Avenx, only the file layout changes.
- **`this.$slots.has()`**: slot-presence checks in actions/logic, shown paired with `data-ax-show` for conditional fallback rendering.

Every syntax claim was verified against the core-concepts docs before writing (`<@for>` + implicit `index`, `<slot name>` fallback, `$slots.has()`, `data-ax-show`, `<@css>` named blocks, `data-props-*` / `this.props`).

Links to [`/core-concepts/templates`](/core-concepts/templates) and [`/migration/overview`](/migration/overview) as required by the acceptance criteria.

## Verification

- Acceptance criteria met: Section 2 updated, **3+ Before/After examples** (File Structure, `<@for>` with implicit `index`, Named Slots), SFC mapping + `this.$slots.has()` documented, both required links present.
- `npm run build` (docs) clean: **44 pages, no broken links**.

Closes #1015
