### PR TITLE
feat(directives): support dot-notation modifiers on custom directives

### DIFF
--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -836,7 +836,7 @@ class ${name} extends AvenxComponent {
         });
       }
 
-      const dirRegex = /\b(data-ax-[a-zA-Z0-9_-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+      const dirRegex = /\b(data-ax-[a-zA-Z0-9_.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
       let dirMatch;
       while ((dirMatch = dirRegex.exec(match[0])) !== null) {
         events.push({

--- a/lib/core/renderer/domPatch.js
+++ b/lib/core/renderer/domPatch.js
@@ -661,7 +661,11 @@ export class DomPatcher {
       const attrs = Array.from(el.attributes || []);
       for (const attr of attrs) {
         if (attr.name.startsWith('data-ax-')) {
-          const dirName = attr.name.slice(8);
+          // Split dot-notation modifiers off the directive name, mirroring the
+          // event modifier convention in core/events/bindEvents.js.
+          const attrKey = attr.name.slice(8);
+          const parts = attrKey.split('.');
+          const dirName = parts[0];
           // Ignore built-in core directives
           if (
             dirName === 'show' ||
@@ -696,13 +700,22 @@ export class DomPatcher {
               el.__avenx_directives = new Map();
             }
 
-            const oldInfo = el.__avenx_directives.get(dirName);
+            // Keyed by the full attribute suffix so that two modifier variants of
+            // the same directive on one element do not overwrite each other.
+            const oldInfo = el.__avenx_directives.get(attrKey);
 
             if (!oldInfo) {
-              el.__avenx_directives.set(dirName, {
+              const modifiers = {};
+              for (let i = 1; i < parts.length; i++) {
+                if (parts[i]) modifiers[parts[i]] = true;
+              }
+
+              el.__avenx_directives.set(attrKey, {
+                name: dirName,
                 value,
                 oldValue: undefined,
                 expression: expr,
+                modifiers,
                 mountedCalled: false,
                 valueChanged: false,
               });
@@ -1028,13 +1041,14 @@ export class DomPatcher {
     if (el.__avenx_directives) {
       for (const [dirName, info] of el.__avenx_directives.entries()) {
         if (info.mountedCalled) {
-          const dirDef = app && app.directives && app.directives.get(dirName);
+          const dirDef = app && app.directives && app.directives.get(info.name);
           if (dirDef && typeof dirDef.unmounted === 'function') {
             try {
               dirDef.unmounted(el, {
                 value: info.value,
                 oldValue: info.value,
                 expression: info.expression,
+                modifiers: info.modifiers,
               });
             } catch (err) {
               logger.warn(`Error in unmounted hook of directive ${dirName}: ${err.message || err}`);
@@ -1058,7 +1072,7 @@ export class DomPatcher {
       const isConnected = this.isNodeInPatchTree(el);
       if (isConnected) {
         for (const [dirName, info] of el.__avenx_directives.entries()) {
-          const dirDef = app.directives.get(dirName);
+          const dirDef = app.directives.get(info.name);
           if (!dirDef) continue;
 
           if (!info.mountedCalled) {
@@ -1067,6 +1081,7 @@ export class DomPatcher {
                 dirDef.mounted(el, {
                   value: info.value,
                   expression: info.expression,
+                  modifiers: info.modifiers,
                 });
               } catch (err) {
                 logger.error(`Error in mounted hook of directive ${dirName}: ${err.message || err}`);
@@ -1080,6 +1095,7 @@ export class DomPatcher {
                   value: info.value,
                   oldValue: info.oldValue,
                   expression: info.expression,
+                  modifiers: info.modifiers,
                 });
               } catch (err) {
                 logger.error(`Error in updated hook of directive ${dirName}: ${err.message || err}`);

--- a/test/helpers/dom-mock.js
+++ b/test/helpers/dom-mock.js
@@ -257,7 +257,7 @@ function setupDOMMock() {
 
         const element = new MockDOMElement(tagName);
 
-        const attrRegex = /([\w@:-]+)(?:=(?:"([^"]*)"|'([^']*)'))?/g;
+        const attrRegex = /([\w@:.-]+)(?:=(?:"([^"]*)"|'([^']*)'))?/g;
         let attrMatch;
 
         while ((attrMatch = attrRegex.exec(attrsStr)) !== null) {

--- a/test/unit/directives_custom.test.js
+++ b/test/unit/directives_custom.test.js
@@ -130,7 +130,7 @@ async function runTests() {
 
     assert.ok(mountedCalled, 'mounted hook should have been called');
     assert.strictEqual(mountedEl.tagName, 'DIV');
-    assert.deepStrictEqual(mountedBinding, { value: 'initial', expression: 'stateVal' });
+    assert.deepStrictEqual(mountedBinding, { value: 'initial', expression: 'stateVal', modifiers: {} });
 
     // Update stateVal to trigger updated hook
     lifeComp.state.stateVal = 'updated-value';
@@ -138,14 +138,82 @@ async function runTests() {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     assert.ok(updatedCalled, 'updated hook should have been called when bound value shifts');
-    assert.deepStrictEqual(updatedBinding, { value: 'updated-value', oldValue: 'initial', expression: 'stateVal' });
+    assert.deepStrictEqual(updatedBinding, { value: 'updated-value', oldValue: 'initial', expression: 'stateVal', modifiers: {} });
 
     // Unmount component to trigger unmounted hook
     lifeComp.unmount();
     assert.ok(unmountedCalled, 'unmounted hook should have been called');
-    assert.deepStrictEqual(unmountedBinding, { value: 'updated-value', oldValue: 'updated-value', expression: 'stateVal' });
+    assert.deepStrictEqual(unmountedBinding, { value: 'updated-value', oldValue: 'updated-value', expression: 'stateVal', modifiers: {} });
 
-    // 4. Verify compiler template checks reject undeclared identifiers in custom directives
+    // 4. Verify dot-notation modifiers are parsed and exposed on the binding
+    console.log('  Testing custom directive modifiers...');
+    let modMountedCalled = false;
+    let modMountedBinding = null;
+    let modUpdatedBinding = null;
+    let modUnmountedBinding = null;
+
+    app.directive('mod-test', {
+      mounted(el, binding) {
+        modMountedCalled = true;
+        modMountedBinding = binding;
+      },
+      updated(el, binding) {
+        modUpdatedBinding = binding;
+      },
+      unmounted(el, binding) {
+        modUnmountedBinding = binding;
+      }
+    });
+
+    class ModifierComponent extends AvenxComponent {
+      constructor() {
+        super({ stateVal: 'initial' });
+      }
+      render() {
+        return `<div data-ax-mod-test.once.passive="stateVal">Text</div>`;
+      }
+    }
+
+    const modComp = new ModifierComponent({});
+    modComp.$app = app;
+    modComp.mount(new MockDOMElement('div'));
+
+    // Regression: a modifier suffix previously stopped the directive from running at all,
+    // because the directive name was looked up as "mod-test.once.passive".
+    assert.ok(modMountedCalled, 'mounted hook should fire on a directive carrying modifiers');
+    assert.deepStrictEqual(
+      modMountedBinding,
+      { value: 'initial', expression: 'stateVal', modifiers: { once: true, passive: true } },
+      'mounted binding should expose modifiers as an object'
+    );
+
+    modComp.state.stateVal = 'updated-value';
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    assert.deepStrictEqual(
+      modUpdatedBinding,
+      {
+        value: 'updated-value',
+        oldValue: 'initial',
+        expression: 'stateVal',
+        modifiers: { once: true, passive: true }
+      },
+      'updated binding should expose modifiers'
+    );
+
+    modComp.unmount();
+    assert.deepStrictEqual(
+      modUnmountedBinding,
+      {
+        value: 'updated-value',
+        oldValue: 'updated-value',
+        expression: 'stateVal',
+        modifiers: { once: true, passive: true }
+      },
+      'unmounted binding should expose modifiers'
+    );
+
+    // 5. Verify compiler template checks reject undeclared identifiers in custom directives
     console.log('  Testing compiler validation for custom directives...');
     const cp = new ComponentParser(new StyleProcessor());
     const tempFile = path.join(__dirname, 'TempCustomDirComp.component.js');


### PR DESCRIPTION
Closes #1001

Parses `data-ax-name.mod1.mod2` into a base directive name plus a `modifiers` object, exposed on the binding passed to `mounted`/`updated`/`unmounted`. Follows the existing event-modifier convention in `bindEvents.js:229-231`.

Note this also fixes a silent failure: a modifier suffix previously caused the directive to be skipped entirely, since the name was looked up including the suffix. Covered by a regression test.

**Three things worth a look:**

- `__avenx_directives` is now keyed by the full attribute suffix rather than the base name, so `data-ax-foo.once` and `data-ax-foo.lazy` on one element don't clobber each other. Lookups use `info.name`.
- `modifiers` is always present (defaults to `{}`) so consumers don't need to guard. This is a shape change to the public binding, it broke three existing `deepStrictEqual` assertions, which I updated.
- **Touches a file outside the two named in the issue:** `test/helpers/dom-mock.js`. The mock DOMParser's attribute regex also excluded `.`, so it split `data-ax-mod-test.once.passive` into separate attributes, no test could exercise the feature without this.
