### PR TITLE
feat(router): add route metadata support

### DIFF
--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -1480,7 +1480,7 @@ export class AvenxComponent {
         }
       }
     }
-    return { hash: '', path: '', page: '', params: {}, query: {} };
+    return { hash: '', path: '', page: '', params: {}, query: {}, meta: {} };
   }
 
   /**

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -398,7 +398,7 @@ export class AvenxRouter {
           page: this.currentRoute.page,
           params: { ...this.currentRoute.params },
           query: { ...this.currentRoute.query },
-          meta:{...(this.currentRoute.meta || {})}
+          meta: { ...(this.currentRoute.meta || {}) },
         }
       : null;
 

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -3,6 +3,7 @@ import { logger } from './AvenxLogger.js';
 import { ProxyHandlerFactory } from '../reactive/proxyHandler.js';
 import { RouteMatcher } from './RouteMatcher.js';
 import { createNavigationDelegate } from './navigation/index.js';
+// import { meta } from '@eslint/js';
 
 //This is declared for controlling the depth of a redirected loop
 const MAX_REDIRECT = 10;
@@ -158,8 +159,7 @@ export class AvenxRouter {
   getRoutes() {
     return Object.entries(this.routes).map(([pattern, definition]) => ({
       pattern,
-      definition:
-        typeof definition === 'object' && definition !== null ? { ...definition } : definition,
+      definition: typeof definition === 'object' && definition !== null ? { ...definition } : definition,
     }));
   }
 
@@ -308,6 +308,7 @@ export class AvenxRouter {
     }
 
     const def = matchedRoute.definition;
+    const meta = typeof def === 'object' && def.meta && typeof def.meta === 'object' ? def.meta : {};
 
     if (def && typeof def === 'object' && def.redirect) {
       // Create a new redirect context when the redirect starts
@@ -388,15 +389,17 @@ export class AvenxRouter {
       page: pageName,
       params,
       query: query || {},
+      meta,
     };
     const from = this.currentRoute
       ? {
-        hash: this.currentRoute.hash,
-        path: this.currentRoute.path,
-        page: this.currentRoute.page,
-        params: { ...this.currentRoute.params },
-        query: { ...this.currentRoute.query },
-      }
+          hash: this.currentRoute.hash,
+          path: this.currentRoute.path,
+          page: this.currentRoute.page,
+          params: { ...this.currentRoute.params },
+          query: { ...this.currentRoute.query },
+          meta:{...(this.currentRoute.meta || {})}
+        }
       : null;
 
     this.#runGuards(guards, to, from)
@@ -566,6 +569,7 @@ export class AvenxRouter {
         this.#currentRouteProxy.hash = '';
         this.#currentRouteProxy.path = '';
         this.#currentRouteProxy.page = '';
+        this.#currentRouteProxy.meta = {};
         for (const key of Object.keys(this.#currentRouteProxy.params)) {
           delete this.#currentRouteProxy.params[key];
         }
@@ -577,11 +581,15 @@ export class AvenxRouter {
       this.#currentRouteIsNull = false;
       if (!this.#currentRouteProxy) {
         const handlerFactory = new ProxyHandlerFactory();
-        this.#currentRouteProxy = new Proxy({ hash: '', path: '', page: '', params: {}, query: {} }, handlerFactory.create());
+        this.#currentRouteProxy = new Proxy(
+          { hash: '', path: '', page: '', params: {}, query: {}, meta: {} },
+          handlerFactory.create(),
+        );
       }
       this.#currentRouteProxy.hash = val.hash || '';
-      this.#currentRouteProxy.path = val.path !== undefined ? val.path : (val.hash ? val.hash.split('?')[0] : '');
+      this.#currentRouteProxy.path = val.path !== undefined ? val.path : val.hash ? val.hash.split('?')[0] : '';
       this.#currentRouteProxy.page = val.page || '';
+      this.#currentRouteProxy.meta = { ...(val.meta || {}) };
       for (const key of Object.keys(this.#currentRouteProxy.params)) {
         delete this.#currentRouteProxy.params[key];
       }

--- a/lib/core/runtime/AvenxRouter.js
+++ b/lib/core/runtime/AvenxRouter.js
@@ -393,13 +393,13 @@ export class AvenxRouter {
     };
     const from = this.currentRoute
       ? {
-          hash: this.currentRoute.hash,
-          path: this.currentRoute.path,
-          page: this.currentRoute.page,
-          params: { ...this.currentRoute.params },
-          query: { ...this.currentRoute.query },
-          meta: { ...(this.currentRoute.meta || {}) },
-        }
+        hash: this.currentRoute.hash,
+        path: this.currentRoute.path,
+        page: this.currentRoute.page,
+        params: { ...this.currentRoute.params },
+        query: { ...this.currentRoute.query },
+        meta: { ...(this.currentRoute.meta || {}) },
+      }
       : null;
 
     this.#runGuards(guards, to, from)

--- a/test/unit/route_query_accessor.test.js
+++ b/test/unit/route_query_accessor.test.js
@@ -4,6 +4,7 @@ import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
 import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
 import { AvenxMock } from '../../lib/core/runtime/AvenxMock.js';
 import { MockDOMElement, setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+// import { meta } from '@eslint/js';
 
 let hashListeners = [];
 
@@ -52,6 +53,7 @@ function teardownWindowMock() {
       page: '',
       params: {},
       query: {},
+      meta:{}
     });
     console.log('  ✅ Fallback $route test passed!');
 

--- a/test/unit/router_meta.test.js
+++ b/test/unit/router_meta.test.js
@@ -1,0 +1,410 @@
+import assert from 'assert';
+
+import { AvenxApp } from '../../lib/core/runtime/AvenxApp.js';
+import { AvenxPage } from '../../lib/core/runtime/AvenxPage.js';
+import { setupDOMMock, teardownDOMMock } from '../helpers/dom-mock.js';
+
+/**
+ *
+ */
+class PageHome extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>Home Page</div>';
+  }
+}
+
+/**
+ *
+ */
+class PageProfile extends AvenxPage {
+  /**
+   *
+   */
+  render() {
+    return '<div>Profile Page</div>';
+  }
+}
+
+let hashListeners = [];
+
+/**
+ *
+ */
+function setupWindowMock() {
+  hashListeners = [];
+
+  global.window = {
+    addEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners.push(cb);
+      }
+    },
+
+    removeEventListener: (event, cb) => {
+      if (event === 'hashchange') {
+        hashListeners = hashListeners.filter((listener) => listener !== cb);
+      }
+    },
+
+    location: {
+      _hash: '#/',
+
+      get hash() {
+        return this._hash;
+      },
+
+      set hash(value) {
+        this._hash = value;
+
+        for (const listener of hashListeners) {
+          listener();
+        }
+      },
+    },
+  };
+}
+
+/**
+ *
+ */
+function teardownWindowMock() {
+  delete global.window;
+}
+
+/**
+ *
+ */
+function waitForRoute() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ *
+ */
+async function testRouteMetaIsAvailableInCurrentRoute() {
+  console.log('🧪 Testing route meta in currentRoute...');
+
+  setupDOMMock();
+  setupWindowMock();
+
+  const app = new AvenxApp({ target: 'div' });
+
+  app.registerPage('Home', PageHome);
+  app.registerPage('Profile', PageProfile);
+
+  const router = app.initRouter({
+    '#/': 'Home',
+
+    '#/profile': {
+      page: 'Profile',
+      meta: {
+        layout: 'admin',
+        requiresAuth: true,
+      },
+    },
+  });
+
+  await waitForRoute();
+
+  window.location.hash = '#/profile';
+
+  await waitForRoute();
+
+  assert.strictEqual(
+    router.currentRoute.meta.layout,
+    'admin',
+    'Current route meta should contain layout',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.requiresAuth,
+    true,
+    'Current route meta should contain requiresAuth',
+  );
+
+  router.destroy();
+
+  teardownWindowMock();
+  teardownDOMMock();
+
+  console.log('  ✅ Route meta in currentRoute test passed!');
+}
+
+/**
+ *
+ */
+async function testRouteMetaIsAvailableInNavigationGuard() {
+  console.log('🧪 Testing route meta in navigation guard...');
+
+  setupDOMMock();
+  setupWindowMock();
+
+  const app = new AvenxApp({ target: 'div' });
+
+  app.registerPage('Home', PageHome);
+  app.registerPage('Profile', PageProfile);
+
+  const router = app.initRouter({
+    '#/': 'Home',
+
+    '#/profile': {
+      page: 'Profile',
+      meta: {
+        layout: 'admin',
+        requiresAuth: true,
+      },
+    },
+  });
+
+  let receivedToMeta = null;
+
+  router.beforeEach((to) => {
+    if (to.page === 'Profile') {
+      receivedToMeta = to.meta;
+    }
+  });
+
+  await waitForRoute();
+
+  window.location.hash = '#/profile';
+
+  await waitForRoute();
+  await waitForRoute();
+
+  assert.ok(
+    receivedToMeta,
+    'Navigation guard should receive meta in to',
+  );
+
+  assert.strictEqual(
+    receivedToMeta.layout,
+    'admin',
+    'Navigation guard should receive layout meta in to',
+  );
+
+  assert.strictEqual(
+    receivedToMeta.requiresAuth,
+    true,
+    'Navigation guard should receive requiresAuth meta in to',
+  );
+
+  router.destroy();
+
+  teardownWindowMock();
+  teardownDOMMock();
+
+  console.log('  ✅ Route meta in navigation guard test passed!');
+}
+
+/**
+ *
+ */
+async function testRouteMetaIsAvailableInFromNavigationGuard() {
+  console.log('🧪 Testing previous route meta in navigation guard...');
+
+  setupDOMMock();
+  setupWindowMock();
+
+  const app = new AvenxApp({ target: 'div' });
+
+  app.registerPage('Home', PageHome);
+  app.registerPage('Profile', PageProfile);
+
+  const router = app.initRouter({
+    '#/': {
+      page: 'Home',
+      meta: {
+        layout: 'public',
+      },
+    },
+
+    '#/profile': {
+      page: 'Profile',
+      meta: {
+        layout: 'admin',
+      },
+    },
+  });
+
+  let receivedFromMeta = null;
+
+  router.beforeEach((to, from) => {
+    if (to.page === 'Profile') {
+      receivedFromMeta = from.meta;
+    }
+  });
+
+  await waitForRoute();
+
+  window.location.hash = '#/profile';
+
+  await waitForRoute();
+  await waitForRoute();
+
+  assert.ok(
+    receivedFromMeta,
+    'Navigation guard should receive meta in from',
+  );
+
+  assert.strictEqual(
+    receivedFromMeta.layout,
+    'public',
+    'Navigation guard should receive previous route meta in from',
+  );
+
+  router.destroy();
+
+  teardownWindowMock();
+  teardownDOMMock();
+
+  console.log('  ✅ Previous route meta in navigation guard test passed!');
+}
+
+/**
+ *
+ */
+async function testRouteWithoutMetaReturnsEmptyObject() {
+  console.log('🧪 Testing route without meta...');
+
+  setupDOMMock();
+  setupWindowMock();
+
+  const app = new AvenxApp({ target: 'div' });
+
+  app.registerPage('Home', PageHome);
+
+  const router = app.initRouter({
+    '#/': 'Home',
+  });
+
+  await waitForRoute();
+
+  assert.strictEqual(
+    typeof router.currentRoute.meta,
+    'object',
+    'Route meta should be an object',
+  );
+
+  assert.strictEqual(
+    Object.keys(router.currentRoute.meta).length,
+    0,
+    'Route without meta should return an empty object',
+  );
+
+  router.destroy();
+
+  teardownWindowMock();
+  teardownDOMMock();
+
+  console.log('  ✅ Route without meta test passed!');
+}
+
+/**
+ *
+ */
+async function testRouteMetaCanContainDifferentValues() {
+  console.log('🧪 Testing route meta can contain different values...');
+
+  setupDOMMock();
+  setupWindowMock();
+
+  const app = new AvenxApp({ target: 'div' });
+
+  app.registerPage('Home', PageHome);
+  app.registerPage('Profile', PageProfile);
+
+  const router = app.initRouter({
+    '#/': 'Home',
+
+    '#/profile': {
+      page: 'Profile',
+      meta: {
+        requiresAuth: true,
+        permissions: ['admin', 'editor'],
+        title: 'Profile',
+        layout: 'admin',
+      },
+    },
+  });
+
+  await waitForRoute();
+
+  window.location.hash = '#/profile';
+
+  await waitForRoute();
+
+  assert.strictEqual(
+    router.currentRoute.meta.requiresAuth,
+    true,
+    'Meta boolean value should be preserved',
+  );
+
+  assert.ok(
+    Array.isArray(router.currentRoute.meta.permissions),
+    'Meta array value should be preserved',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.permissions.length,
+    2,
+    'Meta permissions should contain two values',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.permissions[0],
+    'admin',
+    'First permission should be preserved',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.permissions[1],
+    'editor',
+    'Second permission should be preserved',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.title,
+    'Profile',
+    'Meta string value should be preserved',
+  );
+
+  assert.strictEqual(
+    router.currentRoute.meta.layout,
+    'admin',
+    'Meta layout value should be preserved',
+  );
+
+  router.destroy();
+
+  teardownWindowMock();
+  teardownDOMMock();
+
+  console.log('  ✅ Route meta values test passed!');
+}
+
+/**
+ *
+ */
+(async () => {
+  try {
+    await testRouteMetaIsAvailableInCurrentRoute();
+    await testRouteMetaIsAvailableInNavigationGuard();
+    await testRouteMetaIsAvailableInFromNavigationGuard();
+    await testRouteWithoutMetaReturnsEmptyObject();
+    await testRouteMetaCanContainDifferentValues();
+
+    console.log('🎉 All route meta tests passed!');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Route meta tests failed!');
+    console.error(error);
+
+    teardownWindowMock();
+    teardownDOMMock();
+
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

Adds support for custom metadata on route definitions.

### Changes

- Preserve route `meta` through route matching and navigation.
- Expose route metadata through `currentRoute.meta`.
- Include `meta` in the `to` and `from` objects passed to navigation guards.
- Expose an empty object when no route metadata is defined.
- Added tests for route metadata propagation.
- Updated the existing route accessor test for the new `$route.meta` property.

## Testing

- `npm test`
- All tests passed successfully.

Closes #982 