### PR TITLE
fix: avoid custom directives updates for unchanges values

### DIFF
--- a/lib/core/renderer/domPatch.js
+++ b/lib/core/renderer/domPatch.js
@@ -697,9 +697,10 @@ export class DomPatcher {
             }
 
             const oldInfo = el.__avenx_directives.get(dirName);
+
             if (!oldInfo) {
               el.__avenx_directives.set(dirName, {
-                value: value,
+                value,
                 oldValue: undefined,
                 expression: expr,
                 mountedCalled: false,
@@ -707,10 +708,17 @@ export class DomPatcher {
               });
             } else {
               const oldValue = oldInfo.value;
+
               if (value !== oldValue) {
                 oldInfo.oldValue = oldValue;
                 oldInfo.value = value;
+                oldInfo.expression = expr;
                 oldInfo.valueChanged = true;
+              } else {
+                // The directive value has not changed.
+                // Make sure a previous update flag cannot trigger
+                // another updated() lifecycle call.
+                oldInfo.valueChanged = false;
               }
             }
 

--- a/test/unit/directives_custom.test.js
+++ b/test/unit/directives_custom.test.js
@@ -46,6 +46,15 @@ async function runTests() {
       }
     });
 
+    let sameValueUpdatedCalls = 0;
+
+    app.directive('same-value-test', {
+      mounted() {},
+      updated() {
+        sameValueUpdatedCalls++;
+      }
+    });
+
     assert.ok(app.directives.has('custom-test'), 'custom-test directive should be registered in app.directives');
 
     // 2. Verify focus directive makes the target input gain focus upon load
@@ -85,9 +94,37 @@ async function runTests() {
       }
     }
 
+    class SameValueComponent extends AvenxComponent {
+      constructor() {
+        super({ stateVal: 'same-value' });
+      }
+
+      render() {
+        return `<div data-ax-same-value-test="stateVal">Text</div>`;
+      }
+    }
+
+    const sameValueComp = new SameValueComponent({});
+    sameValueComp.$app = app;
+
+    const sameValueTarget = new MockDOMElement('div');
+    sameValueComp.mount(sameValueTarget);
+
+    // Assign the same value again
+    sameValueComp.state.stateVal = 'same-value';
+
+    // Wait for the batched update
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    assert.strictEqual(
+      sameValueUpdatedCalls,
+      0,
+      'updated hook should not be called when directive value remains unchanged'
+    );
+
     const lifeComp = new LifecycleComponent({});
     lifeComp.$app = app;
-    
+
     const targetEl = new MockDOMElement('div');
     lifeComp.mount(targetEl);
 


### PR DESCRIPTION
##Summary

Prevents custom directive updated() lifecycle hooks from being triggered when the resolved directive value has not changed.

##Changes

Track custom directive values between patch cycles.
Only set valueChanged when the new value differs from the previous value.
Update the stored directive expression when the value changes.
Reset valueChanged when the value remains unchanged.
Added a regression test covering the unchanged-value scenario.