### PR TITLE
feat(reactivity): export toRaw, isReactive, and markRaw utilities

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -664,6 +664,15 @@ export class StateFactory {
     create<T extends Record<string, any> = Record<string, any>>(initialState?: T, options?: Record<string, any>): T;
 }
 
+/** Returns the underlying raw object for a reactive proxy. */
+export function toRaw<T>(target: T): T;
+
+/** Returns true when value is an Avenx reactive proxy. */
+export function isReactive(value: unknown): boolean;
+
+/** Marks an object so it will not be wrapped by reactive proxies. */
+export function markRaw<T extends object>(target: T): T;
+
 /**
  * Factory for creating state proxy traps.
  */

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -8,7 +8,7 @@ export { AvenxApp } from './runtime/AvenxApp.js';
 export { AvenxBridge } from './runtime/AvenxBridge.js';
 export { AvenxGuard } from './runtime/AvenxGuard.js';
 export { AvenxRouter } from './runtime/AvenxRouter.js';
-export { StateFactory } from './reactive/createState.js';
+export { StateFactory, toRaw, isReactive, markRaw } from './reactive/createState.js';
 export { ComputedRegistry } from './reactive/createComputed.js';
 export { ProxyHandlerFactory } from './reactive/proxyHandler.js';
 export { TemplateRenderer } from './renderer/renderTemplate.js';

--- a/lib/core/reactive/createState.js
+++ b/lib/core/reactive/createState.js
@@ -1,5 +1,7 @@
 import { ProxyHandlerFactory, IS_REACTIVE_PROXY, PROXY_REF_SYMBOL } from './proxyHandler.js';
 
+export { toRaw, isReactive, markRaw } from './proxyHandler.js';
+
 /**
  * Factory for creating reactive state objects.
  */

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -10,6 +10,7 @@ export { setDebugReactivity, isDebugReactivityEnabled };
 export const RAW_SYMBOL = Symbol('raw');
 export const IS_REACTIVE_PROXY = Symbol('avenx.reactive.proxy');
 export const PROXY_REF_SYMBOL = Symbol.for('__avenx_proxy_ref__');
+export const NON_REACTIVE_SYMBOL = Symbol.for('avenx.reactive.skip');
 
 const mutatingArrayMethods = new Set([
   'push',
@@ -35,6 +36,9 @@ export function isReactiveTarget(value) {
   if (value === null || typeof value !== 'object') {
     return false;
   }
+  if (value[NON_REACTIVE_SYMBOL]) {
+    return false;
+  }
   const proto = Object.getPrototypeOf(value);
   return (
     proto === null ||
@@ -43,6 +47,51 @@ export function isReactiveTarget(value) {
     value instanceof Set ||
     value instanceof Map
   );
+}
+
+/**
+ * Returns the underlying raw object for a reactive proxy.
+ * @param {any} target
+ * @returns {any}
+ */
+export function toRaw(target) {
+  if (target === null || typeof target !== 'object') {
+    return target;
+  }
+  return target[RAW_SYMBOL] || target;
+}
+
+/**
+ * Returns true when value is an Avenx reactive proxy.
+ * @param {any} value
+ * @returns {boolean}
+ */
+export function isReactive(value) {
+  return !!(value && typeof value === 'object' && value[IS_REACTIVE_PROXY]);
+}
+
+/**
+ * Marks an object so it will not be wrapped by reactive proxies.
+ * @template T
+ * @param {T} target
+ * @returns {T}
+ */
+export function markRaw(target) {
+  if (target === null || typeof target !== 'object') {
+    return target;
+  }
+  if (!Object.isExtensible(target)) {
+    return target;
+  }
+  if (!target[NON_REACTIVE_SYMBOL]) {
+    Object.defineProperty(target, NON_REACTIVE_SYMBOL, {
+      value: true,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  return target;
 }
 
 /**

--- a/test/unit/reactivity_raw_utilities.test.js
+++ b/test/unit/reactivity_raw_utilities.test.js
@@ -1,0 +1,42 @@
+import assert from 'assert';
+import { StateFactory, toRaw, isReactive, markRaw } from '../../lib/core/index.js';
+import { RAW_SYMBOL, NON_REACTIVE_SYMBOL } from '../../lib/core/reactive/proxyHandler.js';
+
+console.log('🧪 Testing toRaw / isReactive / markRaw utilities...');
+
+try {
+  const factory = new StateFactory();
+  const state = factory.create({
+    count: 1,
+    nested: { ok: true },
+  });
+
+  assert.strictEqual(isReactive(state), true, 'state proxy should be reactive');
+  assert.strictEqual(isReactive(state.nested), true, 'nested object should be reactive when accessed');
+  assert.strictEqual(isReactive({ plain: true }), false, 'plain object should not be reactive');
+  assert.strictEqual(isReactive(null), false);
+
+  const raw = toRaw(state);
+  assert.strictEqual(raw[RAW_SYMBOL], undefined, 'raw object should not expose RAW_SYMBOL getter path as nested');
+  assert.notStrictEqual(raw, state, 'toRaw should unwrap the proxy');
+  assert.strictEqual(raw.count, 1);
+  assert.strictEqual(toRaw(42), 42);
+  assert.strictEqual(toRaw(null), null);
+
+  const chart = markRaw({ points: [1, 2, 3], id: 'chart-1' });
+  assert.strictEqual(chart[NON_REACTIVE_SYMBOL], true, 'markRaw should set NON_REACTIVE_SYMBOL');
+
+  const withRaw = factory.create({
+    chart,
+    label: 'demo',
+  });
+  assert.strictEqual(isReactive(withRaw), true);
+  assert.strictEqual(withRaw.chart, chart, 'marked raw object must keep identity');
+  assert.strictEqual(isReactive(withRaw.chart), false, 'marked raw object must not become a proxy');
+
+  console.log('✅ reactivity raw utilities tests passed!');
+} catch (error) {
+  console.error('❌ reactivity raw utilities tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
Exports `toRaw`, `isReactive`, and `markRaw` so third-party objects can skip proxy wrapping.

Fixes #1105