### PR TITLE
feat: implement AvenxRouter and RouteMatcher for hash-based navigatio…

### DIFF
--- a/lib/core/index.d.ts
+++ b/lib/core/index.d.ts
@@ -90,7 +90,13 @@ export class AvenxComponent<S extends Record<string, any> = Record<string, any>>
     /**
      * The active route details.
      */
-    readonly $route: { hash: string; page: string; params: Record<string, any> };
+    readonly $route: {
+        hash: string;
+        path: string;
+        page: string;
+        params: Record<string, any>;
+        query: Record<string, string | boolean | number>;
+    };
 
     /**
      * Runs after the current reactive DOM update flush completes.

--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -1454,7 +1454,7 @@ export class AvenxComponent {
 
   /**
    * The current active route metadata.
-   * @returns {{hash: string, page: string, params: Record<string, any>}} The route details.
+   * @returns {{hash: string, path: string, page: string, params: Record<string, any>, query: Record<string, string | boolean | number>}} The route details.
    */
   get $route() {
     if (typeof window !== 'undefined' && window.__avenx_routers) {
@@ -1464,7 +1464,7 @@ export class AvenxComponent {
         }
       }
     }
-    return { hash: '', page: '', params: {} };
+    return { hash: '', path: '', page: '', params: {}, query: {} };
   }
 
   /**

--- a/lib/core/runtime/AvenxMock.js
+++ b/lib/core/runtime/AvenxMock.js
@@ -168,10 +168,26 @@ export class AvenxMock {
    * @returns {object} Mock router with `push`, `replace`, `getParams`, and `currentRoute`.
    */
   static createMockRouter(options = {}) {
+    const initialHash =
+      (options.currentRoute && options.currentRoute.hash) ||
+      options.hash ||
+      '#/';
+    const [pathPart, queryPart] = initialHash.split('?');
+    const parsedQuery = {};
+    if (queryPart) {
+      const qp = new URLSearchParams(queryPart);
+      for (const [k, v] of qp.entries()) {
+        if (v === 'true') parsedQuery[k] = true;
+        else if (v === 'false') parsedQuery[k] = false;
+        else if (/^\d+$/.test(v)) parsedQuery[k] = Number(v);
+        else parsedQuery[k] = v;
+      }
+    }
     const queryFromOptions =
       options.queryParams ||
+      (options.currentRoute && options.currentRoute.query) ||
       (options.currentRoute && options.currentRoute.params && options.currentRoute.params.query) ||
-      {};
+      parsedQuery;
     const pathParams = {
       ...(options.params || {}),
       ...(options.currentRoute && options.currentRoute.params ? { ...options.currentRoute.params } : {}),
@@ -182,12 +198,11 @@ export class AvenxMock {
     }
 
     const currentRoute = {
-      hash:
-        (options.currentRoute && options.currentRoute.hash) ||
-        options.hash ||
-        '#/',
+      hash: initialHash,
+      path: (options.currentRoute && options.currentRoute.path) || pathPart || '',
       page: (options.currentRoute && options.currentRoute.page) || options.page || '',
       params: pathParams,
+      query: { ...queryFromOptions },
     };
 
     const guards = Array.isArray(options.guards) ? options.guards.slice() : [];
@@ -199,10 +214,29 @@ export class AvenxMock {
      */
     const navigate = (path, method) => {
       const hash = path.startsWith('#') ? path : `#${path.startsWith('/') ? path : `/${path}`}`;
+      const [navPathPart, navQueryPart] = hash.split('?');
+      const navQuery = {};
+      if (navQueryPart) {
+        const qp = new URLSearchParams(navQueryPart);
+        for (const [k, v] of qp.entries()) {
+          if (v === 'true') navQuery[k] = true;
+          else if (v === 'false') navQuery[k] = false;
+          else if (/^\d+$/.test(v)) navQuery[k] = Number(v);
+          else navQuery[k] = v;
+        }
+      }
+      const nextParams = { ...currentRoute.params };
+      if (Object.keys(navQuery).length > 0) {
+        nextParams.query = { ...navQuery };
+      } else {
+        delete nextParams.query;
+      }
       const nextRoute = {
         hash,
+        path: navPathPart,
         page: currentRoute.page,
-        params: { ...currentRoute.params },
+        params: nextParams,
+        query: navQuery,
       };
 
       for (const guard of guards) {
@@ -222,7 +256,9 @@ export class AvenxMock {
       }
 
       currentRoute.hash = nextRoute.hash;
+      currentRoute.path = nextRoute.path;
       currentRoute.params = nextRoute.params;
+      currentRoute.query = nextRoute.query;
       calls.push({ method, args: [path], blocked: false });
       return true;
     };

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -270,7 +270,7 @@ export class AvenxRouter {
     }
 
     const activeRouters = this.delegate.getActiveRouters();
-    const { matchedRoute, params, otherRouterMatches, normalizedHash } = RouteMatcher.matchRoute(
+    const { matchedRoute, params, query, path, otherRouterMatches, normalizedHash } = RouteMatcher.matchRoute(
       this.routes,
       hash,
       this.options,
@@ -360,12 +360,20 @@ export class AvenxRouter {
     const parentGuards = parentDef && typeof parentDef === 'object' ? parentDef.guards || [] : [];
     const guards = [...this.beforeHooks, ...parentGuards, ...childGuards];
 
-    const to = { hash: normalizedHash, page: pageName, params };
+    const to = {
+      hash: normalizedHash,
+      path: path || '',
+      page: pageName,
+      params,
+      query: query || {},
+    };
     const from = this.currentRoute
       ? {
         hash: this.currentRoute.hash,
+        path: this.currentRoute.path,
         page: this.currentRoute.page,
         params: { ...this.currentRoute.params },
+        query: { ...this.currentRoute.query },
       }
       : null;
 
@@ -534,24 +542,36 @@ export class AvenxRouter {
       this.#currentRouteIsNull = true;
       if (this.#currentRouteProxy) {
         this.#currentRouteProxy.hash = '';
+        this.#currentRouteProxy.path = '';
         this.#currentRouteProxy.page = '';
         for (const key of Object.keys(this.#currentRouteProxy.params)) {
           delete this.#currentRouteProxy.params[key];
+        }
+        for (const key of Object.keys(this.#currentRouteProxy.query)) {
+          delete this.#currentRouteProxy.query[key];
         }
       }
     } else {
       this.#currentRouteIsNull = false;
       if (!this.#currentRouteProxy) {
         const handlerFactory = new ProxyHandlerFactory();
-        this.#currentRouteProxy = new Proxy({ hash: '', page: '', params: {} }, handlerFactory.create());
+        this.#currentRouteProxy = new Proxy({ hash: '', path: '', page: '', params: {}, query: {} }, handlerFactory.create());
       }
-      this.#currentRouteProxy.hash = val.hash;
-      this.#currentRouteProxy.page = val.page;
+      this.#currentRouteProxy.hash = val.hash || '';
+      this.#currentRouteProxy.path = val.path !== undefined ? val.path : (val.hash ? val.hash.split('?')[0] : '');
+      this.#currentRouteProxy.page = val.page || '';
       for (const key of Object.keys(this.#currentRouteProxy.params)) {
         delete this.#currentRouteProxy.params[key];
       }
       for (const [key, v] of Object.entries(val.params || {})) {
         this.#currentRouteProxy.params[key] = v;
+      }
+      for (const key of Object.keys(this.#currentRouteProxy.query)) {
+        delete this.#currentRouteProxy.query[key];
+      }
+      const incomingQuery = val.query || (val.params && val.params.query) || {};
+      for (const [key, v] of Object.entries(incomingQuery)) {
+        this.#currentRouteProxy.query[key] = v;
       }
     }
   }

--- a/lib/core/runtime/RouteMatcher.js
+++ b/lib/core/runtime/RouteMatcher.js
@@ -145,6 +145,7 @@ export class RouteMatcher {
 
     let matchedRoute = null;
     const params = {};
+    const query = {};
 
     const [pathPart, queryPart] = normalizedHash.split('?');
     let decodedPath;
@@ -153,6 +154,21 @@ export class RouteMatcher {
       decodedPath = decodeURIComponent(pathPart);
     } catch {
       decodedPath = pathPart;
+    }
+
+    if (queryPart) {
+      const queryParams = new URLSearchParams(queryPart);
+      for (const [key, value] of queryParams.entries()) {
+        if (value === 'true') {
+          query[key] = true;
+        } else if (value === 'false') {
+          query[key] = false;
+        } else if (/^\d+$/.test(value)) {
+          query[key] = Number(value);
+        } else {
+          query[key] = value;
+        }
+      }
     }
 
     const found = this._findMatch(routes, decodedPath);
@@ -171,21 +187,8 @@ export class RouteMatcher {
         }
       });
 
-      if (queryPart) {
-        const queryParams = new URLSearchParams(queryPart);
-        const parsedQuery = {};
-        for (const [key, value] of queryParams.entries()) {
-          if (value === 'true') {
-            parsedQuery[key] = true;
-          } else if (value === 'false') {
-            parsedQuery[key] = false;
-          } else if (/^\d+$/.test(value)) {
-            parsedQuery[key] = Number(value);
-          } else {
-            parsedQuery[key] = value;
-          }
-        }
-        params.query = parsedQuery;
+      if (Object.keys(query).length > 0) {
+        params.query = { ...query };
       }
     }
 
@@ -201,6 +204,6 @@ export class RouteMatcher {
       }
     }
 
-    return { matchedRoute, params, otherRouterMatches, normalizedHash };
+    return { matchedRoute, params, query, path: pathPart, otherRouterMatches, normalizedHash };
   }
 }

--- a/test/unit/mock.test.js
+++ b/test/unit/mock.test.js
@@ -144,7 +144,13 @@ class CounterComponent extends AvenxComponent {
 
     // Test route mocking
     sandbox.setRoute({ hash: '#/users', page: 'users', params: { id: '99' } });
-    assert.deepStrictEqual(mounted.instance.$route, { hash: '#/users', page: 'users', params: { id: '99' } });
+    assert.deepStrictEqual(mounted.instance.$route, {
+      hash: '#/users',
+      path: '#/users',
+      page: 'users',
+      params: { id: '99' },
+      query: {},
+    });
 
     // ==========================================
     // 3. createMockRouter

--- a/test/unit/route_query_accessor.test.js
+++ b/test/unit/route_query_accessor.test.js
@@ -1,0 +1,266 @@
+import assert from 'assert';
+import { AvenxApp } from '../../lib/core/runtime/AvenxApp.js';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
+import { AvenxMock } from '../../lib/core/runtime/AvenxMock.js';
+import { MockDOMElement, setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+let hashListeners = [];
+
+function setupWindowMock(initialHash = '#/') {
+  hashListeners = [];
+  global.window = {
+    addEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners.push(cb);
+      }
+    },
+    removeEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners = hashListeners.filter((l) => l !== cb);
+      }
+    },
+    location: {
+      _hash: initialHash,
+      get hash() {
+        return this._hash;
+      },
+      set hash(val) {
+        this._hash = val;
+        hashListeners.forEach((listener) => listener());
+      },
+    },
+  };
+}
+
+function teardownWindowMock() {
+  delete global.window;
+}
+
+(async () => {
+  try {
+    console.log('🧪 Testing Route Query & Path Accessor ($route.query & $route.path)...');
+
+    // ==========================================
+    // 1. Fallback when no router is active
+    // ==========================================
+    console.log('  Testing fallback $route object...');
+    const standaloneComp = new AvenxComponent();
+    assert.deepStrictEqual(standaloneComp.$route, {
+      hash: '',
+      path: '',
+      page: '',
+      params: {},
+      query: {},
+    });
+    console.log('  ✅ Fallback $route test passed!');
+
+    // ==========================================
+    // 2. Component and Template Access with Router
+    // ==========================================
+    console.log('  Testing $route.query and $route.path with active router...');
+    setupDOMMock();
+    setupWindowMock('#/products?category=shoes&sort=price_asc&inStock=true&page=2');
+
+    const rootEl = new MockDOMElement('div');
+    global.document.querySelector = () => rootEl;
+
+    class ProductPage extends AvenxPage {
+      constructor(bridges, componentRegistry) {
+        super(
+          {},
+          {},
+          bridges,
+          '<div id="route-info">Path: {{ $route.path }}, Category: {{ $route.query.category }}, Sort: {{ $route.query.sort }}, InStock: {{ $route.query.inStock }}, Page: {{ $route.query.page }}</div>',
+          {},
+          componentRegistry,
+        );
+      }
+    }
+
+    class ProductDetailPage extends AvenxPage {
+      constructor(bridges, componentRegistry) {
+        super(
+          {},
+          {},
+          bridges,
+          '<div id="detail">ID: {{ $route.params.id }}, Path: {{ $route.path }}, Tab: {{ $route.query.tab }}, Rating: {{ $route.query.rating }}</div>',
+          {},
+          componentRegistry,
+        );
+      }
+    }
+
+    const app = new AvenxApp({ target: 'div' });
+    app.registerPage('Products', ProductPage);
+    app.registerPage('ProductDetail', ProductDetailPage);
+
+    const router = app.initRouter({
+      '#/products': 'Products',
+      '#/products/:id': 'ProductDetail',
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Verify router.currentRoute
+    assert.strictEqual(router.currentRoute.hash, '#/products?category=shoes&sort=price_asc&inStock=true&page=2');
+    assert.strictEqual(router.currentRoute.path, '#/products');
+    assert.strictEqual(router.currentRoute.page, 'Products');
+    assert.strictEqual(router.currentRoute.query.category, 'shoes');
+    assert.strictEqual(router.currentRoute.query.sort, 'price_asc');
+    assert.strictEqual(router.currentRoute.query.inStock, true);
+    assert.strictEqual(router.currentRoute.query.page, 2);
+
+    // Verify component instance $route access
+    const mountedInstance = rootEl.__avenx_comp_instance;
+    assert.ok(mountedInstance, 'Page should be mounted to rootEl');
+    assert.strictEqual(mountedInstance.$route.path, '#/products');
+    assert.strictEqual(mountedInstance.$route.query.category, 'shoes');
+    assert.strictEqual(mountedInstance.$route.query.sort, 'price_asc');
+    assert.strictEqual(mountedInstance.$route.query.inStock, true);
+    assert.strictEqual(mountedInstance.$route.query.page, 2);
+
+    // Verify rendered output in component render
+    const renderedHtml = mountedInstance.render();
+    assert.ok(
+      renderedHtml.includes('Path: #/products'),
+      `Expected 'Path: #/products', got: ${renderedHtml}`,
+    );
+    assert.ok(
+      renderedHtml.includes('Category: shoes'),
+      `Expected 'Category: shoes', got: ${renderedHtml}`,
+    );
+    assert.ok(
+      renderedHtml.includes('Sort: price_asc'),
+      `Expected 'Sort: price_asc', got: ${renderedHtml}`,
+    );
+    assert.ok(
+      renderedHtml.includes('InStock: true'),
+      `Expected 'InStock: true', got: ${renderedHtml}`,
+    );
+    assert.ok(
+      renderedHtml.includes('Page: 2'),
+      `Expected 'Page: 2', got: ${renderedHtml}`,
+    );
+    console.log('  ✅ Template & component $route accessor test passed!');
+
+    // ==========================================
+    // 3. Reactive updates on navigation
+    // ==========================================
+    console.log('  Testing reactivity on router.navigate()...');
+    router.navigate('#/products?category=hats&sort=desc&inStock=false&page=5');
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert.strictEqual(router.currentRoute.path, '#/products');
+    assert.strictEqual(router.currentRoute.query.category, 'hats');
+    assert.strictEqual(router.currentRoute.query.sort, 'desc');
+    assert.strictEqual(router.currentRoute.query.inStock, false);
+    assert.strictEqual(router.currentRoute.query.page, 5);
+
+    assert.strictEqual(mountedInstance.$route.query.category, 'hats');
+    assert.strictEqual(mountedInstance.$route.query.inStock, false);
+    assert.strictEqual(mountedInstance.$route.query.page, 5);
+
+    const updatedHtml = mountedInstance.render();
+    assert.ok(
+      updatedHtml.includes('Category: hats'),
+      `Expected updated 'Category: hats', got: ${updatedHtml}`,
+    );
+    assert.ok(
+      updatedHtml.includes('InStock: false'),
+      `Expected updated 'InStock: false', got: ${updatedHtml}`,
+    );
+    console.log('  ✅ Reactivity on navigation test passed!');
+
+    // ==========================================
+    // 4. Combined Route Params and Query Params
+    // ==========================================
+    console.log('  Testing combined route params and query params...');
+    router.navigate('#/products/42?tab=reviews&rating=5');
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert.strictEqual(router.currentRoute.hash, '#/products/42?tab=reviews&rating=5');
+    assert.strictEqual(router.currentRoute.path, '#/products/42');
+    assert.strictEqual(router.currentRoute.params.id, '42');
+    assert.strictEqual(router.currentRoute.query.tab, 'reviews');
+    assert.strictEqual(router.currentRoute.query.rating, 5);
+
+    const detailInstance = rootEl.__avenx_comp_instance;
+    assert.strictEqual(detailInstance.$route.path, '#/products/42');
+    assert.strictEqual(detailInstance.$route.params.id, '42');
+    assert.strictEqual(detailInstance.$route.query.tab, 'reviews');
+    assert.strictEqual(detailInstance.$route.query.rating, 5);
+
+    const detailHtml = detailInstance.render();
+    assert.ok(
+      detailHtml.includes('ID: 42'),
+      `Expected 'ID: 42', got: ${detailHtml}`,
+    );
+    assert.ok(
+      detailHtml.includes('Path: #/products/42'),
+      `Expected 'Path: #/products/42', got: ${detailHtml}`,
+    );
+    assert.ok(
+      detailHtml.includes('Tab: reviews'),
+      `Expected 'Tab: reviews', got: ${detailHtml}`,
+    );
+    assert.ok(
+      detailHtml.includes('Rating: 5'),
+      `Expected 'Rating: 5', got: ${detailHtml}`,
+    );
+    console.log('  ✅ Route params + query params test passed!');
+
+    // ==========================================
+    // 5. Clean path without query parameters
+    // ==========================================
+    console.log('  Testing route without query parameters...');
+    router.navigate('#/products');
+    await new Promise((r) => setTimeout(r, 20));
+
+    assert.strictEqual(router.currentRoute.hash, '#/products');
+    assert.strictEqual(router.currentRoute.path, '#/products');
+    assert.deepStrictEqual({ ...router.currentRoute.query }, {});
+    assert.strictEqual(Object.keys(router.currentRoute.query).length, 0);
+    console.log('  ✅ Clean path without query parameters test passed!');
+
+    router.destroy();
+    teardownWindowMock();
+    teardownDOMMock();
+
+    // ==========================================
+    // 6. Mock Router ($route.query & $route.path in AvenxMock)
+    // ==========================================
+    console.log('  Testing AvenxMock.createMockRouter query and path support...');
+    setupDOMMock();
+
+    const mockRouter = AvenxMock.createMockRouter({
+      hash: '#/catalog?category=books&page=1',
+      page: 'Catalog',
+      params: { id: '99' },
+    });
+
+    assert.strictEqual(mockRouter.currentRoute.hash, '#/catalog?category=books&page=1');
+    assert.strictEqual(mockRouter.currentRoute.path, '#/catalog');
+    assert.strictEqual(mockRouter.currentRoute.query.category, 'books');
+    assert.strictEqual(mockRouter.currentRoute.query.page, 1);
+
+    const compWithMock = new AvenxComponent();
+    assert.strictEqual(compWithMock.$route.path, '#/catalog');
+    assert.strictEqual(compWithMock.$route.query.category, 'books');
+
+    mockRouter.push('#/catalog?category=electronics&featured=true');
+    assert.strictEqual(mockRouter.currentRoute.path, '#/catalog');
+    assert.strictEqual(mockRouter.currentRoute.query.category, 'electronics');
+    assert.strictEqual(mockRouter.currentRoute.query.featured, true);
+    assert.strictEqual(compWithMock.$route.query.category, 'electronics');
+    assert.strictEqual(compWithMock.$route.query.featured, true);
+
+    teardownDOMMock();
+    console.log('  ✅ AvenxMock.createMockRouter test passed!');
+
+    console.log('🎉 All Route Query & Path Accessor tests passed successfully!');
+  } catch (err) {
+    console.error('❌ Route Query & Path Accessor test failed:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary & Motivation

Closes #1126

Previously, accessing URL query strings required manually parsing `this.$route.hash` with `URLSearchParams`. This PR adds direct, reactive access to parsed query parameters via `this.$route.query` and exposes the route path without query strings via `this.$route.path`.

---

## Key Changes

* **`$route.query`**: Exposes a reactive dictionary of parsed query parameters (with automatic boolean/number coercion) defaulting to `{}`. Preserves `params.query` for backward compatibility.
* **`$route.path`**: Exposes the clean route path excluding query strings (e.g., `#/products`).
* **Router & Runtime**: Updated `RouteMatcher`, `AvenxRouter`, `AvenxComponent`, and `AvenxMock` to parse, assign, and reactively expose `query` and `path`.
* **TypeScript & Tests**: Updated `$route` typings in `lib/core/index.d.ts` and added full test coverage in `test/unit/route_query_accessor.test.js`.

---

## Verification

* [x] `node test/unit/route_query_accessor.test.js` passed
* [x] Full test suite passed (`npm test` — 127/127)
* [x] Build verified (`npm run build`)