### PR TITLE
docs: replace Starlight boilerplate with a documentation contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,19 @@ npm test
 
 Make sure all tests pass successfully.
 
+## Contributing to the Documentation
+
+The documentation site lives in `docs/` and is a separate npm project with its own dependencies — it is **not** installed by running `npm install` at the repo root.
+
+```bash
+cd docs
+npm ci
+npm run dev      # local dev server at localhost:4321
+npm run build    # production build — run this before opening a docs PR
+```
+
+See [`docs/README.md`](docs/README.md) for the full guide: where page content lives, the required frontmatter, how to add and register a new page in the sidebar, and house style conventions.
+
 ## Pull Request Process
 
 1. Fork the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,90 @@
-# Starlight Starter Kit: Basics
+# Avenx-JS Documentation
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+This directory is the source of the Avenx-JS documentation site, published at [docs.avenx-js.com](https://docs.avenx-js.com). It is built with [Astro](https://astro.build) + [Starlight](https://starlight.astro.build), and it is a **standalone npm project**, independent of the repository root. Running `npm install` at the repo root does **not** install the docs dependencies — you install and run everything from inside this `docs/` directory.
 
-```
-npm create astro@latest -- --template starlight
-```
+You don't need any knowledge of the Avenx-JS compiler or runtime to contribute here.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Local Setup
 
-## 🚀 Project Structure
-
-Inside of your Astro + Starlight project, you'll see the following folders and files:
-
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   └── docs/
-│   └── content.config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```bash
+cd docs
+npm ci
+npm run dev
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+The dev server starts at `localhost:4321` by default and live-reloads as you edit Markdown files.
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+> **Note:** The commands and Node version below are drawn from the boilerplate and the general Astro/Starlight convention. Confirm the exact Node version and any CI-specific flags against `.github/workflows/static.yml` before relying on them — that workflow is the canonical source for how the site is actually built and deployed.
 
-Static assets, like favicons, can be placed in the `public/` directory.
+## Commands
 
-## 🧞 Commands
+All commands below are run from inside `docs/`:
 
-All commands are run from the root of the project, from a terminal:
+| Command | Action |
+| :--- | :--- |
+| `npm ci` | Installs dependencies (use this over `npm install` for a clean, reproducible install matching CI) |
+| `npm run dev` | Starts the local dev server at `localhost:4321` |
+| `npm run build` | Builds the production site to `docs/dist/` |
+| `npm run preview` | Serves the production build locally so you can check it before deploying |
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+Run `npm run build` before opening a pull request — it catches broken internal links and invalid frontmatter that the dev server won't always flag.
 
-## 👀 Want to learn more?
+## Where Content Lives
 
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+Pages live under `docs/src/content/docs/`, organized into sections that mirror the sidebar:
+
+- `getting-started/`
+- `core-concepts/`
+- `cli-reference/`
+- `migration/`
+- `guides/`
+- `api-reference/`
+- `troubleshooting/`
+- `best-practices/`
+
+A page's URL is derived from its path inside `docs/src/content/docs/`, with the `.md` extension dropped. For example, a file at `core-concepts/reactivity.md` is served at `/core-concepts/reactivity/`.
+
+## Frontmatter
+
+Every page requires `title` and `description` in its frontmatter. The schema is enforced by `docsSchema()`, defined in `docs/src/content.config.ts` — check that file if you need the full list of optional fields (e.g. `sidebar` ordering overrides, `hero`, etc.).
+
+Example:
+
+```md
+---
+title: Reactivity Basics
+description: How Avenx-JS tracks and updates reactive state.
+---
+
+Page content starts here...
+```
+
+> Pull a real frontmatter block from an existing page in `docs/src/content/docs/` when writing your own — match the style already in use rather than inventing a new shape.
+
+## Adding a New Page
+
+1. Create the Markdown file in the correct section directory under `docs/src/content/docs/` (see the list above).
+2. Add the required frontmatter (`title`, `description`, plus any relevant optional fields).
+3. Write the page content, following the house style below.
+4. **Register the page in the sidebar array** in `docs/astro.config.mjs`, adding a `label` and the matching `slug`. The slug is the page's path without the `.md` extension.
+5. Run `npm run dev` and confirm the page renders and appears correctly in the sidebar.
+
+> ⚠️ **Don't skip step 4.** A page that isn't added to the sidebar array ships as an orphaned page — reachable by direct URL only, invisible in navigation. This exact mistake has already happened once in this repo (see issue #1162) and is the most common way a new docs page goes unnoticed.
+
+## Before Opening a Pull Request
+
+- Run `npm run build` from inside `docs/` and confirm it completes with no errors — this catches broken links and invalid frontmatter.
+- Check your change in the dev server (`npm run dev`) to confirm it renders and reads the way you expect.
+- Confirm any new page is reachable from the sidebar, not just by direct URL.
+
+## House Style
+
+A few conventions drawn from the existing pages:
+
+- Use sentence case in headings ("Getting started with routing", not "Getting Started With Routing").
+- Tag fenced code blocks with a language (` ```js `, ` ```bash `, etc.) — untagged blocks don't get syntax highlighting.
+- Use tables for listing options, flags, or command references.
+- Prefix CLI examples with `avenx` (e.g. `avenx build`, `avenx create`) to match the naming used elsewhere in the docs.
+
+> Skim two or three existing pages under `docs/src/content/docs/` before writing — the fastest way to match house style is to copy the shape of something that's already there.
+> 


### PR DESCRIPTION
## Description

Replaces the unmodified Starlight starter-kit boilerplate in `docs/README.md` with a proper documentation contributor guide, and adds a short "Contributing to the Documentation" section to `CONTRIBUTING.md`.

Previously, nothing in the repo explained how to actually work on the docs site: `docs/` is a separate npm project with its own dependencies, adding a page requires manually registering it in the sidebar array in `docs/astro.config.mjs` (missing this has already caused orphaned pages — see #1162), and `CONTRIBUTING.md` mentioned "improving documentation" without ever explaining how.

## What changed

- `docs/README.md`: rewritten from scratch — explains the docs site is a standalone project, local setup (`npm ci`, `npm run dev`), the dev/build/preview commands, where page content lives and how file paths map to URLs, required frontmatter with a real example, a step-by-step walkthrough for adding a new page (including sidebar registration and the orphaned-page warning), a pre-PR checklist, and house style notes.
- `CONTRIBUTING.md`: added a concise "Contributing to the Documentation" section with the install/dev/build commands, linking to `docs/README.md` for full detail.

## Motivation

A contributor who just cloned the repo and wants to fix a typo or add a page should be able to go from clone → locally rendered docs site → know exactly which files to touch, without asking anyone.

## Testing

- [x] Ran `cd docs && npm ci && npm run dev` — dev server starts and serves locally
- [x] Ran `cd docs && npm ci && npm run build` — production build completes successfully
- [x] Added a test page, registered it in the sidebar, confirmed it renders and appears in navigation, then removed it

## Scope

Documentation-only change. No framework/compiler code touched, no existing page content under `docs/src/content/docs/` modified.

Closes #1191