### PR TITLE
feat(cli): support custom HTTP headers in avenx serve

### DIFF
--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -78,6 +78,17 @@ export function attachRequestLogger(req, res, logger = console.log) {
 }
 
 /**
+ * Applies configured custom headers to an HTTP response.
+ * @param {object} res - Node HTTP response object.
+ * @param {object} [headers] - Header name/value pairs from server.headers.
+ */
+export function applyCustomHeaders(res, headers = {}) {
+  for (const [name, value] of Object.entries(headers || {})) {
+    res.setHeader(name, value);
+  }
+}
+
+/**
  * Opens the browser to the specified URL.
  * @param {string} url
  */
@@ -608,6 +619,7 @@ export function serveProject(cli, port, host = 'localhost') {
 
   const server = http.createServer((req, res) => {
     attachRequestLogger(req, res);
+    applyCustomHeaders(res, cli.config.server.headers);
     if (cli.config.server.liveReload && req.url === '/__avenx_live_reload__') {
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',

--- a/lib/config.js
+++ b/lib/config.js
@@ -129,6 +129,7 @@ function loadConfig(baseDir) {
       port: 3000,
       host: 'localhost',
       liveReload: true,
+      headers: {},
     },
     style: {
       preprocessor: 'none',
@@ -186,7 +187,7 @@ function loadConfig(baseDir) {
           logger.warn(`Unknown configuration option "${key}" in avenx.config.json${suggestion} Supported top-level options are: ${allowedTopLevel.join(', ')}.`);
         } else {
           if (key === 'server' && userConfig.server && typeof userConfig.server === 'object' && !Array.isArray(userConfig.server)) {
-            const allowedServerKeys = ['port', 'host', 'liveReload'];
+            const allowedServerKeys = ['port', 'host', 'liveReload', 'headers'];
             for (const subKey of Object.keys(userConfig.server)) {
               if (!allowedServerKeys.includes(subKey)) {
                 const closest = getClosestKey(subKey, allowedServerKeys);
@@ -357,6 +358,14 @@ function loadConfig(baseDir) {
 
     if (typeof config.server.liveReload !== 'boolean') {
       throw new Error('server.liveReload must be a boolean');
+    }
+
+    if (
+      typeof config.server.headers !== 'object' ||
+      config.server.headers === null ||
+      Array.isArray(config.server.headers)
+    ) {
+      throw new Error('server.headers must be an object');
     }
 
     return config;

--- a/test/unit/cliConfig.test.js
+++ b/test/unit/cliConfig.test.js
@@ -58,6 +58,7 @@ try {
     assert.strictEqual(defaults.templatesDir, '.avenxtemplates');
     assert.strictEqual(defaults.server.port, 3000);
     assert.strictEqual(defaults.server.liveReload, true);
+    assert.deepStrictEqual(defaults.server.headers, {});
 
     console.log('  Testing valid custom config merge...');
     writeTestConfig({
@@ -72,6 +73,15 @@ try {
     assert.strictEqual(customConfig.server.port, 8080);
     assert.strictEqual(customConfig.server.host, 'localhost');
     assert.strictEqual(customConfig.server.liveReload, false);
+
+    writeTestConfig({
+      server: {
+        headers: { 'Access-Control-Allow-Origin': '*', 'X-Avenx-Test': 'enabled' },
+      },
+    });
+    const headersConfig = loadConfig();
+    assert.strictEqual(headersConfig.server.headers['Access-Control-Allow-Origin'], '*');
+    assert.strictEqual(headersConfig.server.headers['X-Avenx-Test'], 'enabled');
 
     console.log('  Testing invalid config schema validations...');
     writeTestConfig({ srcDir: '' });
@@ -103,6 +113,12 @@ try {
 
     writeTestConfig({ server: { liveReload: 'false' } });
     assertThrows(() => loadConfig(), 'server.liveReload must be a boolean');
+
+    writeTestConfig({ server: { headers: [] } });
+    assertThrows(() => loadConfig(), 'server.headers must be an object');
+
+    writeTestConfig({ server: { headers: null } });
+    assertThrows(() => loadConfig(), 'server.headers must be an object');
 
     writeTestConfig({ voidTags: 'not-an-array' });
     assertThrows(() => loadConfig(), 'voidTags must be an array of non-empty strings');

--- a/test/unit/serve.test.js
+++ b/test/unit/serve.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import http from 'http';
 import { EventEmitter } from 'events';
-import { listenWithPortFallback, formatStatusCode, formatRequestLog, attachRequestLogger } from '../../bin/commands/serve.js';
+import { listenWithPortFallback, formatStatusCode, formatRequestLog, attachRequestLogger, applyCustomHeaders } from '../../bin/commands/serve.js';
 import { setColorEnabled } from '../../bin/colors.js';
 import { AvenxCLI } from '../../bin/cli.js';
 
@@ -127,9 +127,14 @@ function testAttachRequestLogger() {
 async function testHttpDevServerRequestLogging() {
   setColorEnabled(false);
   const logs = [];
+  const customHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'X-Avenx-Test': 'enabled',
+  };
 
   const server = http.createServer((req, res) => {
     attachRequestLogger(req, res, (msg) => logs.push(msg));
+    applyCustomHeaders(res, customHeaders);
     if (req.url === '/') {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end('<html></html>');
@@ -144,23 +149,29 @@ async function testHttpDevServerRequestLogging() {
     const port = server.address().port;
 
     // Send HTTP GET / request (200)
-    await new Promise((resolve, reject) => {
+    const rootHeaders = await new Promise((resolve, reject) => {
       http.get(`http://127.0.0.1:${port}/`, (res) => {
+        const headers = res.headers;
         res.resume();
-        res.on('end', resolve);
+        res.on('end', () => resolve(headers));
       }).on('error', reject);
     });
 
     // Send HTTP GET /favicon.ico request (404)
-    await new Promise((resolve, reject) => {
+    const notFoundHeaders = await new Promise((resolve, reject) => {
       http.get(`http://127.0.0.1:${port}/favicon.ico`, (res) => {
+        const headers = res.headers;
         res.resume();
-        res.on('end', resolve);
+        res.on('end', () => resolve(headers));
       }).on('error', reject);
     });
 
     assert.ok(logs.some((l) => l.includes('GET / - 200')), 'Should log GET / - 200');
     assert.ok(logs.some((l) => l.includes('GET /favicon.ico - 404')), 'Should log GET /favicon.ico - 404');
+    assert.strictEqual(rootHeaders['access-control-allow-origin'], '*');
+    assert.strictEqual(rootHeaders['x-avenx-test'], 'enabled');
+    assert.strictEqual(notFoundHeaders['access-control-allow-origin'], '*');
+    assert.strictEqual(notFoundHeaders['x-avenx-test'], 'enabled');
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary
- add `server.headers` support to `avenx.config.json`
- apply configured headers to every dev-server response path
- validate `server.headers` as an object
- add config and HTTP response coverage for custom headers

## Testing
- config tests cover defaults, valid headers, arrays, and null
- dev-server HTTP test verifies custom headers on both 200 and 404 responses

Closes #987