### PR TITLE
feat(core): support default fallbacks in inject config

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -112,8 +112,12 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
 
     /**
      * Keys or mappings injected from ancestor components.
+     * Object values may be provide-key strings or `{ from?, default }` configs.
      */
-    inject?: Record<string, string> | (() => Record<string, string>) | string[];
+    inject?:
+        | Record<string, string | { from?: string; default?: any }>
+        | (() => Record<string, string | { from?: string; default?: any }>)
+        | string[];
 
     /**
      * @param initialState Initial component state variables.
@@ -327,7 +331,10 @@ export interface ComponentExtendOptions<
         | { handler: (newVal: any, oldVal: any) => void; immediate?: boolean; deep?: boolean }
     >;
     provide?: Record<string, any> | (() => Record<string, any>) | string[];
-    inject?: Record<string, string> | (() => Record<string, string>) | string[];
+    inject?:
+        | Record<string, string | { from?: string; default?: any }>
+        | (() => Record<string, string | { from?: string; default?: any }>)
+        | string[];
     contracts?: string[] | Set<string>;
     options?: Record<string, any>;
     onBeforeMount?(): void;

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -1539,11 +1539,26 @@ export class AvenxComponent {
       injectMap = resolvedOption;
     }
 
-    for (const [localKey, provideKey] of Object.entries(injectMap)) {
+    for (const [localKey, injectDef] of Object.entries(injectMap)) {
+      let provideKey = injectDef;
+      let defaultValue;
+      let hasDefault = false;
+
+      if (injectDef && typeof injectDef === 'object' && !Array.isArray(injectDef)) {
+        provideKey = injectDef.from != null ? injectDef.from : localKey;
+        if (Object.prototype.hasOwnProperty.call(injectDef, 'default')) {
+          hasDefault = true;
+          defaultValue = injectDef.default;
+        }
+      }
+
       Object.defineProperty(this, localKey, {
         get: () => {
           const ancestor = this.#findAncestorProviding(provideKey);
           if (!ancestor) {
+            if (hasDefault) {
+              return typeof defaultValue === 'function' ? defaultValue.call(this) : defaultValue;
+            }
             logger.warn(
               formatMessage(AvenxErrorCodes.COMPONENT_INJECT_KEY_NOT_FOUND, provideKey),
               this.$logContext

--- a/test/integration/provide_inject.test.js
+++ b/test/integration/provide_inject.test.js
@@ -692,6 +692,26 @@ global.requestAnimationFrame = (cb) => {
 
     console.log('  ✅ Reactive Provide/Inject updates tests passed!');
 
+    console.log('  5. Testing inject default fallback values...');
+    class DefaultChild extends AvenxComponent {
+      constructor(bridges, props) {
+        super({}, {}, bridges, `<span>{{theme}}-{{config.size}}</span>`, {}, props);
+      }
+    }
+    DefaultChild.inject = {
+      theme: { from: 'appTheme', default: 'light' },
+      config: { default: () => ({ size: 'medium' }) },
+    };
+
+    const defaultChild = new DefaultChild({}, {});
+    const defaultHost = document.createElement('div');
+    defaultChild.mount(defaultHost);
+    assert.strictEqual(defaultChild.theme, 'light', 'Missing provider should use default theme');
+    assert.deepStrictEqual(defaultChild.config, { size: 'medium' }, 'Missing provider should use factory default');
+    defaultChild.unmount();
+
+    console.log('  ✅ Inject default fallback tests passed!');
+
     console.log('✅ Provide / Inject Integration Tests successfully completed!');
     process.exit(0);
   } catch (error) {


### PR DESCRIPTION
Allow inject entries with from/default when no provider is found. Fixes #1115.