### PR TITLE
feat: add declarative state persistence

### DIFF
--- a/lib/core/reactive/createState.js
+++ b/lib/core/reactive/createState.js
@@ -24,11 +24,36 @@ export class StateFactory {
     if (initialState && initialState[IS_REACTIVE_PROXY]) {
       return initialState;
     }
+
     if (initialState && initialState[PROXY_REF_SYMBOL]) {
       return initialState[PROXY_REF_SYMBOL];
     }
+
+    const persistKeys = new Set(options.persist || []);
+
+    if (
+      persistKeys.size > 0 &&
+      typeof localStorage !== 'undefined' &&
+      initialState &&
+      typeof initialState === 'object'
+    ) {
+      for (const key of persistKeys) {
+        try {
+          const storedValue = localStorage.getItem(key);
+
+          if (storedValue !== null) {
+            initialState[key] = JSON.parse(storedValue);
+          }
+        } catch {
+          // Ignore corrupted or unavailable persisted values.
+          // The original initial state will be used instead.
+        }
+      }
+    }
+
     const handlerFactory = new this.handlerFactoryClass(options);
     const proxy = new Proxy(initialState, handlerFactory.create());
+
     if (Object.isExtensible(initialState)) {
       Object.defineProperty(initialState, PROXY_REF_SYMBOL, {
         value: proxy,
@@ -37,6 +62,7 @@ export class StateFactory {
         configurable: false,
       });
     }
+
     return proxy;
   }
 }

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -161,43 +161,46 @@ export class ProxyHandlerFactory {
    * @param {Function} [options.getComputedValue] - Function to evaluate a computed property.
    * @param {object} [options.instance] - The component instance for fallback property lookups.
    * @param {boolean} [options.bypassSymbol] - Bypasses Symbol check during lookup.
+   * @param {string[]} [options.persist] - List of state keys to persist in localStorage.
    */
   constructor({
-  computedKeys = [],
-  onChange = () => {},
-  getComputedValue = () => undefined,
-  instance = null,
-  bypassSymbol = false,
-  persist = [],
-} = {}) {
-  /** @type {Set<string>} */
-  this.computedKeys = new Set(computedKeys);
-  /** @type {Function} */
-  this.onChange = onChange;
-  /** @type {Function} */
-  this.getComputedValueReal = getComputedValue;
-  /** @type {Set<string>} */
-  this.persistKeys = new Set(persist);
-  /** @type {WeakMap<object, Proxy>} */
-  this.proxyCache = new WeakMap();
-  /** @type {Map<string, AvenxWatcher>} */
-  this.computedWatchers = new Map();
-  /** @type {object|null} */
-  this.instance = instance;
-  /** @type {boolean} */
-  this.bypassSymbol =
-    bypassSymbol ||
-    (typeof globalThis !== 'undefined' &&
-      !!globalThis.__avenx_bypass_symbol__);
-  /** @type {object|null} */
-  this.rootTarget = null;
-}
+    computedKeys = [],
+    onChange = () => {},
+    getComputedValue = () => undefined,
+    instance = null,
+    bypassSymbol = false,
+    persist = [],
+  } = {}) {
+    /** @type {Set<string>} */
+    this.computedKeys = new Set(computedKeys);
+    /** @type {Function} */
+    this.onChange = onChange;
+    /** @type {Function} */
+    this.getComputedValueReal = getComputedValue;
+    /** @type {Set<string>} */
+    this.persistKeys = new Set(persist);
+    /** @type {WeakMap<object, Proxy>} */
+    this.proxyCache = new WeakMap();
+    /** @type {Map<string, AvenxWatcher>} */
+    this.computedWatchers = new Map();
+    /** @type {object|null} */
+    this.instance = instance;
+    /** @type {boolean} */
+    this.bypassSymbol =
+      bypassSymbol ||
+      (typeof globalThis !== 'undefined' &&
+        !!globalThis.__avenx_bypass_symbol__);
+    /** @type {object|null} */
+    this.rootTarget = null;
+  }
+
   /**
    * Evaluates and caches a computed property using an internal AvenxWatcher.
    * @param {string} key - The computed key.
    * @param {object} receiver - The proxy receiver.
    * @returns {any}
    */
