### PR TITLE
feat(runtime): add $inspect() component diagnostic snapshot

### DIFF
--- a/lib/core/runtime/AvenxComponent.js
+++ b/lib/core/runtime/AvenxComponent.js
@@ -17,10 +17,11 @@ import { AvenxSandbox } from '../security/sandbox.js';
 
 import { AvenxWatcher } from '../reactive/watcher.js';
 import { Resource } from '../reactive/Resource.js';
-import { ProxyHandlerFactory, RAW_SYMBOL } from '../reactive/proxyHandler.js';
+import { ProxyHandlerFactory, RAW_SYMBOL, toRaw } from '../reactive/proxyHandler.js';
 import { processBindDirectives } from '../utils/templateUtils.js';
 import { profile } from '../utils/profiler.js';
 import { parseValidationRules, validateValue, getFieldName, updateValidationState } from '../validation/validator.js';
+import { serializeSafe } from '../tooling/inspect.js';
 
 export const RESERVED_INSTANCE_KEYS = [
   'mount',
@@ -551,6 +552,33 @@ export class AvenxComponent {
         const nodes = groups.named?.[name];
         return Array.isArray(nodes) && nodes.length > 0;
       },
+    };
+  }
+
+  /**
+   * Returns a diagnostic snapshot of the component for runtime debugging.
+   * Props and state are sanitized clones (safe to log, serialize, or diff);
+   * `element` is intentionally the live root element so it stays inspectable
+   * in browser devtools. Computed properties are listed by key only, so
+   * inspecting never evaluates them.
+   * @returns {{ componentName: string, props: object, state: object, computed: string[], slots: string[], element: Element|null }}
+   */
+  $inspect() {
+    const groups = this.#transcludedGroups;
+    const slots = [
+      ...(Array.isArray(groups?.default) && groups.default.length > 0 ? ['default'] : []),
+      ...Object.keys(groups?.named || {}),
+    ];
+
+    // Serialize the raw targets: enumerating the reactive proxies would
+    // evaluate computed properties as a side effect.
+    return {
+      componentName: this.$logContext.componentName,
+      props: serializeSafe(toRaw(this.props)),
+      state: serializeSafe(toRaw(this.state)),
+      computed: this.#computed.keys(),
+      slots,
+      element: this.$element,
     };
   }
 

--- a/lib/core/tooling/inspect.js
+++ b/lib/core/tooling/inspect.js
@@ -5,7 +5,7 @@
  * @param {WeakSet<object>} [seen] - WeakSet tracking visited objects to prevent circular loops.
  * @returns {*} The safe clone.
  */
