### PR TITLE
test: run official plugin suites from npm and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Run plugin tests
+        run: npm run test:plugins
+
       - name: Run lint
         if: matrix.node-version != 18
         run: npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Avenx.js
 
-First of all, thank you for your interest in contributing to Avenx.js! 🎉
+First of all, thank you for your interest in contributing to Avenx.js!
 
 Avenx.js is an open-source JavaScript framework focused on simplicity, maintainability, and developer experience. Every contribution, whether it's code, documentation, bug reports, or ideas, helps improve the project.
 
@@ -23,6 +23,7 @@ A quick start for working on the codebase:
 1. **Clone and install dependencies**:
    ```bash
    npm install
+   ```
 
 ## Plugin tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,13 @@ A quick start for working on the codebase:
 1. **Clone and install dependencies**:
    ```bash
    npm install
+
+## Plugin tests
+
+Official plugins under `plugins/` ship their own suites. From the repository root run:
+
+```bash
+npm run test:plugins
+```
+
+CI runs this after `npm test`. Prefer fixing a plugin failure against the working-tree core rather than a published `avenx-core`.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prepare": "npm run build",
     "pretest": "npm run build",
     "test": "node test/run-tests.js",
+    "test:plugins": "npm --prefix plugins/avenx-i18n test && npm --prefix plugins/avenx-persistence test && npm --prefix plugins/avenx-charts test",
     "test:unit": "node test/run-tests.js unit",
     "test:integration": "node test/run-tests.js integration",
     "test:system": "node test/run-tests.js system",


### PR DESCRIPTION
The i18n, persistence and charts plugins already have tests, but npm test and CI never ran them.
Add npm run test:plugins, wire it into CI, and document it in CONTRIBUTING.

Fixes #1269