+  
   evaluateComputedWatcher(key, receiver) {
     const target = receiver[RAW_SYMBOL] || receiver;
     track(target, key);
@@ -692,83 +695,77 @@ export class ProxyHandlerFactory {
    * @param {any} value - The new value.
    * @returns {boolean}
    */
- set(target, key, value) {
-  if (value && value[RAW_SYMBOL]) {
-    value = value[RAW_SYMBOL];
-  }
-
-  const oldValue = target[key];
-  const changed =
-    typeof key !== 'symbol' &&
-    (oldValue !== value || (Array.isArray(target) && key === 'length'));
-
-  // Journaled before the assignment, because whether the key already existed
-  // is the difference between restoring a value and deleting one, and that
-  // cannot be told apart once the write has landed.
-  if (changed && journal.active) {
-    if (Array.isArray(target) && key === 'length') {
-      // `arr.length = 0` discards elements that no single before/after pair
-      // describes, so the whole array is saved instead.
-      journal.recordCollection(target, this, 'array');
-    } else {
-      journal.recordWrite(
-        target,
-        key,
-        oldValue,
-        value,
-        Object.prototype.hasOwnProperty.call(target, key),
-        this
-      );
+  set(target, key, value) {
+    if (value && value[RAW_SYMBOL]) {
+      value = value[RAW_SYMBOL];
     }
-  }
 
-  if (isReactiveTarget(oldValue)) {
-    cleanupParentMap(oldValue);
-  }
+    const oldValue = target[key];
+    const changed =
+      typeof key !== 'symbol' &&
+      (oldValue !== value || (Array.isArray(target) && key === 'length'));
 
-  target[key] = value;
-
-  if (isReactiveTarget(value)) {
-    parentMap.set(value, { parentTarget: target, parentKey: key });
-  }
-
-  // Persist configured root-level state values to localStorage.
-  if (
-    changed &&
-    typeof key !== 'symbol' &&
-    target === this.rootTarget &&
-    this.persistKeys.has(key) &&
-    typeof localStorage !== 'undefined'
-  ) {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Ignore storage and serialization errors so persistence
-      // never breaks normal reactive state updates.
-    }
-  }
-
-  if (changed) {
-    // A write is recorded here rather than inside trigger(): trigger walks up
-    // the parentMap re-firing itself for every ancestor, so recording there
-    // would log one write per level of nesting for a single assignment.
-    // Opening the node around the trigger call makes every watcher it wakes a
-    // child of the write that woke it.
-    const token = tracer.on ? traceWrite(target, key, oldValue, value) : -1;
-
-    try {
-      trigger(target, key, oldValue, value);
-      this.notifyChange(target);
-    } finally {
-      if (token >= 0) {
-        tracer.leave(token);
+    // Journaled before the assignment, because whether the key already existed
+    // is the difference between restoring a value and deleting one, and that
+    // cannot be told apart once the write has landed.
+    if (changed && journal.active) {
+      if (Array.isArray(target) && key === 'length') {
+        // `arr.length = 0` discards elements that no single before/after pair
+        // describes, so the whole array is saved instead.
+        journal.recordCollection(target, this, 'array');
+      } else {
+        journal.recordWrite(
+          target,
+          key,
+          oldValue,
+          value,
+          Object.prototype.hasOwnProperty.call(target, key),
+          this
+        );
       }
     }
+
+    if (isReactiveTarget(oldValue)) {
+      cleanupParentMap(oldValue);
+    }
+
+    target[key] = value;
+
+    if (isReactiveTarget(value)) {
+      parentMap.set(value, { parentTarget: target, parentKey: key });
+    }
+
+    // Persist configured root-level state values to localStorage.
+    if (
+      changed &&
+      typeof key !== 'symbol' &&
+      target === this.rootTarget &&
+      this.persistKeys.has(key) &&
+      typeof localStorage !== 'undefined'
+    ) {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+        // Ignore storage and serialization errors so persistence
+        // never breaks normal reactive state updates.
+      }
+    }
+
+    if (changed) {
+      const token = tracer.on ? traceWrite(target, key, oldValue, value) : -1;
+
+      try {
+        trigger(target, key, oldValue, value);
+        this.notifyChange(target);
+      } finally {
+        if (token >= 0) {
+          tracer.leave(token);
+        }
+      }
+    }
+
+    return true;
   }
-
-  return true;
-}
-
   /**
    * Proxy 'get' trap.
    * Redirects to evaluateComputedWatcher if the key is a computed property.

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -163,30 +163,35 @@ export class ProxyHandlerFactory {
    * @param {boolean} [options.bypassSymbol] - Bypasses Symbol check during lookup.
    */
   constructor({
-    computedKeys = [],
-    onChange = () => {},
-    getComputedValue = () => undefined,
-    instance = null,
-    bypassSymbol = false,
-  } = {}) {
-    /** @type {Set<string>} */
-    this.computedKeys = new Set(computedKeys);
-    /** @type {Function} */
-    this.onChange = onChange;
-    /** @type {Function} */
-    this.getComputedValueReal = getComputedValue;
-    /** @type {WeakMap<object, Proxy>} */
-    this.proxyCache = new WeakMap();
-    /** @type {Map<string, AvenxWatcher>} */
-    this.computedWatchers = new Map();
-    /** @type {object|null} */
-    this.instance = instance;
-    /** @type {boolean} */
-    this.bypassSymbol = bypassSymbol || (typeof globalThis !== 'undefined' && !!globalThis.__avenx_bypass_symbol__);
-    /** @type {object|null} */
-    this.rootTarget = null;
-  }
-
+  computedKeys = [],
+  onChange = () => {},
+  getComputedValue = () => undefined,
+  instance = null,
+  bypassSymbol = false,
+  persist = [],
+} = {}) {
+  /** @type {Set<string>} */
+  this.computedKeys = new Set(computedKeys);
+  /** @type {Function} */
+  this.onChange = onChange;
+  /** @type {Function} */
+  this.getComputedValueReal = getComputedValue;
+  /** @type {Set<string>} */
+  this.persistKeys = new Set(persist);
+  /** @type {WeakMap<object, Proxy>} */
+  this.proxyCache = new WeakMap();
+  /** @type {Map<string, AvenxWatcher>} */
+  this.computedWatchers = new Map();
+  /** @type {object|null} */
+  this.instance = instance;
+  /** @type {boolean} */
+  this.bypassSymbol =
+    bypassSymbol ||
+    (typeof globalThis !== 'undefined' &&
+      !!globalThis.__avenx_bypass_symbol__);
+  /** @type {object|null} */
+  this.rootTarget = null;
+}
   /**
    * Evaluates and caches a computed property using an internal AvenxWatcher.
    * @param {string} key - The computed key.
@@ -687,53 +692,82 @@ export class ProxyHandlerFactory {
    * @param {any} value - The new value.
    * @returns {boolean}
    */
-  set(target, key, value) {
-    if (value && value[RAW_SYMBOL]) {
-      value = value[RAW_SYMBOL];
-    }
-    const oldValue = target[key];
-    const changed = typeof key !== 'symbol' && (oldValue !== value || (Array.isArray(target) && key === 'length'));
-
-    // Journaled before the assignment, because whether the key already existed
-    // is the difference between restoring a value and deleting one, and that
-    // cannot be told apart once the write has landed.
-    if (changed && journal.active) {
-      if (Array.isArray(target) && key === 'length') {
-        // `arr.length = 0` discards elements that no single before/after pair
-        // describes, so the whole array is saved instead.
-        journal.recordCollection(target, this, 'array');
-      } else {
-        journal.recordWrite(target, key, oldValue, value, Object.prototype.hasOwnProperty.call(target, key), this);
-      }
-    }
-
-    if (isReactiveTarget(oldValue)) {
-      cleanupParentMap(oldValue);
-    }
-    target[key] = value;
-
-    if (isReactiveTarget(value)) {
-      parentMap.set(value, { parentTarget: target, parentKey: key });
-    }
-
-    if (changed) {
-      // A write is recorded here rather than inside trigger(): trigger walks up
-      // the parentMap re-firing itself for every ancestor, so recording there
-      // would log one write per level of nesting for a single assignment.
-      // Opening the node around the trigger call makes every watcher it wakes a
-      // child of the write that woke it.
-      const token = tracer.on ? traceWrite(target, key, oldValue, value) : -1;
-      try {
-        trigger(target, key, oldValue, value);
-        this.notifyChange(target);
-      } finally {
-        if (token >= 0) {
-          tracer.leave(token);
-        }
-      }
-    }
-    return true;
+ set(target, key, value) {
+  if (value && value[RAW_SYMBOL]) {
+    value = value[RAW_SYMBOL];
   }
+
+  const oldValue = target[key];
+  const changed =
+    typeof key !== 'symbol' &&
+    (oldValue !== value || (Array.isArray(target) && key === 'length'));
+
+  // Journaled before the assignment, because whether the key already existed
+  // is the difference between restoring a value and deleting one, and that
+  // cannot be told apart once the write has landed.
+  if (changed && journal.active) {
+    if (Array.isArray(target) && key === 'length') {
+      // `arr.length = 0` discards elements that no single before/after pair
+      // describes, so the whole array is saved instead.
+      journal.recordCollection(target, this, 'array');
+    } else {
+      journal.recordWrite(
+        target,
+        key,
+        oldValue,
+        value,
+        Object.prototype.hasOwnProperty.call(target, key),
+        this
+      );
+    }
+  }
+
+  if (isReactiveTarget(oldValue)) {
+    cleanupParentMap(oldValue);
+  }
+
+  target[key] = value;
+
+  if (isReactiveTarget(value)) {
+    parentMap.set(value, { parentTarget: target, parentKey: key });
+  }
+
+  // Persist configured root-level state values to localStorage.
+  if (
+    changed &&
+    typeof key !== 'symbol' &&
+    target === this.rootTarget &&
+    this.persistKeys.has(key) &&
+    typeof localStorage !== 'undefined'
+  ) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Ignore storage and serialization errors so persistence
+      // never breaks normal reactive state updates.
+    }
+  }
+
+  if (changed) {
+    // A write is recorded here rather than inside trigger(): trigger walks up
+    // the parentMap re-firing itself for every ancestor, so recording there
+    // would log one write per level of nesting for a single assignment.
+    // Opening the node around the trigger call makes every watcher it wakes a
+    // child of the write that woke it.
+    const token = tracer.on ? traceWrite(target, key, oldValue, value) : -1;
+
+    try {
+      trigger(target, key, oldValue, value);
+      this.notifyChange(target);
+    } finally {
+      if (token >= 0) {
+        tracer.leave(token);
+      }
+    }
+  }
+
+  return true;
+}
 
   /**
    * Proxy 'get' trap.

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -193,14 +193,13 @@ export class ProxyHandlerFactory {
     /** @type {object|null} */
     this.rootTarget = null;
   }
