### PR TITLE
fix(serve): deny sensitive files under the project root

### DIFF
--- a/bin/commands/serve.js
+++ b/bin/commands/serve.js
@@ -68,7 +68,39 @@ export function resolveRequestPath(baseDir, requestUrl) {
     filePath = path.join(root, 'index.html');
   }
 
+  if (isDeniedProjectPath(root, filePath)) {
+    return null;
+  }
+
   return filePath;
+}
+
+/**
+ * Returns true when a resolved path should not be served from the project root.
+ * Dot segments, node_modules, and package manifests are refused after containment.
+ * @param {string} root
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isDeniedProjectPath(root, filePath) {
+  const relative = path.relative(path.resolve(root), path.resolve(filePath));
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return true;
+  }
+
+  const segments = relative.split(path.sep).filter(Boolean);
+  const deniedFiles = new Set(['package.json', 'package-lock.json', 'npm-shrinkwrap.json']);
+
+  for (const segment of segments) {
+    if (segment === 'node_modules' || segment.startsWith('.')) {
+      return true;
+    }
+    if (deniedFiles.has(segment)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/test/unit/servePathTraversal.test.js
+++ b/test/unit/servePathTraversal.test.js
@@ -4,7 +4,7 @@ import os from 'os';
 import net from 'net';
 import path from 'path';
 import http from 'http';
-import { resolveRequestPath } from '../../bin/commands/serve.js';
+import { resolveRequestPath, isDeniedProjectPath } from '../../bin/commands/serve.js';
 
 /**
  * Regression coverage for the development server joining the raw request target
@@ -170,12 +170,47 @@ async function testLiveServerRejectsTraversal() {
   }
 }
 
+/**
+ * Sensitive project files must not be served even when they sit inside the root.
+ */
+function testSensitiveProjectFilesAreDenied() {
+  console.log('Testing sensitive project files are denied...');
+
+  fs.writeFileSync(path.join(projectDir, '.env'), 'SECRET=1');
+  fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(projectDir, '.git', 'config'), '[core]');
+  fs.mkdirSync(path.join(projectDir, 'node_modules', 'x'), { recursive: true });
+  fs.writeFileSync(path.join(projectDir, 'node_modules', 'x', 'index.js'), 'export {}');
+  fs.writeFileSync(path.join(projectDir, 'package.json'), '{"name":"demo"}');
+
+  const denied = ['/.env', '/.git/config', '/node_modules/x/index.js', '/package.json'];
+  for (const attempt of denied) {
+    assert.strictEqual(resolveRequestPath(projectDir, attempt), null, `${attempt} must be denied`);
+  }
+
+  assert.strictEqual(
+    resolveRequestPath(projectDir, '/index.html'),
+    path.join(projectDir, 'index.html'),
+    'application files must still resolve',
+  );
+  assert.strictEqual(
+    resolveRequestPath(projectDir, '/assets/app.js'),
+    path.join(assetsDir, 'app.js'),
+    'assets must still resolve',
+  );
+
+  assert.ok(isDeniedProjectPath(projectDir, path.join(projectDir, '.env')));
+  assert.ok(!isDeniedProjectPath(projectDir, path.join(projectDir, 'index.html')));
+  console.log('  sensitive project files denied.');
+}
+
 (async () => {
   try {
     testTraversalIsRejected();
     testLegitimateRequestsResolve();
     testQueryStringsAreStripped();
     testMalformedRequestsAreRejected();
+    testSensitiveProjectFilesAreDenied();
     await testLiveServerRejectsTraversal();
     console.log('🎉 All dev server path traversal tests passed successfully!');
   } catch (err) {


### PR DESCRIPTION
avenx serve already blocked path traversal but still returned .env, .git, node_modules and package.json from inside the project.
Refuse those paths with the same 403 path as a failed containment check, and cover them in the unit tests.

Fixes #1265
