### PR TITLE
fix(diagnostics): point catalogue docsUrl at the real documentation origin

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -18,7 +18,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Check template markup for balanced tags.',
       'Ensure directives use valid syntax (e.g., <@for ...>).'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c01'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c01-compiler-dist-creation-failed'
   },
   AVX_C02: {
     code: 'AVX_C02',
@@ -32,7 +32,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Rename or merge duplicate action definitions.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c02'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#src-directory-missing'
   },
   AVX_C03: {
     code: 'AVX_C03',
@@ -46,7 +46,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Declare the missing state variable in <state varName="..." />.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c03'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#component-name-conflict'
   },
   AVX_C04: {
     code: 'AVX_C04',
@@ -60,7 +60,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Check the directive reference documentation for allowable parent-child relationships.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c04'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c04-static-contract-violation'
   },
   AVX_C05: {
     code: 'AVX_C05',
@@ -74,7 +74,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Wrap root template content inside a single container element or fragment.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c05'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c05-isolated-contract-violation'
   },
   AVX_C06: {
     code: 'AVX_C06',
@@ -88,7 +88,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Ensure interpolation contains valid JavaScript expressions.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-c06'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c06-invalid-contract-declaration'
   },
 
   // Runtime Diagnostics (AVX_R01 - AVX_R18)
@@ -104,7 +104,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Ensure the selector exists in index.html before mounting or call after DOMContentLoaded.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r01'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r01-mount-target-not-found'
   },
   AVX_R08: {
     code: 'AVX_R08',
@@ -118,7 +118,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Use optional chaining or default values for nullable reactive properties.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r08'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#template-interpolation-failure'
   },
   AVX_R18: {
     code: 'AVX_R18',
@@ -132,7 +132,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Break recursive mutations or add termination conditions to reactive watchers.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r18'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r18-reactive-deadlock-detected'
   },
 
   // Warning Diagnostics (AVX_W01 - AVX_W35)
@@ -148,7 +148,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Remove unused state declarations to reduce memory footprint.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-w01'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w01-compiler-bundle-size-exceeded'
   },
   AVX_W29: {
     code: 'AVX_W29',
@@ -162,7 +162,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Add a unique @key attribute to the root repeated item (e.g., @key="item.id").'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-w29'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w29-compiler-circular-dependency'
   },
   AVX_W35: {
     code: 'AVX_W35',
@@ -176,7 +176,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Migrate to updated lifecycle hooks as specified in the migration guide.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-w35'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w35-compiler-deadlock-parse-failed'
   },
 
   // Atlas diagnostics (AVX_W40 - AVX_W41)
@@ -197,7 +197,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Add the missing read if the warning has caught a half-finished change.',
       'Silence it for one project with `"warnings": { "AVX_W40": "off" }` in avenx.config.json.'
     ],
-    docsUrl: 'https://avenx.dev/docs/core-concepts/atlas#unread-state'
+    docsUrl: 'https://avenx-js.com/core-concepts/atlas#avx-w40-unread-state'
   },
   AVX_W41: {
     code: 'AVX_W41',
@@ -216,7 +216,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Delete the action if it really is unreachable.',
       'Lifecycle actions the runtime calls by name (onMount, onUnmount, and the rest) are already exempt; if yours is invoked another way, silence the code with `"warnings": { "AVX_W41": "off" }`.'
     ],
-    docsUrl: 'https://avenx.dev/docs/core-concepts/atlas#unreachable-action'
+    docsUrl: 'https://avenx-js.com/core-concepts/atlas#avx-w41-unreachable-action'
   },
 
   // Rewind diagnostics (AVX_W42 - AVX_W44, AVX_R29)
@@ -237,7 +237,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Run `avenx why <owner>.<action>` to see which relationships Atlas did resolve.',
       'Silence it for one project with `"warnings": { "AVX_W42": "off" }` in avenx.config.json.'
     ],
-    docsUrl: 'https://avenx.dev/docs/core-concepts/rewind#unbounded'
+    docsUrl: 'https://avenx-js.com/core-concepts/rewind#avx-w42-the-write-set-is-incomplete'
   },
   AVX_W43: {
     code: 'AVX_W43',
@@ -255,7 +255,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Accept it: state is still restored, and the listed effects are what a rewind will leave behind.',
       'Silence it for one project with `"warnings": { "AVX_W43": "off" }` in avenx.config.json.'
     ],
-    docsUrl: 'https://avenx.dev/docs/core-concepts/rewind#irreversible'
+    docsUrl: 'https://avenx-js.com/core-concepts/rewind#avx-w43-an-effect-a-rewind-cannot-undo'
   },
   AVX_W44: {
     code: 'AVX_W44',
@@ -273,7 +273,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Set onConflict="force" on the action when the transaction really is the authority on that value.',
       'Silence it for one project with `"warnings": { "AVX_W44": "off" }` in avenx.config.json.'
     ],
-    docsUrl: 'https://avenx.dev/docs/core-concepts/rewind#overlap'
+    docsUrl: 'https://avenx-js.com/core-concepts/rewind#avx-w44-two-transactions-writing-the-same-state'
   },
   AVX_R29: {
     code: 'AVX_R29',
@@ -292,7 +292,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Raise `rewind.maxSnapshotItems` in avenx.config.json if a large collection was the reason.',
       'Set onConflict="force" on the action if this transaction should win regardless.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r29'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r29-transaction-rewind-failed'
   },
 
   // Trace diagnostics (AVX_R25 - AVX_R28)
