### PR TITLE
feat(cli): verify -f shorthand flag and document --force option (#934)

### DIFF
--- a/bin/commands/help.js
+++ b/bin/commands/help.js
@@ -41,6 +41,7 @@ ${bold(cyan('Options:'))}
   ${green('--dev')}                     ${gray('Build for development: readable runtime, inline CSS source maps')}
   ${green('--prod')}                    ${gray('Build for production (the default for "build")')}
   ${green('--dry-run, -d')}             ${gray('Preview actions without writing or deleting any files')}
+  ${green('--force, -f')}               ${gray('Force overwrite existing files during scaffold generation')}
   ${green('--with-test')}               ${gray('Generate a colocated unit test file alongside the component')}
   ${green('--no-test')}                 ${gray('Skip generating unit test files')}
   ${green('--template, -t <name>')}     ${gray('Use a custom scaffold template for code generation')}

--- a/test/system/cli.test.js
+++ b/test/system/cli.test.js
@@ -287,6 +287,7 @@ async function runTest() {
       'utf-8',
     );
 
+
     assert.ok(
       forcedDefaultBoxJs.includes('DefaultBox Component'),
       'Force generation should overwrite the modified component',
@@ -348,6 +349,43 @@ async function runTest() {
     );
 
     console.log('✅ Page --force test passed!');
+
+    console.log('🧪 Testing avenx generate component -f (shorthand)...');
+
+    fs.writeFileSync(
+      defaultBoxJsPath,
+      '// MODIFIED BY SHORT FLAG TEST',
+    );
+
+    const shortForceResult = runCli([
+      'generate',
+      'component',
+      'default-box',
+      '-f',
+    ]);
+
+    assert.strictEqual(shortForceResult.status, 0, 'Short flag -f component generation should succeed');
+    assert.match(
+      shortForceResult.stderr,
+      /Force enabled: overwriting existing Component 'default-box'/,
+      'Short flag -f generation should warn before overwriting the existing component',
+    );
+
+    const shortForcedJs = fs.readFileSync(
+      defaultBoxJsPath,
+      'utf-8',
+    );
+
+    assert.ok(
+      shortForcedJs.includes('DefaultBox Component'),
+      'Short flag -f generation should overwrite the modified component',
+    );
+    assert.ok(
+      !shortForcedJs.includes('// MODIFIED BY SHORT FLAG TEST'),
+      'Short flag -f generation should remove the modified component content',
+    );
+
+    console.log('✅ Component -f test passed!');
 
     console.log('🧪 Testing avenx generate bridge --force...');
 


### PR DESCRIPTION
### Description
Resolves #934 by adding verification for the `-f` shorthand flag in the CLI system test suite and documenting the `--force, -f` option in the CLI help command.

### Changes
- Added system CLI test case in `test/system/cli.test.js` to ensure the `-f` shorthand properly triggers overwrite logic and logs the warning.
- Updated `bin/commands/help.js` to include `--force, -f` under the available options output.

### Closes
Closes #934