### PR TITLE
docs(router): document back(), forward(), go(delta) history navigation

### DIFF
--- a/docs/src/content/docs/api-reference/router-guard.md
+++ b/docs/src/content/docs/api-reference/router-guard.md
@@ -58,6 +58,21 @@ const brandingRouter = AvenxApp.initRouter(
 - ### `navigate(hash)`
   Programs a programmatic navigation to the specified route hash. It updates the browser history and triggers the matching route lifecycle.
 
+- ### `back()`
+  Navigates backward one step in the browser / session history stack. Equivalent to `router.go(-1)` (and, under `BrowserNavigationDelegate`, `window.history.back()`).
+  - **Returns:** `void`
+
+- ### `forward()`
+  Navigates forward one step in the history stack. Equivalent to `router.go(1)` (and, under `BrowserNavigationDelegate`, `window.history.forward()`).
+  - **Returns:** `void`
+
+- ### `go(delta)`
+  Moves to a relative position in the history stack, `delta` steps away from the current entry.
+  - **Arguments:** `delta: number` — negative values move backward, positive values move forward, `0` is a no-op.
+  - **Returns:** `void`
+
+  All three methods delegate to the router's underlying `NavigationDelegate` — see [Pluggable Navigation Delegates](#pluggable-navigation-delegates-navigationdelegate) below for how `back`/`forward`/`go` differ between `BrowserNavigationDelegate` and `MemoryNavigationDelegate`.
+
 - ### `beforeEach(callback)`
   Registers a global guard callback or `AvenxGuard` instance/class that runs before every route transition.
   - **Arguments:** `callback: Function | typeof AvenxGuard | AvenxGuard`
@@ -408,6 +423,9 @@ The base `NavigationDelegate` class defines the contract for all navigation adap
 | :--- | :--- | :--- |
 | `getHash()` | `string` | Returns the current location hash string (e.g. `'#/home'`). |
 | `setHash(hash: string)` | `void` | Navigates/sets the current location hash string and notifies registered listeners. |
+| `back()` | `void` | Navigates backward one step in history. |
+| `forward()` | `void` | Navigates forward one step in history. |
+| `go(delta: number)` | `void` | Moves to a history position `delta` steps relative to the current one. |
 | `onHashChange(callback: (hash: string) => void)` | `Function` | Subscribes to location hash change events. Returns an unregister function. |
 | `onLinkClick(callback: (route: string) => void)` | `Function` | Subscribes to link click events (e.g. `[data-ax-link]`). Returns an unregister function. |
 | `setTitle(title: string)` | `void` | Updates document or in-memory page title. |
@@ -420,8 +438,8 @@ The base `NavigationDelegate` class defines the contract for all navigation adap
 
 Avenx-JS provides two built-in navigation delegates:
 
-1. **`BrowserNavigationDelegate`**: The default delegate in browser environments. Binds directly to `window.location.hash`, `hashchange` events, document link clicks (`[data-ax-link]`), and `document.title`.
-2. **`MemoryNavigationDelegate`**: An in-memory delegate for Node.js, SSR, and headless test environments. Manages route location state, active subscriptions, and page titles purely in memory without DOM or window dependencies.
+1. **`BrowserNavigationDelegate`**: The default delegate in browser environments. Binds directly to `window.location.hash`, `hashchange` events, document link clicks (`[data-ax-link]`), and `document.title`. Its `back()`, `forward()`, and `go(delta)` methods forward directly to `window.history.back()`, `window.history.forward()`, and `window.history.go(delta)`, so history traversal is driven by the real browser history stack.
+2. **`MemoryNavigationDelegate`**: An in-memory delegate for Node.js, SSR, and headless test environments. Manages route location state, active subscriptions, and page titles purely in memory without DOM or window dependencies. It tracks its own `history` array and a `cursorIndex` pointer rather than delegating to `window.history`; `back()` and `forward()` are implemented as `go(-1)` / `go(1)`, and `go(delta)` moves `cursorIndex` by `delta` (clamped to the array bounds, a no-op past either end) and re-emits the resulting hash to subscribers. This gives predictable, synchronous back/forward simulation for unit and integration tests.
 
 ### Configuring Navigation Delegates
 
@@ -452,6 +470,12 @@ class MemoryNavigationDelegate extends NavigationDelegate {
   /** Current hash string held in memory */
   currentHash: string;
 
+  /** Ordered stack of hashes visited via setHash() */
+  history: string[];
+
+  /** Index of currentHash within history */
+  cursorIndex: number;
+
   /** Active in-memory title */
   title: string;
 
@@ -460,6 +484,15 @@ class MemoryNavigationDelegate extends NavigationDelegate {
 
   /** Updates currentHash and invokes registered hash listeners */
   setHash(hash: string): void;
+
+  /** Moves cursorIndex back one entry; equivalent to go(-1) */
+  back(): void;
+
+  /** Moves cursorIndex forward one entry; equivalent to go(1) */
+  forward(): void;
+
+  /** Moves cursorIndex by delta steps (no-op if out of bounds) */
+  go(delta: number): void;
 
   /** Registers a hash listener; returns unsubscribe function */
   onHashChange(callback: (hash: string) => void): Function;

--- a/docs/src/content/docs/core-concepts/routing.md
+++ b/docs/src/content/docs/core-concepts/routing.md
@@ -202,6 +202,82 @@ Then:
 ```javascript
 this.$route.params.id; // "42"
 ```
+## Programmatic History Navigation
+
+In addition to `router.navigate(hash)`, `AvenxRouter` exposes methods for traversing the browser / session history stack programmatically: `back()`, `forward()`, and `go(delta)`. These are available on the router instance and, inside components, via `this.$router`.
+
+| Method | Description | Equivalent to |
+| ------ | ------------ | ------------- |
+| `router.back()` | Navigates backward one step in the history stack. | `router.go(-1)` / `window.history.back()` |
+| `router.forward()` | Navigates forward one step in the history stack. | `router.go(1)` / `window.history.forward()` |
+| `router.go(delta)` | Moves to a relative history position given by the integer `delta` (negative to go back, positive to go forward). | `window.history.go(delta)` |
+
+### Back Buttons
+
+```html
+<!-- src/components/nav-bar.component.js -->
+<button @click="goBack">← Back</button>
+
+<action name="goBack">
+  this.$router.back();
+</action>
+```
+
+### Multi-Step Wizards
+
+`go(delta)` is useful for jumping more than one step at a time — for example, skipping back over several wizard steps that each pushed their own history entry:
+
+```html
+<!-- src/components/checkout-wizard.component.js -->
+<button @click="backToPayment">← Back to Payment</button>
+
+<action name="backToPayment">
+  // From a step two screens ahead of Payment, jump back two steps at once
+  this.$router.go(-2);
+</action>
+```
+
+### Cancel Handlers
+
+A "Cancel" action in a form or modal commonly needs to return the user to wherever they came from, without hard-coding the previous hash:
+
+```html
+<!-- src/pages/edit-profile.page.js -->
+<button @click="cancelEdit">Cancel</button>
+
+<action name="cancelEdit">
+  this.$router.back();
+</action>
+```
+
+:::note
+`back()`, `forward()`, and `go(delta)` move the history cursor but that doesn't guarantee a route change — if there's nowhere to go, the call is a no-op. Route guards (`canActivate`) still run against the resulting route once the history position (and therefore the hash) actually changes.
+:::
+
+### Delegate Behavior & Testability
+
+History traversal is delegated to whichever `NavigationDelegate` the router is configured with (see [Pluggable Navigation Delegates](/api-reference/router-guard/#pluggable-navigation-delegates-navigationdelegate) in the API reference):
+
+- **`BrowserNavigationDelegate`** forwards `back()`, `forward()`, and `go(delta)` directly to `window.history`, so the browser's own back/forward buttons and programmatic calls behave identically.
+- **`MemoryNavigationDelegate`** maintains its own in-memory history array and cursor index instead of relying on `window.history`. Calling `go(delta)` moves that cursor and re-emits the resulting hash to subscribers, which makes backward/forward transitions deterministic and easy to assert in unit and integration tests, without a DOM or `jsdom` history mock.
+
+```javascript
+import { MemoryNavigationDelegate } from 'avenx-core/runtime/navigation';
+
+const delegate = new MemoryNavigationDelegate('#/step-1');
+delegate.setHash('#/step-2');
+delegate.setHash('#/step-3');
+
+delegate.back();
+delegate.getHash(); // '#/step-2'
+
+delegate.go(-1);
+delegate.getHash(); // '#/step-1'
+
+delegate.forward();
+delegate.getHash(); // '#/step-2'
+```
+
 ## 4. In-Place Parameter Updates
 
 :::caution


### PR DESCRIPTION
Adds a Programmatic History Navigation section to the routing guide (core-concepts/routing.md) covering back()/forward()/go(delta), with back-button, multi-step wizard, and cancel-handler examples.

Updates the AvenxRouter API reference (api-reference/router-guard.md):
- Adds back()/forward()/go(delta) to the Methods list
- Adds the three methods to the NavigationDelegate abstract contract table
- Expands BrowserNavigationDelegate / MemoryNavigationDelegate descriptions to explain how each implements history traversal (window.history vs an in-memory history array + cursorIndex)
- Adds history/cursorIndex fields and the three methods to the MemoryNavigationDelegate TS reference block

Closes #1156