### PR TITLE
fix(diagnostics): align AVX_C01-C06 catalogue with AvenxErrorCodes

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -6,87 +6,89 @@ export const DIAGNOSTIC_CATALOGUE = {
   // Compiler Diagnostics (AVX_C01 - AVX_C06)
   AVX_C01: {
     code: 'AVX_C01',
-    name: 'InvalidTemplateSyntax',
+    name: 'CompilerDistCreationFailed',
     severity: 'error',
     category: 'compiler',
-    summary: 'The component template contains invalid syntax or unclosed tags.',
+    summary: 'The compiler could not create the build output (dist) directory.',
     causes: [
-      'A tag was opened but not properly closed.',
-      'Malformed directive attributes or expression syntax.'
+      'The process lacks write permission for the configured dist path.',
+      'A non-directory file already exists at the dist location.'
     ],
     remedies: [
-      'Check template markup for balanced tags.',
-      'Ensure directives use valid syntax (e.g., <@for ...>).'
+      'Ensure the project directory is writable by the build process.',
+      'Remove or rename any file blocking the dist path, then rebuild.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c01-compiler-dist-creation-failed'
   },
   AVX_C02: {
     code: 'AVX_C02',
-    name: 'DuplicateActionDefinition',
+    name: 'CompilerSrcDirMissing',
     severity: 'error',
     category: 'compiler',
-    summary: 'An action name was defined more than once within the same component.',
+    summary: 'The project source directory (src) does not exist.',
     causes: [
-      'Two <action name="..."> blocks share the same name identifier.'
+      'avenx build or avenx check was run outside a scaffolded project.',
+      'srcDir in avenx.config.json points at a missing folder.'
     ],
     remedies: [
-      'Rename or merge duplicate action definitions.'
+      'Run avenx init to create a project skeleton.',
+      'Create the configured source directory or correct srcDir.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#src-directory-missing'
   },
   AVX_C03: {
     code: 'AVX_C03',
-    name: 'UndefinedStateReference',
+    name: 'CompilerDuplicateComponentName',
     severity: 'error',
     category: 'compiler',
-    summary: 'A state variable referenced in the template or action is not declared.',
+    summary: 'Two or more component files compile to the same class name.',
     causes: [
-      'Referencing a variable not defined in <state /> declarations.'
+      'Component class names are derived from file names, so identically named files collide when bundled.'
     ],
     remedies: [
-      'Declare the missing state variable in <state varName="..." />.'
+      'Rename or move one of the conflicting files so each produces a distinct class name.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#component-name-conflict'
   },
   AVX_C04: {
     code: 'AVX_C04',
-    name: 'InvalidDirectiveUsage',
+    name: 'CompilerContractStaticViolation',
     severity: 'error',
     category: 'compiler',
-    summary: 'A framework directive is used in an invalid context.',
+    summary: 'A node or component marked with the static contract contains dynamic content.',
     causes: [
-      'Placing directives where they cannot be evaluated or nesting incompatible directives.'
+      'Interpolations, bindings, or other dynamic expressions appear under a static contract.'
     ],
     remedies: [
-      'Check the directive reference documentation for allowable parent-child relationships.'
+      'Remove the dynamic expression, or drop the static contract from that subtree.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c04-static-contract-violation'
   },
   AVX_C05: {
     code: 'AVX_C05',
-    name: 'MissingRootElement',
+    name: 'CompilerContractIsolatedViolation',
     severity: 'error',
     category: 'compiler',
-    summary: 'Component template markup lacks a valid root container element.',
+    summary: 'An isolated component reaches outside its isolation boundary.',
     causes: [
-      'Template root has multiple adjacent unparented nodes without a fragment wrapper.'
+      'The template or script accesses $bridges, $parent, or other external scope while isolated.'
     ],
     remedies: [
-      'Wrap root template content inside a single container element or fragment.'
+      'Remove the external access, or stop declaring the isolated contract on that component.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c05-isolated-contract-violation'
   },
   AVX_C06: {
     code: 'AVX_C06',
-    name: 'MalformedExpression',
+    name: 'CompilerContractInvalidDeclaration',
     severity: 'error',
     category: 'compiler',
-    summary: 'An expression enclosed in {{ ... }} failed interpolation parsing.',
+    summary: 'A <contract /> declaration is unknown or malformed.',
     causes: [
-      'JavaScript syntax error inside template expression interpolation delimiters.'
+      'An unrecognized contract name or invalid contract attribute syntax was used.'
     ],
     remedies: [
-      'Ensure interpolation contains valid JavaScript expressions.'
+      'Use a supported contract name and check the contract declaration syntax in the docs.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-c06-invalid-contract-declaration'
   },

--- a/test/unit/diagnosticCatalogueCodes.test.js
+++ b/test/unit/diagnosticCatalogueCodes.test.js
@@ -1,0 +1,26 @@
+/**
+ * Every catalogue key must be a real AvenxErrorCodes value so avenx explain
+ * cannot describe a different diagnostic than the compiler raises.
+ */
+import assert from 'assert';
+import { DIAGNOSTIC_CATALOGUE } from '../../lib/core/diagnostics/catalogue.js';
+import { AvenxErrorCodes } from '../../lib/core/runtime/AvenxError.js';
+
+console.log('Testing diagnostic catalogue keys against AvenxErrorCodes...');
+
+const known = new Set(Object.values(AvenxErrorCodes));
+
+for (const code of Object.keys(DIAGNOSTIC_CATALOGUE)) {
+  assert.ok(
+    known.has(code),
+    `catalogue key ${code} is not defined in AvenxErrorCodes`,
+  );
+}
+
+assert.strictEqual(
+  DIAGNOSTIC_CATALOGUE.AVX_C03.name,
+  'CompilerDuplicateComponentName',
+  'AVX_C03 must describe duplicate component names',
+);
+
+console.log(`  all ${Object.keys(DIAGNOSTIC_CATALOGUE).length} catalogue keys match AvenxErrorCodes`);


### PR DESCRIPTION
avenx explain gave wrong remedies for AVX_C01-C06 because the catalogue described a different scheme than AvenxErrorCodes.
Rewrite those six entries and add a unit test that every catalogue key exists in AvenxErrorCodes.

Fixes #1255
