### PR TITLE
feat(cli): add avenx env command for active environment inspection

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ import { printHelp } from './commands/help.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInspect } from './commands/inspect.js';
 import { runStats } from './commands/stats.js';
+import { runEnv } from './commands/env.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -156,6 +157,9 @@ export class AvenxCLI {
         break;
       case 'doctor':
         runDoctor(this);
+        break;
+      case 'env':
+        runEnv(this, args);
         break;
       case 'inspect':
       case 'i':

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+import { loadEnv, parseEnv } from '../../lib/env.js';
+import { bold, cyan, green, yellow, gray } from '../colors.js';
+
+/**
+ * Masks a secret value for display (e.g. secr****).
+ * @param {string} value
+ * @returns {string}
+ */
+function maskSecret(value) {
+  const str = String(value ?? '');
+  if (str.length <= 4) {
+    return '*'.repeat(Math.max(str.length, 4));
+  }
+  return `${str.slice(0, 4)}${'*'.repeat(Math.min(8, str.length - 4))}`;
+}
+
+/**
+ * Pads a string to a fixed width for table-like output.
+ * @param {string} value
+ * @param {number} width
+ * @returns {string}
+ */
+function pad(value, width) {
+  const s = String(value ?? '');
+  if (s.length >= width) return s;
+  return s + ' '.repeat(width - s.length);
+}
+
+/**
+ * Reads .env keys that were defined in the project file (if present).
+ * @param {string} rootDir
+ * @returns {{ path: string|null, keys: string[], exists: boolean, error: string|null }}
+ */
+function readEnvFileMeta(rootDir) {
+  const envPath = path.join(rootDir, '.env');
+  if (!fs.existsSync(envPath)) {
+    return { path: null, keys: [], exists: false, error: null };
+  }
+  try {
+    const content = fs.readFileSync(envPath, 'utf-8');
+    const parsed = parseEnv(content);
+    return { path: envPath, keys: Object.keys(parsed), exists: true, error: null };
+  } catch (err) {
+    return {
+      path: envPath,
+      keys: [],
+      exists: true,
+      error: err && err.message ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Prints active environment configuration (public vs private).
+ * @param {{ baseDir: string }} cli
+ * @param {string[]} [_args]
+ */
+export function runEnv(cli, _args = []) {
+  const rootDir = cli.baseDir || process.cwd();
+  loadEnv(rootDir);
+
+  const meta = readEnvFileMeta(rootDir);
+  const fileKeys = new Set(meta.keys);
+  const publicKeys = new Set();
+  const systemKeys = new Set();
+
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('AVX_PUBLIC_')) {
+      publicKeys.add(key);
+    }
+  }
+  for (const key of fileKeys) {
+    if (key.startsWith('AVX_PUBLIC_')) {
+      publicKeys.add(key);
+    } else {
+      systemKeys.add(key);
+    }
+  }
+
+  console.log(`\n${bold(cyan('Avenx Environment'))}`);
+  console.log(`${gray('Project:')} ${rootDir}\n`);
+
+  console.log(bold(cyan('Source Files')));
+  if (!meta.exists) {
+    console.log(`  ${yellow('⚠')} No .env file found (only process env AVX_PUBLIC_* shown)`);
+  } else if (meta.error) {
+    console.log(`  ${yellow('✖')} Failed to read ${meta.path}: ${meta.error}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`  ${green('✔')} ${meta.path}`);
+  }
+  console.log();
+
+  const pubList = [...publicKeys].sort();
+  console.log(bold(cyan('Public Variables')) + gray(' (AVX_PUBLIC_* — inlined at build time)'));
+  if (pubList.length === 0) {
+    console.log(`  ${gray('(none)')}`);
+  } else {
+    console.log(`  ${pad('Key', 28)} ${pad('Value', 24)} Notes`);
+    for (const key of pubList) {
+      const value = process.env[key] ?? '';
+      const note = value === '' ? yellow('empty') : gray('inlined');
+      console.log(`  ${pad(key, 28)} ${pad(value, 24)} ${note}`);
+    }
+  }
+  console.log();
+
+  const sysList = [...systemKeys].sort();
+  console.log(bold(cyan('System Variables')) + gray(' (from .env — values masked)'));
+  if (sysList.length === 0) {
+    console.log(`  ${gray('(none)')}`);
+  } else {
+    console.log(`  ${pad('Key', 28)} Value`);
+    for (const key of sysList) {
+      const value = process.env[key] ?? '';
+      console.log(`  ${pad(key, 28)} ${maskSecret(value)}`);
+    }
+  }
+  console.log();
+}

--- a/bin/commands/help.js
+++ b/bin/commands/help.js
@@ -22,6 +22,7 @@ ${bold(cyan('Commands:'))}
   ${green('clean')}                     ${gray('Clear build output directory')}
   ${green('check (lint)')}              ${gray('Validate templates without building')}
   ${green('doctor')}                    ${gray('Diagnose environment, config, and project health')}
+  ${green('env')}                       ${gray('Print and validate active environment variables')}
   ${green('inspect (i)')}               ${gray('Inspect project route and component hierarchy')}
   ${green('stats (s)')}                ${gray('Display component & bundle footprint metrics')}
   ${green('serve [port]')}              ${gray('Start dev server with hot-reload (default: 3000)')}

--- a/test/unit/cliEnvCommand.test.js
+++ b/test/unit/cliEnvCommand.test.js
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import { runEnv } from '../../bin/commands/env.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_DIR = path.join(__dirname, 'env-unit-test-project');
+
+function setup() {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(TEST_DIR, '.env'),
+    [
+      'AVX_PUBLIC_API_URL=https://api.example.com',
+      'AVX_PUBLIC_EMPTY=',
+      'SECRET_TOKEN=supersecretvalue',
+      'DB_PASSWORD=dbpass',
+    ].join('\n'),
+    'utf-8'
+  );
+}
+
+function cleanup() {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+  delete process.env.AVX_PUBLIC_API_URL;
+  delete process.env.AVX_PUBLIC_EMPTY;
+  delete process.env.SECRET_TOKEN;
+  delete process.env.DB_PASSWORD;
+}
+
+console.log('🧪 Testing bin/commands/env.js...');
+
+try {
+  setup();
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    logs.push(args.map(String).join(' '));
+  };
+
+  runEnv({ baseDir: TEST_DIR });
+
+  console.log = originalLog;
+  const output = logs.join('\n');
+
+  assert.ok(output.includes('.env'), 'should list .env source file');
+  assert.ok(output.includes('AVX_PUBLIC_API_URL'), 'should list public key');
+  assert.ok(output.includes('https://api.example.com'), 'should show public value unmasked');
+  assert.ok(output.includes('SECRET_TOKEN'), 'should list private key');
+  assert.ok(!output.includes('supersecretvalue'), 'should mask private value');
+  assert.ok(output.includes('supe'), 'masked secret should keep a short prefix');
+
+  cleanup();
+  console.log('✅ cliEnvCommand tests passed!');
+} catch (error) {
+  console.log = console.log.bind(console);
+  cleanup();
+  console.error('❌ cliEnvCommand tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
Adds `avenx env` to list `AVX_PUBLIC_*` values and mask private `.env` secrets for build debugging.

Fixes #1124