@@ -310,7 +310,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Upgrade avenx-core to a version that understands this trace format version.',
       'Re-record the session with `avenx serve --trace`.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r25'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r25-traceunreadable'
   },
   AVX_R26: {
     code: 'AVX_R26',
@@ -327,7 +327,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'Remove the source of non-determinism — move timer-driven state changes into an action, or drop pollInterval — and record again.',
       'Pass { allowBestEffort: true } to replay() to run it anyway; the result reports what diverged instead of claiming a pass.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r26'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r26-tracenotdeterministic'
   },
   AVX_R27: {
     code: 'AVX_R27',
@@ -345,7 +345,7 @@ export const DIAGNOSTIC_CATALOGUE = {
       'If the change was intended, re-record the trace and re-export the test.',
       'If it was not, the divergence is the bug the trace was meant to catch.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r27'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r27-tracereplaydiverged'
   },
   AVX_R28: {
     code: 'AVX_R28',
@@ -359,7 +359,7 @@ export const DIAGNOSTIC_CATALOGUE = {
     remedies: [
       'Pass a mount() function that constructs and mounts the application, and returns the context your assertions need.'
     ],
-    docsUrl: 'https://avenx.dev/docs/troubleshooting#avx-r28'
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-r28-tracereplayfailed'
   },
 };
 

--- a/test/unit/diagnosticCatalogueOrigin.test.js
+++ b/test/unit/diagnosticCatalogueOrigin.test.js
@@ -1,0 +1,44 @@
+/**
+ * Every docsUrl in DIAGNOSTIC_CATALOGUE must point at the project's real
+ * documentation origin, so that `avenx explain <code>` always prints a link
+ * that resolves.
+ *
+ * This is a string check — it does not open the URLs — and it is the regression
+ * net for the drift that would otherwise silently route every code to a dead
+ * host (e.g. `avenx.dev`) on the next catalogue rewrite.
+ */
+import assert from 'assert';
+import { DIAGNOSTIC_CATALOGUE } from '../../lib/core/diagnostics/catalogue.js';
+
+console.log('🧪 Testing diagnostic catalogue docsUrl origin...');
+
+const EXPECTED_ORIGIN = 'https://avenx-js.com/';
+
+try {
+  const codes = Object.keys(DIAGNOSTIC_CATALOGUE).sort();
+
+  for (const code of codes) {
+    const entry = DIAGNOSTIC_CATALOGUE[code];
+    assert.ok(entry, `${code} is present in the catalogue`);
+    assert.ok('docsUrl' in entry, `${code} carries a docsUrl`);
+
+    const url = entry.docsUrl;
+
+    assert.ok(
+      typeof url === 'string' && url.startsWith(EXPECTED_ORIGIN),
+      `${code}: docsUrl "${url}" does not start with "${EXPECTED_ORIGIN}"` +
+      ' — the catalogue points at the wrong host or path.'
+    );
+
+    assert.ok(
+      /^[a-z][a-z0-9+.-]*:\/\//i.test(url),
+      `${code}: docsUrl "${url}" is not a well-formed absolute URL`
+    );
+  }
+
+  console.log(`  ✅ all ${codes.length} catalogue entries point at the project documentation origin`);
+} catch (error) {
+  console.error('❌ diagnostic catalogue docsUrl origin tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

All 22 `docsUrl` entries in `DIAGNOSTIC_CATALOGUE` pointed at `https://avenx.dev`, which is not the project's documentation host and does not resolve. `avenx explain <code>` prints dead links, which defeats the one part of the output that is meant to take a user from "I have a code" to "I understand the code."

This commit rewrites every `docsUrl` to use `https://avenx-js.com` (the host declared in `package.json` `homepage`) and to point at the page that actually exists under `docs/src/content/docs/`, with an anchor matching the heading slug for that code where one exists:

- troubleshooting codes → `/troubleshooting/errors#<heading-slug>`
- AVX_W40/W41 (Atlas)   → `/core-concepts/atlas#<heading-slug>`
- AVX_W42-W44 (Rewind)  → `/core-concepts/rewind#<heading-slug>`
- AVX_C02, AVX_C03, AVX_R08 (no `### ` heading in errors.md) → anchor is the slug of the documented description, as specified in the issue

A unit test in `test/unit/diagnosticCatalogueOrigin.test.js` asserts that every `docsUrl` starts with the expected origin, so the same drift cannot happen silently on a future catalogue rewrite.

## Test plan

- [x] `test/unit/diagnosticCatalogueOrigin.test.js` — all 22 catalogue entries start with `https://avenx-js.com/`; passes alongside the existing 156 unit tests
- [x] `npm test` (unit suite) — 156/156 pass

## Manual verification

- `npx avenx explain AVX_W29` prints a link to `https://avenx-js.com/troubleshooting/errors#avx-w29-compiler-circular-dependency`
- `npx avenx explain AVX_W42` prints a link to `https://avenx-js.com/core-concepts/rewind#avx-w42-the-write-set-is-incomplete`
- `npx avenx explain AVX_C01` prints a link to `https://avenx-js.com/troubleshooting/errors#avx-c01-compiler-dist-creation-failed`

## Issue

Fixes #1257

    .-------.
    | | | | |
    '-------'
        |
       ( )     ShadowSpatula
