### PR TITLE
feat(cli): color command output and compiler diagnostics

### DIFF
--- a/bin/avenx.js
+++ b/bin/avenx.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { AvenxCLI } from './cli.js';
+import { red } from './colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,7 +25,9 @@ function compareVersions(current, required) {
 
 if (!compareVersions(current, MIN_NODE_VERSION)) {
   console.error(
-    `Avenx requires Node.js ${MIN_NODE_VERSION.join('.')} or later.\n` + `Current version: ${process.versions.node}`,
+    red(
+      `Avenx requires Node.js ${MIN_NODE_VERSION.join('.')} or later.\n` + `Current version: ${process.versions.node}`,
+    ),
   );
   process.exit(1);
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url';
 import loadConfig from '../lib/config.js';
 import { loadEnv } from '../lib/env.js';
 import { checkGitStatus } from './utils.js';
+import { createSeverityFormatter, cyan, gray } from './colors.js';
 import { initProject } from './commands/init.js';
 import { generateComponent, generatePage, generateBridge, generateGuard } from './commands/generate.js';
 import { destroyComponent, destroyPage, destroyBridge, destroyGuard } from './commands/destroy.js';
@@ -30,6 +31,9 @@ export class AvenxCLI {
     loadEnv(this.baseDir);
     this.frameworkDir = path.join(__dirname, '..');
     this.config = { ...loadConfig(this.baseDir), ...options };
+    // Tint compiler warnings yellow and errors red for every command that compiles
+    // (build, check, watch, serve). Stays inert when colors are unsupported.
+    this.config.logging = { ...this.config.logging, formatter: createSeverityFormatter() };
   }
 
   /**
@@ -54,7 +58,9 @@ export class AvenxCLI {
         arg !== '--dry-run' &&
         arg !== '-d' &&
         arg !== '--force' &&
-        arg !== '-f',
+        arg !== '-f' &&
+        arg !== '--no-color' &&
+        arg !== '--no-colors',
     );
     const type = filteredArgs[0];
     const name = filteredArgs[1];
@@ -162,11 +168,11 @@ export class AvenxCLI {
       }
       case 'watch':
       case 'w':
-        console.log(`👀 Watching for changes in ${this.config.srcDir}/...\n`);
+        console.log(cyan(`👀 Watching for changes in ${this.config.srcDir}/...\n`));
         buildProject(this);
         watchProject(this);
         process.on('SIGINT', () => {
-          console.log('\nStopping watch...');
+          console.log(`\n${gray('Stopping watch...')}`);
           process.exit(0);
         });
         break;

--- a/bin/colors.js
+++ b/bin/colors.js
@@ -1,0 +1,119 @@
+/**
+ * @file colors.js
+ * @description Zero-dependency ANSI styling helpers for the Avenx CLI.
+ *
+ * Styles are applied only when the active terminal can render them. Detection
+ * follows the widely adopted conventions so that piped output, CI logs, and
+ * `--json` consumers keep receiving clean, parseable text:
+ *
+ * - `--no-color` / `--no-colors` argument  → always disabled
+ * - `NO_COLOR` environment variable        → always disabled (https://no-color.org)
+ * - `FORCE_COLOR` environment variable     → enabled unless set to `0`/`false`
+ * - `TERM=dumb`                            → disabled
+ * - non-TTY stdout (pipes, files, CI)      → disabled
+ *
+ * When styling is disabled every helper returns the plain string unchanged,
+ * so call sites never need to branch on color support themselves.
+ */
+
+/**
+ * Determines whether ANSI escape codes should be emitted for this process.
+ * @returns {boolean} True when the current stdout stream can render colors.
+ */
+export function detectColorSupport() {
+  const argv = process.argv || [];
+  if (argv.includes('--no-color') || argv.includes('--no-colors')) {
+    return false;
+  }
+
+  const env = process.env || {};
+  if (typeof env.NO_COLOR === 'string' && env.NO_COLOR !== '') {
+    return false;
+  }
+  if (typeof env.FORCE_COLOR === 'string' && env.FORCE_COLOR !== '') {
+    return env.FORCE_COLOR !== '0' && env.FORCE_COLOR !== 'false';
+  }
+  if (env.TERM === 'dumb') {
+    return false;
+  }
+
+  const stream = process.stdout;
+  if (!stream || !stream.isTTY) {
+    return false;
+  }
+  if (typeof stream.hasColors === 'function') {
+    return stream.hasColors();
+  }
+  return true;
+}
+
+let colorEnabled = detectColorSupport();
+
+/**
+ * Reports whether styling helpers currently emit ANSI escape codes.
+ * @returns {boolean}
+ */
+export function isColorEnabled() {
+  return colorEnabled;
+}
+
+/**
+ * Overrides color support, mainly for tests and explicit CLI flags.
+ * Call without arguments to re-run the automatic detection.
+ * @param {boolean} [value] - Force enable (true) or disable (false).
+ * @returns {boolean} The resolved state.
+ */
+export function setColorEnabled(value) {
+  colorEnabled = value === undefined ? detectColorSupport() : Boolean(value);
+  return colorEnabled;
+}
+
+/**
+ * Builds a styling function for an ANSI open/close code pair.
+ * Closing with the attribute-specific reset (instead of a full reset) keeps
+ * nested styles such as `bold(cyan('text'))` intact.
+ * @param {number} open - The ANSI code that enables the style.
+ * @param {number} close - The ANSI code that disables just that style.
+ * @returns {function(string): string} The styling function.
+ */
+function style(open, close) {
+  const openCode = `\x1b[${open}m`;
+  const closeCode = `\x1b[${close}m`;
+  return (text) => (colorEnabled ? `${openCode}${text}${closeCode}` : String(text));
+}
+
+/** Bold text, used for section headings. */
+export const bold = style(1, 22);
+/** Dimmed text, used for secondary details. */
+export const dim = style(2, 22);
+/** Red text, reserved for errors and failed checks. */
+export const red = style(31, 39);
+/** Green text, reserved for successful actions. */
+export const green = style(32, 39);
+/** Yellow text, reserved for warnings. */
+export const yellow = style(33, 39);
+/** Blue text, used for informational notices. */
+export const blue = style(34, 39);
+/** Cyan text, used for headings and highlighted values. */
+export const cyan = style(36, 39);
+/** Gray text, used for descriptions and hints. */
+export const gray = style(90, 39);
+
+/**
+ * Creates an AvenxLogger formatter that tints diagnostics by severity:
+ * warnings yellow and errors red, leaving informational build output untouched.
+ *
+ * The formatter returns the original argument list (no `[Avenx level]` prefix),
+ * matching the compiler's existing CLI output format, and only styles string
+ * arguments so Error objects and structured context keep their shape.
+ * @returns {function(string, any[]): any[]} A formatter for `logger.configure`.
+ */
+export function createSeverityFormatter() {
+  return (level, args) => {
+    const tint = level === 'warn' ? yellow : level === 'error' || level === 'fatal' ? red : null;
+    if (!tint || !Array.isArray(args)) {
+      return args;
+    }
+    return args.map((arg) => (typeof arg === 'string' ? tint(arg) : arg));
+  };
+}

--- a/bin/commands/build.js
+++ b/bin/commands/build.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import AvenxCompiler from '../../lib/compiler.js';
+import { cyan, gray, green, red } from '../colors.js';
 
 /**
  * Runs the compiler build along with optional prebuild and postbuild lifecycle hooks.
@@ -12,14 +13,14 @@ export function buildProject(cli) {
   const baseDir = (cli && cli.baseDir) || process.cwd();
 
   if (hooks.prebuild && typeof hooks.prebuild === 'string' && hooks.prebuild.trim() !== '') {
-    console.log(`🏃 Running prebuild hook: ${hooks.prebuild}...`);
+    console.log(gray(`🏃 Running prebuild hook: ${hooks.prebuild}...`));
     execSync(hooks.prebuild, { stdio: 'inherit', cwd: baseDir });
   }
 
   new AvenxCompiler(cli.config).build();
 
   if (hooks.postbuild && typeof hooks.postbuild === 'string' && hooks.postbuild.trim() !== '') {
-    console.log(`🏃 Running postbuild hook: ${hooks.postbuild}...`);
+    console.log(gray(`🏃 Running postbuild hook: ${hooks.postbuild}...`));
     execSync(hooks.postbuild, { stdio: 'inherit', cwd: baseDir });
   }
 }
@@ -31,11 +32,11 @@ export function buildProject(cli) {
 export function cleanProject(cli) {
   const distDir = path.join(cli.baseDir, cli.config.distDir);
   if (fs.existsSync(distDir)) {
-    console.log(`🧹 Cleaning build output directory: ${cli.config.distDir}...`);
+    console.log(cyan(`🧹 Cleaning build output directory: ${cli.config.distDir}...`));
     fs.rmSync(distDir, { recursive: true, force: true });
-    console.log('✅ Clean complete.');
+    console.log(green('✅ Clean complete.'));
   } else {
-    console.log(`🧹 Build output directory ${cli.config.distDir} does not exist. Nothing to clean.`);
+    console.log(cyan(`🧹 Build output directory ${cli.config.distDir} does not exist. Nothing to clean.`));
   }
 }
 
@@ -176,7 +177,7 @@ export function runCheckPass(cli, args = []) {
     if (isJson) {
       diagnostics.push(parseDiagnostic('error', [err]));
     } else {
-      originalError(`❌ ${err.message || err}`);
+      originalError(red(`❌ ${err.message || err}`));
     }
   } finally {
     console.warn = originalWarn;
@@ -210,7 +211,7 @@ export function checkProject(cli, args = []) {
     const srcDir = (cli && cli.config && cli.config.srcDir) || 'src';
     const srcPath = path.join((cli && cli.baseDir) || process.cwd(), srcDir);
 
-    console.log(`[${getTimestamp()}] 👀 Watching for template changes in ${srcDir}/...`);
+    console.log(cyan(`[${getTimestamp()}] 👀 Watching for template changes in ${srcDir}/...`));
 
     const executeCheck = () => {
       const timestamp = getTimestamp();
@@ -225,9 +226,9 @@ export function checkProject(cli, args = []) {
       } else {
         const totalIssues = report.warningCount + report.errorCount;
         if (totalIssues > 0) {
-          console.error(`[${timestamp}] ❌ Found ${totalIssues} validation issue(s).`);
+          console.error(red(`[${timestamp}] ❌ Found ${totalIssues} validation issue(s).`));
         } else {
-          console.log(`[${timestamp}] ✓ No template validation issues found.`);
+          console.log(green(`[${timestamp}] ✓ No template validation issues found.`));
         }
       }
       return report;
@@ -237,7 +238,7 @@ export function checkProject(cli, args = []) {
     const initialReport = executeCheck();
 
     if (!fs.existsSync(srcPath)) {
-      console.error(`❌ Source directory does not exist: ${srcPath}`);
+      console.error(red(`❌ Source directory does not exist: ${srcPath}`));
       return initialReport;
     }
 
@@ -246,14 +247,14 @@ export function checkProject(cli, args = []) {
       clearTimeout(timeout);
       timeout = setTimeout(() => {
         const fileMsg = filename ? ` in ${filename}` : '';
-        console.log(`\n[${getTimestamp()}] 📄 Change detected${fileMsg}. Re-checking templates...`);
+        console.log(`\n${cyan(`[${getTimestamp()}] 📄 Change detected${fileMsg}. Re-checking templates...`)}`);
         executeCheck();
       }, 100);
     });
 
 
     const cleanup = () => {
-      console.log('\nStopping template check watcher...');
+      console.log(`\n${gray('Stopping template check watcher...')}`);
       if (watcher) watcher.close();
       if (!cli || !cli._noExit) {
         process.exit(0);
@@ -284,7 +285,7 @@ export function checkProject(cli, args = []) {
 
   const totalIssues = report.warningCount + report.errorCount;
   if (totalIssues > 0) {
-    console.error(`\nFound ${totalIssues} validation issue(s).`);
+    console.error(`\n${red(`Found ${totalIssues} validation issue(s).`)}`);
     process.exitCode = 1;
     if (!cli || !cli._noExit) {
       process.exit(1);
@@ -292,7 +293,7 @@ export function checkProject(cli, args = []) {
     return report;
   }
 
-  console.log('✓ No template validation issues found.');
+  console.log(green('✓ No template validation issues found.'));
   process.exitCode = 0;
   if (!cli || !cli._noExit) {
     process.exit(0);

--- a/bin/commands/destroy.js
+++ b/bin/commands/destroy.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parseName, fail } from '../utils.js';
+import { cyan, gray, green } from '../colors.js';
 
 /**
  * Automatically removes imports, registrations, and mount statements for a class from src/main.app.js.
@@ -58,7 +59,7 @@ export function unregisterFromMainApp(cli, className, folderName) {
 
   if (content !== newContent) {
     fs.writeFileSync(mainPath, newContent);
-    console.log(`✅ Cleaned up imports and registrations for '${className}' in ${cli.config.srcDir}/main.app.js`);
+    console.log(green(`✅ Cleaned up imports and registrations for '${className}' in ${cli.config.srcDir}/main.app.js`));
   }
 }
 
@@ -78,22 +79,24 @@ export function destroyComponent(cli, name, dryRun = false) {
   const compDir = path.join(cli.baseDir, cli.config.srcDir, 'components', lowerName);
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Component '${lowerName}' files would be deleted:`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.js`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.css`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/`);
+    console.log(cyan(`🧪 [Dry Run] Component '${lowerName}' files would be deleted:`));
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.js`));
     console.log(
-      `🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove registrations/imports for '${capitalizedName}'.`,
+      gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.css`),
     );
-    console.log('🧪 [Dry Run] No files were deleted or modified.');
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/components/${lowerName}/`));
+    console.log(
+      cyan(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove registrations/imports for '${capitalizedName}'.`),
+    );
+    console.log(cyan('🧪 [Dry Run] No files were deleted or modified.'));
     return;
   }
 
   if (fs.existsSync(compDir)) {
     fs.rmSync(compDir, { recursive: true, force: true });
-    console.log(`✅ Component '${lowerName}' directory deleted at ${cli.config.srcDir}/components/${lowerName}/`);
+    console.log(green(`✅ Component '${lowerName}' directory deleted at ${cli.config.srcDir}/components/${lowerName}/`));
   } else {
-    console.log(`ℹ️ Component '${lowerName}' directory was not found.`);
+    console.log(gray(`ℹ️ Component '${lowerName}' directory was not found.`));
   }
 
   unregisterFromMainApp(cli, capitalizedName, lowerName);
@@ -117,13 +120,13 @@ export function destroyPage(cli, name, dryRun = false) {
   const cssPath = path.join(pageDir, `${lowerName}.page.css`);
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Page '${lowerName}' files would be deleted:`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/pages/${lowerName}.page.js`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/pages/${lowerName}.page.css`);
+    console.log(cyan(`🧪 [Dry Run] Page '${lowerName}' files would be deleted:`));
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/pages/${lowerName}.page.js`));
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/pages/${lowerName}.page.css`));
     console.log(
-      `🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations/routes for '${capitalizedName}'.`,
+      cyan(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations/routes for '${capitalizedName}'.`),
     );
-    console.log('🧪 [Dry Run] No files were deleted or modified.');
+    console.log(cyan('🧪 [Dry Run] No files were deleted or modified.'));
     return;
   }
 
@@ -140,9 +143,9 @@ export function destroyPage(cli, name, dryRun = false) {
   }
 
   if (deletedAny) {
-    console.log(`✅ Page '${capitalizedName}' files deleted.`);
+    console.log(green(`✅ Page '${capitalizedName}' files deleted.`));
   } else {
-    console.log(`ℹ️ Page '${capitalizedName}' files were not found.`);
+    console.log(gray(`ℹ️ Page '${capitalizedName}' files were not found.`));
   }
 
   unregisterFromMainApp(cli, capitalizedName, lowerName);
@@ -166,20 +169,22 @@ export function destroyBridge(cli, name, dryRun = false) {
   const bridgePath = path.join(globalDir, `${lowerName}.bridge.js`);
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Bridge '${capitalizedName}' file would be deleted:`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/global/${lowerName}.bridge.js`);
+    console.log(cyan(`🧪 [Dry Run] Bridge '${capitalizedName}' file would be deleted:`));
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/global/${lowerName}.bridge.js`));
     console.log(
-      `🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations for '${capitalizedName}'.`,
+      cyan(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations for '${capitalizedName}'.`),
     );
-    console.log('🧪 [Dry Run] No files were deleted or modified.');
+    console.log(cyan('🧪 [Dry Run] No files were deleted or modified.'));
     return;
   }
 
   if (fs.existsSync(bridgePath)) {
     fs.rmSync(bridgePath, { force: true });
-    console.log(`✅ Bridge '${capitalizedName}' file deleted at ${cli.config.srcDir}/global/${lowerName}.bridge.js`);
+    console.log(
+      green(`✅ Bridge '${capitalizedName}' file deleted at ${cli.config.srcDir}/global/${lowerName}.bridge.js`),
+    );
   } else {
-    console.log(`ℹ️ Bridge '${capitalizedName}' file was not found.`);
+    console.log(gray(`ℹ️ Bridge '${capitalizedName}' file was not found.`));
   }
 
   unregisterFromMainApp(cli, capitalizedName, lowerName);
@@ -203,20 +208,22 @@ export function destroyGuard(cli, name, dryRun = false) {
   const guardPath = path.join(guardDir, `${lowerName}.guard.js`);
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Guard '${capitalizedName}' file would be deleted:`);
-    console.log(`[DRY-RUN] Would delete: ${cli.config.srcDir}/guards/${lowerName}.guard.js`);
+    console.log(cyan(`🧪 [Dry Run] Guard '${capitalizedName}' file would be deleted:`));
+    console.log(gray(`[DRY-RUN] Would delete: ${cli.config.srcDir}/guards/${lowerName}.guard.js`));
     console.log(
-      `🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations for '${capitalizedName}'.`,
+      cyan(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated to remove imports/registrations for '${capitalizedName}'.`),
     );
-    console.log('🧪 [Dry Run] No files were deleted or modified.');
+    console.log(cyan('🧪 [Dry Run] No files were deleted or modified.'));
     return;
   }
 
   if (fs.existsSync(guardPath)) {
     fs.rmSync(guardPath, { force: true });
-    console.log(`✅ Guard '${capitalizedName}' file deleted at ${cli.config.srcDir}/guards/${lowerName}.guard.js`);
+    console.log(
+      green(`✅ Guard '${capitalizedName}' file deleted at ${cli.config.srcDir}/guards/${lowerName}.guard.js`),
+    );
   } else {
-    console.log(`ℹ️ Guard '${capitalizedName}' file was not found.`);
+    console.log(gray(`ℹ️ Guard '${capitalizedName}' file was not found.`));
   }
 
   unregisterFromMainApp(cli, capitalizedName, lowerName);

--- a/bin/commands/doctor.js
+++ b/bin/commands/doctor.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
+import { bold, cyan, green, yellow, red, gray } from '../colors.js';
 
 const MIN_NODE_VERSION = [18, 0, 0];
 
@@ -43,10 +44,10 @@ function compareVersions(current, required) {
  * @param {string} [hint]
  */
 function printCheck(status, message, hint) {
-  const icons = { pass: '\x1b[32m✔\x1b[0m', warn: '\x1b[33m⚠\x1b[0m', fail: '\x1b[31m✖\x1b[0m' };
+  const icons = { pass: green('✔'), warn: yellow('⚠'), fail: red('✖') };
   console.log(`  ${icons[status]} ${message}`);
   if (hint) {
-    console.log(`    \x1b[90m→ ${hint}\x1b[0m`);
+    console.log(`    ${gray(`→ ${hint}`)}`);
   }
 }
 
@@ -98,11 +99,11 @@ export function runDoctor(cli) {
     printCheck(status, message, hint);
   };
 
-  console.log('\x1b[1;36mAvenx Doctor\x1b[0m');
-  console.log(`Project root: ${root}\n`);
+  console.log(bold(cyan('Avenx Doctor')));
+  console.log(`${gray(`Project root: ${root}`)}\n`);
 
   // --- Node.js ---
-  console.log('\x1b[1mNode.js\x1b[0m');
+  console.log(bold('Node.js'));
   const current = process.versions.node.split('.').map(Number);
   if (compareVersions(current, MIN_NODE_VERSION)) {
     record('pass', `Node.js ${process.versions.node} (>= ${MIN_NODE_VERSION.join('.')})`);
@@ -115,7 +116,7 @@ export function runDoctor(cli) {
   }
 
   // --- package.json ---
-  console.log('\n\x1b[1mProject files\x1b[0m');
+  console.log(`\n${bold('Project files')}`);
   const pkgPath = path.join(root, 'package.json');
   let isFrameworkRepo = false;
   if (fs.existsSync(pkgPath)) {
@@ -185,7 +186,7 @@ export function runDoctor(cli) {
   }
 
   // --- Directories ---
-  console.log('\n\x1b[1mProject structure\x1b[0m');
+  console.log(`\n${bold('Project structure')}`);
   const srcRel = (userConfig && userConfig.srcDir) || cli.config.srcDir || 'src';
   const distRel = (userConfig && userConfig.distDir) || cli.config.distDir || 'dist';
   const srcDir = path.join(root, srcRel);
@@ -237,7 +238,7 @@ export function runDoctor(cli) {
   }
 
   // --- Git ---
-  console.log('\n\x1b[1mGit\x1b[0m');
+  console.log(`\n${bold('Git')}`);
   try {
     const output = execSync('git status --porcelain', {
       cwd: root,
@@ -254,12 +255,14 @@ export function runDoctor(cli) {
   }
 
   // --- Summary ---
-  console.log('\n\x1b[1mSummary\x1b[0m');
-  console.log(`  \x1b[32m${results.pass} passed\x1b[0m · \x1b[33m${results.warn} warnings\x1b[0m · \x1b[31m${results.fail} failed\x1b[0m`);
+  console.log(`\n${bold('Summary')}`);
+  console.log(
+    `  ${green(`${results.pass} passed`)} · ${yellow(`${results.warn} warnings`)} · ${red(`${results.fail} failed`)}`,
+  );
   if (results.fail > 0) {
-    console.log('\n\x1b[31mDoctor found issues that should be fixed.\x1b[0m\n');
+    console.log(`\n${red('Doctor found issues that should be fixed.')}\n`);
     process.exitCode = 1;
   } else {
-    console.log('\n\x1b[32mEnvironment looks healthy.\x1b[0m\n');
+    console.log(`\n${green('Environment looks healthy.')}\n`);
   }
 }

--- a/bin/commands/generate.js
+++ b/bin/commands/generate.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parseName, readTemplate, abortIfGeneratedPathExists, fail } from '../utils.js';
+import { cyan, gray, green, yellow } from '../colors.js';
 
 /**
  * Automatically adds import and registration for a component in src/main.app.js.
@@ -51,7 +52,7 @@ export function registerInMainApp(cli, className, folderName) {
   }
 
   fs.writeFileSync(mainPath, lines.join('\n'));
-  console.log(`✅ Component '${className}' registered in ${cli.config.srcDir}/main.app.js`);
+  console.log(green(`✅ Component '${className}' registered in ${cli.config.srcDir}/main.app.js`));
 }
 
 /**
@@ -78,16 +79,14 @@ export function generateBridge(cli, name, dryRun = false, force = false) {
   }
 
   if (force && fs.existsSync(bridgePath)) {
-    console.warn(
-      `\x1b[33m⚠️ Force enabled: overwriting existing Bridge '${lowerName}'.\x1b[0m`,
-    );
+    console.warn(yellow(`⚠️ Force enabled: overwriting existing Bridge '${lowerName}'.`));
   }
 
   if (dryRun) {
     console.log(
-      `🧪 [Dry Run] Bridge '${capitalizedName}' would be created at ${cli.config.srcDir}/global/${lowerName}.bridge.js`,
+      cyan(`🧪 [Dry Run] Bridge '${capitalizedName}' would be created at ${cli.config.srcDir}/global/${lowerName}.bridge.js`),
     );
-    console.log('🧪 [Dry Run] No files were written.');
+    console.log(cyan('🧪 [Dry Run] No files were written.'));
     return;
   }
 
@@ -99,8 +98,8 @@ export function generateBridge(cli, name, dryRun = false, force = false) {
 
   fs.writeFileSync(bridgePath, template.replace(/{{ name }}/g, capitalizedName));
 
-  console.log(`✅ Bridge '${capitalizedName}' generated at ${cli.config.srcDir}/global/${lowerName}.bridge.js`);
-  console.log(`ℹ️ It will be automatically registered as '${capitalizedName}' on the next build.`);
+  console.log(green(`✅ Bridge '${capitalizedName}' generated at ${cli.config.srcDir}/global/${lowerName}.bridge.js`));
+  console.log(gray(`ℹ️ It will be automatically registered as '${capitalizedName}' on the next build.`));
 }
 
 /**
@@ -127,16 +126,14 @@ export function generateGuard(cli, name, dryRun = false, force = false) {
   }
 
   if (force && fs.existsSync(guardPath)) {
-    console.warn(
-      `\x1b[33m⚠️ Force enabled: overwriting existing Guard '${lowerName}'.\x1b[0m`,
-    );
+    console.warn(yellow(`⚠️ Force enabled: overwriting existing Guard '${lowerName}'.`));
   }
 
   if (dryRun) {
     console.log(
-      `🧪 [Dry Run] Guard '${capitalizedName}' would be created at ${cli.config.srcDir}/guards/${lowerName}.guard.js`,
+      cyan(`🧪 [Dry Run] Guard '${capitalizedName}' would be created at ${cli.config.srcDir}/guards/${lowerName}.guard.js`),
     );
-    console.log('🧪 [Dry Run] No files were written.');
+    console.log(cyan('🧪 [Dry Run] No files were written.'));
     return;
   }
 
@@ -148,8 +145,8 @@ export function generateGuard(cli, name, dryRun = false, force = false) {
 
   fs.writeFileSync(guardPath, template.replace(/{{ name }}/g, capitalizedName));
 
-  console.log(`✅ Guard '${capitalizedName}' generated at ${cli.config.srcDir}/guards/${lowerName}.guard.js`);
-  console.log(`ℹ️ It can be used in your route configurations.`);
+  console.log(green(`✅ Guard '${capitalizedName}' generated at ${cli.config.srcDir}/guards/${lowerName}.guard.js`));
+  console.log(gray(`ℹ️ It can be used in your route configurations.`));
 }
 
 /**
@@ -176,16 +173,14 @@ export function generatePage(cli, name, dryRun = false, force = false) {
   }
 
   if (force && (fs.existsSync(jsPath) || fs.existsSync(cssPath))) {
-    console.warn(
-      `\x1b[33m⚠️ Force enabled: overwriting existing Page '${lowerName}'.\x1b[0m`,
-    );
+    console.warn(yellow(`⚠️ Force enabled: overwriting existing Page '${lowerName}'.`));
   }
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Page '${capitalizedName}' would be created at:`);
+    console.log(cyan(`🧪 [Dry Run] Page '${capitalizedName}' would be created at:`));
     console.log(`  ${cli.config.srcDir}/pages/${lowerName}.page.js`);
     console.log(`  ${cli.config.srcDir}/pages/${lowerName}.page.css`);
-    console.log('🧪 [Dry Run] No files were written.');
+    console.log(cyan('🧪 [Dry Run] No files were written.'));
     return;
   }
 
@@ -199,8 +194,8 @@ export function generatePage(cli, name, dryRun = false, force = false) {
   fs.writeFileSync(jsPath, jsTemplate.replace(/{{ name }}/g, capitalizedName));
   fs.writeFileSync(cssPath, cssTemplate);
 
-  console.log(`✅ Page '${capitalizedName}' generated at ${cli.config.srcDir}/pages/${lowerName}.page.js`);
-  console.log(`ℹ️ It will be automatically registered and routed if you update src/main.app.js.`);
+  console.log(green(`✅ Page '${capitalizedName}' generated at ${cli.config.srcDir}/pages/${lowerName}.page.js`));
+  console.log(gray(`ℹ️ It will be automatically registered and routed if you update src/main.app.js.`));
 }
 
 /**
@@ -225,19 +220,17 @@ export function generateComponent(cli, name, dryRun = false, force = false) {
   }
 
   if (force && fs.existsSync(compDir)) {
-    console.warn(
-      `\x1b[33m⚠️ Force enabled: overwriting existing Component '${lowerName}'.\x1b[0m`,
-    );
+    console.warn(yellow(`⚠️ Force enabled: overwriting existing Component '${lowerName}'.`));
   }
 
   if (dryRun) {
-    console.log(`🧪 [Dry Run] Component '${lowerName}' would be created at:`);
+    console.log(cyan(`🧪 [Dry Run] Component '${lowerName}' would be created at:`));
     console.log(`  ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.js`);
     console.log(`  ${cli.config.srcDir}/components/${lowerName}/${lowerName}.component.css`);
-    console.log(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated with:`);
+    console.log(cyan(`🧪 [Dry Run] ${cli.config.srcDir}/main.app.js would be updated with:`));
     console.log(`  import ${capitalizedName} from './components/${lowerName}/${lowerName}.component.js';`);
     console.log(`  app.register('${capitalizedName}', ${capitalizedName});`);
-    console.log('🧪 [Dry Run] No files were written.');
+    console.log(cyan('🧪 [Dry Run] No files were written.'));
     return;
   }
 
@@ -252,6 +245,6 @@ export function generateComponent(cli, name, dryRun = false, force = false) {
   );
   fs.writeFileSync(path.join(compDir, `${lowerName}.component.css`), cssTemplate);
 
-  console.log(`✅ Component '${lowerName}' generated at ${cli.config.srcDir}/components/${lowerName}/`);
+  console.log(green(`✅ Component '${lowerName}' generated at ${cli.config.srcDir}/components/${lowerName}/`));
   registerInMainApp(cli, capitalizedName, lowerName);
 }

--- a/bin/commands/help.js
+++ b/bin/commands/help.js
@@ -1,35 +1,37 @@
+import { bold, cyan, green, gray } from '../colors.js';
+
 /**
  * Prints the help message with available commands to the console.
  */
 export function printHelp() {
   console.log(`
-\x1b[1;36mAvenx-JS CLI\x1b[0m
-\x1b[1mUsage:\x1b[0m \x1b[32mavenx\x1b[0m \x1b[90m<command> [type] [name]\x1b[0m
+${bold(cyan('Avenx-JS CLI'))}
+${bold('Usage:')} ${green('avenx')} ${gray('<command> [type] [name]')}
 
-\x1b[1;36mCommands:\x1b[0m
-  \x1b[32minit\x1b[0m                      \x1b[90mInitialize a new Avenx project structure\x1b[0m
-  \x1b[32mgenerate component <name>\x1b[0m \x1b[90mGenerate a new component (alias: g)\x1b[0m
-  \x1b[32mgenerate page <name>\x1b[0m      \x1b[90mGenerate a new page (alias: g p)\x1b[0m
-  \x1b[32mgenerate bridge <name>\x1b[0m    \x1b[90mGenerate a new shared reactive bridge\x1b[0m
-  \x1b[32mgenerate guard <name>\x1b[0m     \x1b[90mGenerate a new route guard\x1b[0m
-  \x1b[32mdestroy component <name>\x1b[0m  \x1b[90mDelete a component and its registrations (alias: d)\x1b[0m
-  \x1b[32mdestroy page <name>\x1b[0m       \x1b[90mDelete a page (alias: d p)\x1b[0m
-  \x1b[32mdestroy bridge <name>\x1b[0m     \x1b[90mDelete a shared reactive bridge\x1b[0m
-  \x1b[32mdestroy guard <name>\x1b[0m      \x1b[90mDelete a route guard\x1b[0m
-  \x1b[32mbuild (b)\x1b[0m                 \x1b[90mBuild the project using configured output directory\x1b[0m
-  \x1b[32mclean\x1b[0m                     \x1b[90mClear build output directory\x1b[0m
-  \x1b[32mcheck (lint)\x1b[0m              \x1b[90mValidate templates without building\x1b[0m
-  \x1b[32mdoctor\x1b[0m                    \x1b[90mDiagnose environment, config, and project health\x1b[0m
-  \x1b[32minspect (i)\x1b[0m               \x1b[90mInspect project route and component hierarchy\x1b[0m
-  \x1b[32mserve [port]\x1b[0m              \x1b[90mStart dev server with hot-reload (default: 3000)\x1b[0m
-  \x1b[32mwatch (w)\x1b[0m                 \x1b[90mWatch for file changes and rebuild automatically\x1b[0m
-  \x1b[32mhelp\x1b[0m                      \x1b[90mShow this help message\x1b[0m
+${bold(cyan('Commands:'))}
+  ${green('init')}                      ${gray('Initialize a new Avenx project structure')}
+  ${green('generate component <name>')} ${gray('Generate a new component (alias: g)')}
+  ${green('generate page <name>')}      ${gray('Generate a new page (alias: g p)')}
+  ${green('generate bridge <name>')}    ${gray('Generate a new shared reactive bridge')}
+  ${green('generate guard <name>')}     ${gray('Generate a new route guard')}
+  ${green('destroy component <name>')}  ${gray('Delete a component and its registrations (alias: d)')}
+  ${green('destroy page <name>')}       ${gray('Delete a page (alias: d p)')}
+  ${green('destroy bridge <name>')}     ${gray('Delete a shared reactive bridge')}
+  ${green('destroy guard <name>')}      ${gray('Delete a route guard')}
+  ${green('build (b)')}                 ${gray('Build the project using configured output directory')}
+  ${green('clean')}                     ${gray('Clear build output directory')}
+  ${green('check (lint)')}              ${gray('Validate templates without building')}
+  ${green('doctor')}                    ${gray('Diagnose environment, config, and project health')}
+  ${green('inspect (i)')}               ${gray('Inspect project route and component hierarchy')}
+  ${green('serve [port]')}              ${gray('Start dev server with hot-reload (default: 3000)')}
+  ${green('watch (w)')}                 ${gray('Watch for file changes and rebuild automatically')}
+  ${green('help')}                      ${gray('Show this help message')}
 
-\x1b[1;36mOptions:\x1b[0m
-  \x1b[32m--dry-run, -d\x1b[0m             \x1b[90mPreview actions without writing or deleting any files\x1b[0m
-  \x1b[32m--json, -j\x1b[0m                \x1b[90mOutput check/lint validation diagnostics in JSON format\x1b[0m
-  \x1b[32m--watch, -w\x1b[0m               \x1b[90mWatch project component files for continuous template linting\x1b[0m
-  \x1b[32m--version, -v\x1b[0m            \x1b[90mOutput the current version\x1b[0m
+${bold(cyan('Options:'))}
+  ${green('--dry-run, -d')}             ${gray('Preview actions without writing or deleting any files')}
+  ${green('--json, -j')}                ${gray('Output check/lint validation diagnostics in JSON format')}
+  ${green('--watch, -w')}               ${gray('Watch project component files for continuous template linting')}
+  ${green('--no-color')}                ${gray('Disable colored output (the NO_COLOR variable is honored too)')}
+  ${green('--version, -v')}             ${gray('Output the current version')}
     `);
 }
-

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { readTemplate } from '../utils.js';
 import { runWizard } from '../wizard.js';
 import { getInitialHtml } from './serve.js';
+import { bold, cyan, green } from '../colors.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,7 +18,7 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../../packa
 export async function initProject(cli, args = []) {
   const { stylePreprocessor, layoutTemplate, isInteractive } = await runWizard(args);
 
-  console.log(`🚀 Initializing new Avenx-JS project (Style: ${stylePreprocessor}, Layout: ${layoutTemplate})...`);
+  console.log(bold(cyan(`🚀 Initializing new Avenx-JS project (Style: ${stylePreprocessor}, Layout: ${layoutTemplate})...`)));
 
   // Write avenx.config.json if preprocessor option is configured
   const configPath = path.join(cli.baseDir, 'avenx.config.json');
@@ -242,7 +243,7 @@ export async function initProject(cli, args = []) {
     fs.writeFileSync(gitignorePath, `node_modules/\n${cli.config.distDir}/\n.DS_Store\n`);
     console.log('  Created: .gitignore');
   }
-  console.log('✅ Project initialized successfully!');
+  console.log(green('✅ Project initialized successfully!'));
   if (isInteractive) {
     process.stdin.pause();
   }

--- a/bin/commands/inspect.js
+++ b/bin/commands/inspect.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { bold, cyan, yellow } from '../colors.js';
 
 /**
  * Converts a string to PascalCase.
@@ -213,26 +214,26 @@ export function runInspect(cli) {
   components.sort((a, b) => a.relPath.localeCompare(b.relPath));
   bridges.sort((a, b) => a.relPath.localeCompare(b.relPath));
 
-  console.log(`📦 Avenx Project Hierarchy (${srcRel}/)`);
+  console.log(bold(cyan(`📦 Avenx Project Hierarchy (${srcRel}/)`)));
 
   const categories = [
     {
       title: `📄 Pages (${pages.length})`,
       items: pages.map((p) => {
         const routeStr = p.route ? ` (${p.route})` : '';
-        return `${p.name}${routeStr} -> ${p.relPath}`;
+        return { text: `${p.name}${routeStr} -> ${p.relPath}`, warn: false };
       }),
     },
     {
       title: `🧩 Components (${components.length})`,
       items: components.map((c) => {
         const unusedStr = c.isUnused ? ' (⚠️ Unused)' : '';
-        return `${c.name} -> ${c.relPath}${unusedStr}`;
+        return { text: `${c.name} -> ${c.relPath}${unusedStr}`, warn: Boolean(c.isUnused) };
       }),
     },
     {
       title: `🌉 Bridges (${bridges.length})`,
-      items: bridges.map((b) => `${b.name} -> ${b.relPath}`),
+      items: bridges.map((b) => ({ text: `${b.name} -> ${b.relPath}`, warn: false })),
     },
   ];
 
@@ -242,13 +243,15 @@ export function runInspect(cli) {
     const catPrefix = isLastCategory ? '└── ' : '├── ';
     const childIndent = isLastCategory ? '    ' : '│   ';
 
-    console.log(`${catPrefix}${category.title}`);
+    console.log(bold(`${catPrefix}${category.title}`));
 
     for (let iIdx = 0; iIdx < category.items.length; iIdx++) {
       const item = category.items[iIdx];
       const isLastItem = iIdx === category.items.length - 1;
       const itemPrefix = isLastItem ? '└── ' : '├── ';
-      console.log(`${childIndent}${itemPrefix}${item}`);
+      // Styling wraps the whole line so the tree stays aligned and greppable.
+      const line = `${childIndent}${itemPrefix}${item.text}`;
+      console.log(item.warn ? yellow(line) : line);
     }
   }
 }

--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -3,6 +3,7 @@ import path from 'path';
 import http from 'http';
 import { exec } from 'child_process';
 import { buildProject } from './build.js';
+import { cyan, green, yellow } from '../colors.js';
 
 /**
  * Opens the browser to the specified URL.
@@ -481,7 +482,7 @@ export function watchProject(cli) {
     if (filename) {
       clearTimeout(timeout);
       timeout = setTimeout(() => {
-        console.log(`\n📄 Change detected: ${filename}. Rebuilding...`);
+        console.log(`\n${cyan(`📄 Change detected: ${filename}. Rebuilding...`)}`);
         buildProject(cli);
 
         if (cli.liveReloadClients) {
@@ -512,7 +513,7 @@ export function listenWithPortFallback(server, requestedPort, host, onListening)
 
     const occupiedPort = port;
     port += 1;
-    console.warn(`\nPort ${occupiedPort} is already in use. Trying ${port} instead.`);
+    console.warn(`\n${yellow(`Port ${occupiedPort} is already in use. Trying ${port} instead.`)}`);
     server.listen(port, host);
   });
 
@@ -616,9 +617,9 @@ export function serveProject(cli, port, host = 'localhost') {
 
   listenWithPortFallback(server, port, host, (activePort) => {
     const url = `http://${host}:${activePort}`;
-    console.log(`\n🚀 Dev-Server running at ${url}`);
+    console.log(`\n${green(`🚀 Dev-Server running at ${url}`)}`);
     if (cli.config.server.liveReload) {
-      console.log(`👀 Watching for changes in ${cli.config.srcDir}/...\n`);
+      console.log(cyan(`👀 Watching for changes in ${cli.config.srcDir}/...\n`));
     }
     openBrowser(url);
   });

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'node:readline';
 import { execSync } from 'child_process';
+import { red, yellow, gray } from './colors.js';
 
 /**
  * Helper to parse input names into PascalCase and kebab-case.
@@ -34,7 +35,7 @@ export function checkGitStatus() {
       return true;
     }
 
-    console.warn('⚠️ You have unstaged changes in your repository.');
+    console.warn(yellow('⚠️ You have unstaged changes in your repository.'));
 
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       return true;
@@ -52,7 +53,7 @@ export function checkGitStatus() {
         if (answer.trim().toLowerCase() === 'y') {
           resolve(true);
         } else {
-          console.log('Operation cancelled.');
+          console.log(gray('Operation cancelled.'));
           resolve(false);
         }
       });
@@ -88,7 +89,7 @@ export function promptQuestion(query, defaultValue, validator = null) {
             rl.close();
             resolve(trimmed);
           } else {
-            console.log(`\x1b[31m❌ ${valid}\x1b[0m`);
+            console.log(red(`❌ ${valid}`));
             ask();
           }
         } else {
@@ -130,7 +131,7 @@ export function readTemplate(baseDir, config, frameworkDir, subfolder, filename)
  * @param {string} message
  */
 export function fail(message) {
-  console.error(`\x1b[31m❌ Error: ${message}\x1b[0m`);
+  console.error(red(`❌ Error: ${message}`));
   process.exitCode = 1;
 }
 

--- a/bin/wizard.js
+++ b/bin/wizard.js
@@ -1,4 +1,5 @@
 import { promptQuestion } from './utils.js';
+import { bold, cyan } from './colors.js';
 
 /**
  * Runs the interactive project wizard prompts if interactive mode is enabled.
@@ -16,7 +17,7 @@ export async function runWizard(args = []) {
   let layoutTemplate = 'blank';
 
   if (isInteractive) {
-    console.log('\n\x1b[36m--- Avenx-JS Project Wizard ---\x1b[0m\n');
+    console.log(`\n${bold(cyan('--- Avenx-JS Project Wizard ---'))}\n`);
 
     const preprocessorInput = await promptQuestion(
       'Select style preprocessor:\n' +

--- a/docs/src/content/docs/cli-reference/commands.md
+++ b/docs/src/content/docs/cli-reference/commands.md
@@ -21,7 +21,22 @@ The following flags can be passed globally to `avenx` commands:
 | :--- | :--- | :--- | :--- |
 | `--dry-run` | `-d` | Previews file creation, modification, or deletion actions without modifying disk. | `generate`, `destroy` |
 | `--force` | `-f` | Forces command execution by bypassing uncommitted Git working tree status checks. | `init`, `generate`, `destroy`, `build` |
+| `--no-color` | | Disables colored terminal output. | Global |
 | `--version` | `-v` | Displays the installed version of the Avenx-JS CLI package. | Global |
+
+### Colored Output
+
+CLI output is color-coded to make results easier to scan: successful actions are green, warnings (including compiler warnings such as `AVX_W03`) are yellow, errors are red, and headings are bold.
+
+Colors are emitted only when the terminal can render them. They are disabled automatically when output is piped or redirected, when running in a non-TTY environment such as CI, and when `TERM=dumb`. They can also be controlled explicitly:
+
+| Control | Effect |
+| :--- | :--- |
+| `--no-color` | Disables colors for a single command. |
+| `NO_COLOR=1` | Disables colors for the environment ([no-color.org](https://no-color.org)). |
+| `FORCE_COLOR=1` | Forces colors on even without a TTY. |
+
+Machine-readable output is never colored: `avenx check --json` always emits clean JSON diagnostics regardless of these settings.
 
 ---
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -59,7 +59,10 @@ class AvenxCompiler {
         (config.logging &&
           (config.logging.silent || config.logging.level === 'silent' || config.logging.level === 'off')) ||
         false,
-      formatter: (level, args) => args, // CLI output doesn't need prefixes for generic info logs
+      // CLI output doesn't need prefixes for generic info logs. The CLI injects its
+      // own formatter (see bin/colors.js) to tint warnings and errors; other
+      // consumers such as the Vite plugin keep the plain pass-through default.
+      formatter: (config.logging && config.logging.formatter) || ((level, args) => args),
     });
 
     /**

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -63,7 +63,13 @@ async function runTestFile(file) {
   }
 
   return new Promise((resolve) => {
-    const child = fork(file, [], { stdio: 'inherit', execArgv });
+    // Tests inherit this runner's stdio, so a real terminal would otherwise enable
+    // CLI colors and wrap asserted output in ANSI escapes. Keep it deterministic.
+    const child = fork(file, [], {
+      stdio: 'inherit',
+      execArgv,
+      env: { ...process.env, NO_COLOR: '1' },
+    });
     child.on('exit', (code) => {
       if (code === 0) {
         resolve({ file: relativePath, success: true });

--- a/test/unit/cliColors.test.js
+++ b/test/unit/cliColors.test.js
@@ -1,0 +1,196 @@
+import assert from 'assert';
+import {
+  bold,
+  createSeverityFormatter,
+  cyan,
+  detectColorSupport,
+  gray,
+  green,
+  isColorEnabled,
+  red,
+  setColorEnabled,
+  yellow,
+} from '../../bin/colors.js';
+
+const ESC = '\u001b';
+
+/**
+ * Runs a callback with a temporary process environment and argv.
+ * @param {object} options
+ * @param {object} [options.env] - Environment overrides ('' removes the key).
+ * @param {string[]} [options.argv] - Replacement argv array.
+ * @param {function(): any} fn - The callback to execute.
+ * @returns {any}
+ */
+function withProcess({ env = {}, argv = null }, fn) {
+  const originalEnv = {};
+  for (const key of Object.keys(env)) {
+    originalEnv[key] = process.env[key];
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = env[key];
+    }
+  }
+  const originalArgv = process.argv;
+  if (argv) {
+    process.argv = argv;
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const key of Object.keys(originalEnv)) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    process.argv = originalArgv;
+  }
+}
+
+/**
+ * Verifies the environment-based color detection rules.
+ */
+function testDetection() {
+  console.log('  Testing color support detection...');
+
+  assert.strictEqual(
+    withProcess({ env: { NO_COLOR: '1', FORCE_COLOR: undefined } }, detectColorSupport),
+    false,
+    'NO_COLOR must disable colors',
+  );
+
+  assert.strictEqual(
+    withProcess({ env: { NO_COLOR: '', FORCE_COLOR: '1' } }, detectColorSupport),
+    true,
+    'FORCE_COLOR should enable colors even without a TTY',
+  );
+
+  assert.strictEqual(
+    withProcess({ env: { NO_COLOR: '', FORCE_COLOR: '0' } }, detectColorSupport),
+    false,
+    'FORCE_COLOR=0 must disable colors',
+  );
+
+  assert.strictEqual(
+    withProcess({ env: { NO_COLOR: '', FORCE_COLOR: undefined, TERM: 'dumb' } }, detectColorSupport),
+    false,
+    'TERM=dumb must disable colors',
+  );
+
+  assert.strictEqual(
+    withProcess(
+      { env: { NO_COLOR: '', FORCE_COLOR: '1' }, argv: ['node', 'avenx', 'build', '--no-color'] },
+      detectColorSupport,
+    ),
+    false,
+    '--no-color must win over FORCE_COLOR',
+  );
+
+  const detected = withProcess({ env: { NO_COLOR: '', FORCE_COLOR: undefined } }, detectColorSupport);
+  assert.strictEqual(typeof detected, 'boolean', 'Detection must always resolve to a boolean');
+  if (!process.stdout.isTTY) {
+    assert.strictEqual(detected, false, 'Piped or redirected stdout must disable colors');
+  }
+}
+
+/**
+ * Verifies that styling helpers are inert when colors are disabled.
+ */
+function testDisabledOutput() {
+  console.log('  Testing plain output when colors are disabled...');
+  setColorEnabled(false);
+
+  assert.strictEqual(isColorEnabled(), false);
+  for (const style of [bold, gray, green, yellow, red, cyan]) {
+    assert.strictEqual(style('hello'), 'hello', 'Disabled styles must return the raw string');
+  }
+  assert.ok(!green('✅ done').includes(ESC), 'No escape codes should be emitted when disabled');
+}
+
+/**
+ * Verifies emitted escape sequences and nesting behaviour.
+ */
+function testEnabledOutput() {
+  console.log('  Testing ANSI output when colors are enabled...');
+  setColorEnabled(true);
+
+  assert.strictEqual(isColorEnabled(), true);
+  assert.strictEqual(green('ok'), `${ESC}[32mok${ESC}[39m`);
+  assert.strictEqual(yellow('warn'), `${ESC}[33mwarn${ESC}[39m`);
+  assert.strictEqual(red('err'), `${ESC}[31merr${ESC}[39m`);
+  assert.strictEqual(cyan('head'), `${ESC}[36mhead${ESC}[39m`);
+  assert.strictEqual(gray('hint'), `${ESC}[90mhint${ESC}[39m`);
+  assert.strictEqual(bold('title'), `${ESC}[1mtitle${ESC}[22m`);
+
+  // Attribute-specific resets keep nested styles intact.
+  assert.strictEqual(bold(cyan('Avenx')), `${ESC}[1m${ESC}[36mAvenx${ESC}[39m${ESC}[22m`);
+
+  // Message text stays contiguous so output remains greppable.
+  const line = green(`✅ Component 'my-button' generated at src/components/my-button/`);
+  assert.ok(
+    line.includes(`✅ Component 'my-button' generated at src/components/my-button/`),
+    'Styling must wrap whole lines rather than splitting the message',
+  );
+}
+
+/**
+ * Verifies the compiler diagnostic formatter tints by severity.
+ */
+function testSeverityFormatter() {
+  console.log('  Testing compiler severity formatter...');
+  const format = createSeverityFormatter();
+
+  setColorEnabled(true);
+  assert.deepStrictEqual(
+    format('warn', ['[AVX_W03] Undeclared variable "userName".']),
+    [`${ESC}[33m[AVX_W03] Undeclared variable "userName".${ESC}[39m`],
+    'Compiler warnings must be yellow',
+  );
+  assert.deepStrictEqual(
+    format('error', ['❌ Build failed']),
+    [`${ESC}[31m❌ Build failed${ESC}[39m`],
+    'Compiler errors must be red',
+  );
+  assert.deepStrictEqual(
+    format('fatal', ['boom']),
+    [`${ESC}[31mboom${ESC}[39m`],
+    'Fatal messages must be red',
+  );
+  assert.deepStrictEqual(
+    format('info', ['bundle.js: 81.29 KB']),
+    ['bundle.js: 81.29 KB'],
+    'Informational build output must stay untouched',
+  );
+
+  const err = new Error('structured');
+  assert.strictEqual(format('error', [err])[0], err, 'Non-string arguments must be passed through as-is');
+
+  setColorEnabled(false);
+  assert.deepStrictEqual(
+    format('warn', ['plain warning']),
+    ['plain warning'],
+    'Formatter must stay inert when colors are disabled',
+  );
+}
+
+try {
+  console.log('🧪 Testing CLI color helpers...');
+  const originalState = isColorEnabled();
+
+  testDetection();
+  testDisabledOutput();
+  testEnabledOutput();
+  testSeverityFormatter();
+
+  setColorEnabled(originalState);
+  console.log('✅ All CLI color helper tests passed!');
+} catch (error) {
+  setColorEnabled(false);
+  console.error('❌ CLI color helper tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
The help command was already colored, but the rest of the CLI printed plain text, making warnings and errors hard to spot while scanning terminal output.

Add a zero-dependency bin/colors.js as the single place ANSI decisions are made, and move the previously hardcoded escape codes in help, doctor, generate, utils, and wizard onto it. Extend coloring to the remaining commands (init, generate, destroy, build, clean, check, serve, watch, inspect) using one palette: green for success, yellow for warnings, red for errors, cyan and bold for headings.

Compiler warnings are now yellow and errors red. The tinting is installed through the formatter lib/compiler.js already configures for CLI output, which is the single point covering build, check, watch, and serve. The formatter is injected from the CLI, so no ANSI reaches lib/core or the browser bundle, and consumers that pass no formatter (such as the Vite plugin) keep the plain pass-through default.

Colors are emitted only when the terminal can render them: --no-color, NO_COLOR, FORCE_COLOR, TERM=dumb, and non-TTY stdout are all honored, and helpers return plain strings when disabled so call sites never branch on color support. Machine-readable output is unaffected; avenx check --json still emits clean JSON.

Test children inherit the runner's stdio, so a real terminal would otherwise enable colors and wrap asserted output in escape codes. Set NO_COLOR in the fork environment to keep assertions deterministic. The suite also passes with colors forced on.

Known limitation: unknown-key warnings from loadConfig() are emitted before the formatter is installed and remain uncolored.

Closes #564 
