### PR TITLE
fix: address triggerEvent CI checks

### DIFF
--- a/lib/core/runtime/AvenxMock.js
+++ b/lib/core/runtime/AvenxMock.js
@@ -258,10 +258,9 @@ export class AvenxMock {
    * Triggers a DOM or custom event on an element.
    * Uses native event constructors for common DOM events and CustomEvent
    * for custom component events.
-   *
    * @param {Element|object} target - Target element.
    * @param {string} eventName - Event name.
-   * @param {object} [detailOrOptions={}] - Event detail or event options.
+   * @param {object} [detailOrOptions] - Event detail or event options.
    * @returns {Event|object}
    */
   static triggerEvent(target, eventName, detailOrOptions = {}) {
@@ -284,8 +283,8 @@ export class AvenxMock {
 
       switch (eventName) {
         case 'click':
-          if (typeof MouseEvent !== 'undefined') {
-            event = new MouseEvent(eventName, {
+          if (typeof window !== 'undefined' && typeof window.MouseEvent !== 'undefined') {
+            event = new window.MouseEvent(eventName, {
               bubbles: true,
               cancelable: true,
               ...options,
@@ -294,8 +293,8 @@ export class AvenxMock {
           break;
 
         case 'input':
-          if (typeof InputEvent !== 'undefined') {
-            event = new InputEvent(eventName, {
+          if (typeof window !== 'undefined' && typeof window.InputEvent !== 'undefined') {
+            event = new window.InputEvent(eventName, {
               bubbles: true,
               cancelable: true,
               ...options,
@@ -304,8 +303,8 @@ export class AvenxMock {
           break;
 
         case 'keyup':
-          if (typeof KeyboardEvent !== 'undefined') {
-            event = new KeyboardEvent(eventName, {
+          if (typeof window !== 'undefined' && typeof window.KeyboardEvent !== 'undefined') {
+            event = new window.KeyboardEvent(eventName, {
               bubbles: true,
               cancelable: true,
               ...options,
@@ -319,14 +318,20 @@ export class AvenxMock {
 
       // Fallback for unsupported/missing native event constructors
       if (!event) {
-        if (typeof CustomEvent !== 'undefined') {
-          event = new CustomEvent(eventName, {
+        if (
+          typeof window !== 'undefined' &&
+          typeof window.CustomEvent !== 'undefined'
+        ) {
+          event = new window.CustomEvent(eventName, {
             bubbles: true,
             cancelable: true,
             detail: detailOrOptions,
           });
-        } else if (typeof Event !== 'undefined') {
-          event = new Event(eventName, {
+        } else if (
+          typeof window !== 'undefined' &&
+          typeof window.Event !== 'undefined'
+        ) {
+          event = new window.Event(eventName, {
             bubbles: true,
             cancelable: true,
           });


### PR DESCRIPTION
## Summary

Follow-up fix for PR #1027.

This addresses CI/environment compatibility issues in `AvenxMock.triggerEvent()` by safely accessing native event constructors through `window`.

## Changes

- Use `window.MouseEvent` for click events
- Use `window.InputEvent` for input events
- Use `window.KeyboardEvent` for keyup events
- Use `window.CustomEvent` and `window.Event` for fallbacks
- Keep the existing `triggerEvent()` behavior unchanged

## Related PR

Follow-up to #1027

Closes #983