-function serializeSafe(val, seen = new WeakSet()) {
+export function serializeSafe(val, seen = new WeakSet()) {
   if (val === null || typeof val !== 'object') {
     if (typeof val === 'function') {
       return '[Function]';

--- a/test/unit/componentInspect.test.js
+++ b/test/unit/componentInspect.test.js
@@ -1,0 +1,150 @@
+import assert from 'assert';
+import '../helpers/register-happy-dom.js';
+import { AvenxComponent } from '../../lib/core/runtime/AvenxComponent.js';
+
+/**
+ * Tests the shape of the $inspect() snapshot and its component name resolution.
+ */
+function testInspectSnapshotShape() {
+  console.log('🧪 Testing $inspect() snapshot shape...');
+
+  let computedEvaluations = 0;
+
+  class ProfileCard extends AvenxComponent {
+    constructor() {
+      super(
+        { count: 2 },
+        {
+          doubled() {
+            computedEvaluations++;
+            return this.state.count * 2;
+          },
+        },
+        {},
+        '<div>{{state.count}}</div>',
+        {},
+        { title: 'Hello' },
+      );
+    }
+  }
+
+  const component = new ProfileCard();
+  const snapshot = component.$inspect();
+
+  assert.strictEqual(snapshot.componentName, 'ProfileCard', 'componentName should come from the constructor');
+  assert.deepStrictEqual(snapshot.state, { count: 2 }, 'state should be included in the snapshot');
+  assert.strictEqual(computedEvaluations, 0, '$inspect() must not evaluate computed properties');
+  assert.deepStrictEqual(snapshot.props, { title: 'Hello' }, 'props should be included in the snapshot');
+  assert.deepStrictEqual(snapshot.computed, ['doubled'], 'computed should list keys only');
+  assert.deepStrictEqual(snapshot.slots, [], 'slots should be empty before mount target setup');
+  assert.strictEqual(snapshot.element, null, 'element should be null before mount');
+
+  console.log('  ✅ $inspect() returns the expected snapshot schema.');
+}
+
+/**
+ * Tests the component name fallback for anonymous/base-class instances.
+ */
+function testInspectComponentNameFallback() {
+  console.log('🧪 Testing $inspect() component name fallback...');
+
+  const component = new AvenxComponent({}, {}, {}, '<div></div>');
+  const snapshot = component.$inspect();
+
+  assert.strictEqual(snapshot.componentName, 'Component', 'base-class instances should fall back to "Component"');
+
+  console.log('  ✅ $inspect() falls back to "Component" for unnamed components.');
+}
+
+/**
+ * Tests that state and props snapshots are dead clones, detached from the
+ * component's reactive proxies.
+ */
+function testInspectSnapshotIsDetached() {
+  console.log('🧪 Testing $inspect() snapshot detachment...');
+
+  const component = new AvenxComponent(
+    { user: { name: 'Ada' } },
+    {},
+    {},
+    '<div></div>',
+    {},
+    { level: 1 },
+  );
+
+  const snapshot = component.$inspect();
+  snapshot.state.user.name = 'mutated';
+  snapshot.props.level = 99;
+
+  assert.strictEqual(component.state.user.name, 'Ada', 'mutating the snapshot must not touch component state');
+  assert.strictEqual(component.props.level, 1, 'mutating the snapshot must not touch component props');
+
+  component.state.user.name = 'Grace';
+  assert.strictEqual(snapshot.state.user.name, 'mutated', 'later state changes must not alter an existing snapshot');
+
+  console.log('  ✅ $inspect() snapshots are detached from reactive state.');
+}
+
+/**
+ * Tests that functions and circular references in state are sanitized.
+ */
+function testInspectSanitizesUncloneableValues() {
+  console.log('🧪 Testing $inspect() sanitization of functions and circular refs...');
+
+  const circular = { id: 7 };
+  circular.self = circular;
+
+  const component = new AvenxComponent(
+    { onPick: () => {}, node: circular },
+    {},
+    {},
+    '<div></div>',
+  );
+
+  const snapshot = component.$inspect();
+
+  assert.strictEqual(snapshot.state.onPick, '[Function]', 'functions should serialize to "[Function]"');
+  assert.strictEqual(snapshot.state.node.id, 7, 'plain values inside circular objects should survive');
+  assert.strictEqual(snapshot.state.node.self, '[Circular]', 'circular references should serialize to "[Circular]"');
+
+  console.log('  ✅ $inspect() sanitizes functions and circular references.');
+}
+
+/**
+ * Tests that slots list transcluded slot names and element is the live root.
+ */
+function testInspectSlotsAndElement() {
+  console.log('🧪 Testing $inspect() slots and element after mount target setup...');
+
+  const component = new AvenxComponent(
+    {},
+    {},
+    {},
+    '<div><slot></slot><slot name="footer"></slot></div>',
+  );
+  const root = document.createElement('div');
+  const defaultNode = document.createElement('span');
+  defaultNode.textContent = 'body';
+  const footerNode = document.createElement('span');
+  footerNode.setAttribute('slot', 'footer');
+  footerNode.textContent = 'footer';
+  root.appendChild(defaultNode);
+  root.appendChild(footerNode);
+
+  component.__setMountTarget(root);
+
+  const snapshot = component.$inspect();
+
+  assert.deepStrictEqual(snapshot.slots, ['default', 'footer'], 'slots should list default and named slot names');
+  assert.strictEqual(snapshot.element, root, 'element should be the live root element');
+
+  console.log('  ✅ $inspect() reports slot names and the live root element.');
+}
+
+testInspectSnapshotShape();
+testInspectComponentNameFallback();
+testInspectSnapshotIsDetached();
+testInspectSanitizesUncloneableValues();
+testInspectSlotsAndElement();
+
+console.log('✅ All $inspect() tests passed.');


### PR DESCRIPTION
Adds a public `AvenxComponent.$inspect()` method that returns a diagnostic snapshot of a component, so debugging no longer requires reaching into private `#` fields from the console.

Returns `{ componentName, props, state, computed, slots, element }`:

- `props` / `state` — sanitized deep clones via the existing `serializeSafe()` from `lib/core/tooling/inspect.js` (now exported), so the snapshot is safe to log, serialize, or diff instead of being a live reactive proxy.
- `componentName` — from `$logContext`, which already handles anonymous and `Object` constructors.
- `computed` — keys only, never evaluated.
- `slots` — actual transcluded slot names from `#transcludedGroups`.
- `element` — intentionally the live root element, so it stays inspectable in devtools.

Return-only, no console logging (as agreed on the issue). Implemented as a method rather than a getter, since devtools and debuggers eagerly invoke getters and this does O(state-size) work.

**One deviation from the plan on the issue:** serializing `this.state` directly evaluated every computed property as a side effect (the reactive proxy's `ownKeys` trap exposes computed keys) and emitted a spurious `AVX_R04` circular-dependency warning. The snapshot now serializes the raw targets via the existing `toRaw()` helper; a regression test asserts `$inspect()` triggers zero computed evaluations.

Tests: new `test/unit/componentInspect.test.js` (schema shape, anonymous-name fallback, snapshot detachment in both directions, `[Function]` / `[Circular]` sanitization, slot names + live element). Full unit suite passes 113/113; ESLint clean on all touched files.

Closes #988 