-
-    /**
+  
+  /**
    * Evaluates and caches a computed property using an internal AvenxWatcher.
    * @param {string} key - The computed key.
    * @param {object} receiver - The proxy receiver.
    * @returns {any}
    */
-
   evaluateComputedWatcher(key, receiver) {
     const target = receiver[RAW_SYMBOL] || receiver;
     track(target, key);
@@ -219,7 +218,7 @@ export class ProxyHandlerFactory {
     }
     return watcher.evaluate();
   }
-
+  
   /**
    * Cleans up all computed watchers created by this proxy handler.
    */

--- a/lib/core/reactive/proxyHandler.js
+++ b/lib/core/reactive/proxyHandler.js
@@ -194,13 +194,13 @@ export class ProxyHandlerFactory {
     this.rootTarget = null;
   }
 
-  /**
+    /**
    * Evaluates and caches a computed property using an internal AvenxWatcher.
    * @param {string} key - The computed key.
    * @param {object} receiver - The proxy receiver.
    * @returns {any}
    */
-  
+
   evaluateComputedWatcher(key, receiver) {
     const target = receiver[RAW_SYMBOL] || receiver;
     track(target, key);

--- a/test/unit/reactivity.test.js
+++ b/test/unit/reactivity.test.js
@@ -744,8 +744,8 @@ function testCorruptedPersistedState() {
     testReactivityEncapsulation();
     testParentMapMemoryLeak();
     testStatePersistenceInitialization();
-testStatePersistenceMutation();
-testCorruptedPersistedState();
+    testStatePersistenceMutation();
+    testCorruptedPersistedState();
     console.log('✅ All reactivity tests passed!');
   } catch (error) {
     console.error('❌ Reactivity tests failed!');

--- a/test/unit/reactivity.test.js
+++ b/test/unit/reactivity.test.js
@@ -10,6 +10,7 @@ const mockElement = {
 global.document = {
   querySelector: () => mockElement,
 };
+global.localStorage = global.window.localStorage;
 
 import { isReactiveTarget, RAW_SYMBOL } from '../../lib/core/reactive/proxyHandler.js';
 import { StateFactory } from '../../lib/core/reactive/createState.js';
@@ -646,6 +647,88 @@ function testParentMapMemoryLeak() {
   console.log('  ✅ parentMap memory leak and side effect prevention tests passed!');
 }
 
+/**
+ * Verifies that configured state values are restored from localStorage.
+ */
+function testStatePersistenceInitialization() {
+  console.log('🧪 Testing persisted state initialization...');
+
+  localStorage.clear();
+  localStorage.setItem('count', JSON.stringify(42));
+
+  const state = new StateFactory().create(
+    {
+      count: 0,
+      name: 'Avenx',
+    },
+    {
+      persist: ['count'],
+    },
+  );
+
+  assert.strictEqual(state.count, 42);
+  assert.strictEqual(state.name, 'Avenx');
+
+  localStorage.clear();
+
+  console.log('  ✅ Persisted state initialization test passed!');
+}
+
+/**
+ * Verifies that configured state values are written to localStorage on mutation.
+ */
+function testStatePersistenceMutation() {
+  console.log('🧪 Testing persisted state mutation...');
+
+  localStorage.clear();
+
+  const state = new StateFactory().create(
+    {
+      count: 0,
+    },
+    {
+      persist: ['count'],
+    },
+  );
+
+  state.count = 5;
+
+  assert.strictEqual(localStorage.getItem('count'), JSON.stringify(5));
+
+  state.count = 10;
+
+  assert.strictEqual(localStorage.getItem('count'), JSON.stringify(10));
+
+  localStorage.clear();
+
+  console.log('  ✅ Persisted state mutation test passed!');
+}
+
+/**
+ * Verifies that corrupted persisted JSON is ignored gracefully.
+ */
+function testCorruptedPersistedState() {
+  console.log('🧪 Testing corrupted persisted state handling...');
+
+  localStorage.clear();
+  localStorage.setItem('count', '{invalid-json');
+
+  const state = new StateFactory().create(
+    {
+      count: 7,
+    },
+    {
+      persist: ['count'],
+    },
+  );
+
+  assert.strictEqual(state.count, 7);
+
+  localStorage.clear();
+
+  console.log('  ✅ Corrupted persisted state test passed!');
+}
+
 (async () => {
   try {
     testIsReactiveTarget();
@@ -660,6 +743,9 @@ function testParentMapMemoryLeak() {
     testMapAndSetReactivity();
     testReactivityEncapsulation();
     testParentMapMemoryLeak();
+    testStatePersistenceInitialization();
+testStatePersistenceMutation();
+testCorruptedPersistedState();
     console.log('✅ All reactivity tests passed!');
   } catch (error) {
     console.error('❌ Reactivity tests failed!');


### PR DESCRIPTION
## Description

Implements declarative state persistence for configured reactive state values.

## Changes

- Added `persist` configuration to reactive state.
- Restores persisted values from `localStorage` during state initialization.
- Automatically saves configured state updates to `localStorage`.
- Handles corrupted or unavailable persisted JSON gracefully.
- Added unit tests for initialization, mutation, and corrupted persisted state.

## Related Issue

Closes #136