### PR TITLE
feat(testing): add flushPromises helper for async unit tests

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -935,6 +935,8 @@ export class AvenxMock {
         eventType: string,
         detail?: Record<string, any>
     ): Promise<void>;
+
+    static flushPromises(): Promise<void>;
 }
 
 export interface MountTestComponentOptions {
@@ -968,6 +970,8 @@ export function fireEvent(
     eventType: string,
     detail?: Record<string, any>
 ): Promise<void>;
+
+export function flushPromises(): Promise<void>;
 
 export class AvenxSandbox {
     components: Map<string, typeof AvenxComponent>;

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -26,7 +26,7 @@ export { LifecycleManager } from './runtime/lifecycle.js';
 export { StyleMountManager, styleMountManager } from './runtime/StyleMountManager.js';
 export { AvenxLogger, logger, LogLevels, defaultFormatter, consoleTransport } from './runtime/AvenxLogger.js';
 export { AvenxWatcher, watchEffect, setDebugReactivity, isDebugReactivityEnabled, getActiveCausationTrace, clearCausationTrace } from './reactive/watcher.js';
-export { AvenxMock, AvenxSandbox, mountTestComponent, fireEvent } from './runtime/AvenxMock.js';
+export { AvenxMock, AvenxSandbox, mountTestComponent, fireEvent, flushPromises } from './runtime/AvenxMock.js';
 export { AvenxPage } from './runtime/AvenxPage.js';
 export { VirtualList } from './runtime/VirtualList.js';
 export { initInspector } from './tooling/inspect.js';

--- a/lib/core/runtime/AvenxMock.js
+++ b/lib/core/runtime/AvenxMock.js
@@ -464,6 +464,29 @@ export class AvenxMock {
   static fireEvent(element, eventType, detail) {
     return fireEvent(element, eventType, detail);
   }
+
+  /**
+   * Waits for pending Promise microtasks / macrotasks to settle.
+   * @returns {Promise<void>}
+   */
+  static flushPromises() {
+    return flushPromises();
+  }
+}
+
+/**
+ * Settles the event loop so pending Promises and timers can complete.
+ * Prefer this over ad-hoc `setTimeout` chains in unit tests.
+ * @returns {Promise<void>}
+ */
+export function flushPromises() {
+  return new Promise((resolve) => {
+    if (typeof setImmediate === 'function') {
+      setImmediate(resolve);
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
 }
 
 /**

--- a/test/unit/mockFlushPromises.test.js
+++ b/test/unit/mockFlushPromises.test.js
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { AvenxMock, flushPromises } from '../../lib/core/index.js';
+
+console.log('🧪 Testing flushPromises helper...');
+
+(async () => {
+  try {
+    let settled = false;
+    Promise.resolve().then(() => {
+      settled = true;
+    });
+
+    assert.strictEqual(settled, false, 'microtask should not have run yet');
+    await flushPromises();
+    assert.strictEqual(settled, true, 'flushPromises should allow pending Promise to settle');
+
+    let viaStatic = false;
+    Promise.resolve().then(() => {
+      viaStatic = true;
+    });
+    await AvenxMock.flushPromises();
+    assert.strictEqual(viaStatic, true, 'AvenxMock.flushPromises should settle pending Promises');
+
+    console.log('✅ flushPromises tests passed!');
+  } catch (error) {
+    console.error('❌ flushPromises tests failed!');
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Adds `flushPromises()` on `AvenxMock` and core exports so tests can settle pending Promises without ad-hoc timeouts.

Fixes #1119