### PR TITLE
feat(compiler): Report a template tag that resolves to no component

### DIFF
--- a/docs/src/content/docs/troubleshooting/errors.md
+++ b/docs/src/content/docs/troubleshooting/errors.md
@@ -415,6 +415,7 @@ const app = new AvenxApp({
 | `[AVX_W38]` | Bridge "{0}" never emits the event "{1}". | **Cause:** Code subscribes with `on()` to an event name that no `emit()` call in the bridge produces, so the handler would never run.<br />**Resolution:** Subscribe to an emitted event, or emit the one you meant. The warning lists the emitted events and suggests the closest match. |
 | `[AVX_W40]` | "{0}" is read nowhere in the application. | **Cause:** [Atlas](/core-concepts/atlas/) found no template binding, computed, action, resource or guard that reads this state key. Either it is dead, or the read it was meant to have is missing.<br />**Resolution:** Run `avenx impact <owner>.<key>` to see the relationships Atlas did find, then delete the declaration or add the missing read. Not reported when unresolved analysis in reach could be hiding a read. |
 | `[AVX_W41]` | "{0}" is never invoked. | **Cause:** [Atlas](/core-concepts/atlas/) found no template handler, action, computed, resource or guard that calls this action.<br />**Resolution:** Run `avenx why <owner>.<action>` to confirm, then wire up the call site or delete the action. Lifecycle actions the runtime invokes by name (`onMount` and the rest) are exempt, as are the members of a bridge nothing imports. |
+| `[AVX_W46]` | Component "<{0}>" does not resolve to a registered component, built-in, or HTML/SVG element. | **Cause:** A PascalCase template tag is misspelled or names a component that was never created or imported (e.g. `<UserCrad />` for `<UserCard />`).<br />**Resolution:** Fix the spelling (the warning suggests the closest name), create the component, or use a lowercase HTML element. Custom elements with a dash are never flagged. See [AVX_W46](#avx_w46--compiler_unresolved_component_reference). |
 | `[AVX_R19]` | bridge() expects a definition object, received {0}. | **Cause:** `bridge()` was called with no argument, or with something that is not a plain object.<br />**Resolution:** Pass a definition object, e.g. `bridge({ state: { count: 0 } })`. |
 | `[AVX_R20]` | Bridge definition declares "{0}", which is reserved by the Bridge API. | **Cause:** The definition declares `on`, `emit`, `$dispose` or `$name`, or a getter/action collides with a state key.<br />**Resolution:** Rename the member. |
 | `[AVX_R21]` | Bridge definition declares "{0}" as a top-level value. | **Cause:** Data was placed at the top level of the definition instead of inside `state`.<br />**Resolution:** Move it into the `state` object. Only actions, getters, `state` and `setup` belong at the top level. |
@@ -2944,6 +2945,25 @@ with the emit moved to the caller, after the transaction has committed.
 4. Silence it with `"warnings": { "AVX_W44": "off" }`.
 
 The warning does not fire when either write set is unbounded (AVX_W42), or for a caller and its callee — a nested transaction joins the enclosing frame and cannot conflict with it.
+
+### AVX_W46 — COMPILER_UNRESOLVED_COMPONENT_REFERENCE
+
+**Warning Message**
+
+```text
+Component "<{0}>" referenced in template of {1} does not resolve to a registered component, a built-in tag, or a known HTML/SVG element.
+```
+
+**Cause:** A PascalCase tag in a template names something that is not a registered component, not a framework built-in (`<slot>`, `<resource>`, `<@for>`, `<@if>`, `<@suspense>`, `<@errorBoundary>`, `<@deadlock>`, `<@defer>`, …), and not a known HTML/SVG element. The usual reason is a misspelled name (`<UserCrad />` for `<UserCard />`) or a component that was never created or imported. Without this check the mistake escapes the build and surfaces only at runtime as [AVX_R03](#avx_r03--component_not_found), or inside a page as [AVX_W13](#avx_w13--page_component_not_registered) — with no file, no line and no suggestion.
+
+**Resolution:**
+
+1. Fix the spelling. The warning names the file, the line, the offending tag, and the closest registered component when one is within the suggestion threshold.
+2. Create the component file (e.g. `UserCard.component.js`) so the name resolves.
+3. Use a lowercase HTML element, or a dash-containing custom element (e.g. `my-widget`) — custom elements are never flagged.
+4. If the component is registered at runtime through `app.register()`, which the compiler cannot see, silence the code with `"warnings": { "AVX_W46": "off" }` in `avenx.config.json`.
+
+This is a warning rather than an error precisely because a component may be registered at runtime. `avenx check` reports it (including in `--json` output), so a rename that misses one call site no longer passes CI silently.
 
 ## Runtime Codes (`AVX_R*`)
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -208,6 +208,9 @@ class AvenxCompiler {
     bundleJs += bridgeData.bridgesJs;
     // Components resolve their bridge imports against this map.
     this.componentParser.setBridges(bridgeData.bridges);
+    // Every component and page name, discovered up front so a template tag can
+    // be validated against the whole project (AVX_W46) as each file is parsed.
+    this.collectComponentNames();
     this.validateBridgeUsage(bridgeData.bridges);
     // Guards resolve their bridge imports against the same registry components
     // use, so `import session from '../bridges/session.bridge.js'` means the
@@ -470,6 +473,7 @@ class AvenxCompiler {
     try {
       const bridgeData = phase('bridges', () => this.processBridges());
       this.componentParser.setBridges((bridgeData && bridgeData.bridges) || new Map());
+      phase('componentNames', () => this.collectComponentNames());
       phase('components', () => this.processComponents());
       phase('pages', () => this.processPages());
       return this.finishModel();
@@ -958,6 +962,48 @@ class AvenxCompiler {
     }
 
     return guardsJs;
+  }
+
+  /**
+   * Collects every registered component and page name by filename and hands
+   * the set to the parser before any file is compiled.
+   *
+   * The unresolved-component check (AVX_W46) runs per file, while a file is
+   * being parsed, so it cannot rely on the running scan having reached every
+   * sibling yet. Discovering all names up front from filenames — the same
+   * PascalCase derivation `processComponents`/`processPages` use — means the
+   * check sees the whole project regardless of the order files are visited or
+   * whether tree shaking drops a component from the output.
+   * @returns {Set<string>} The registered component and page names.
+   * @private
+   */
+  collectComponentNames() {
+    const names = new Set();
+
+    const toClassName = (fileName, suffix) =>
+      path
+        .basename(fileName, suffix)
+        .split(/[-_]/)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join('');
+
+    const scan = (dir, suffix) => {
+      if (!fs.existsSync(dir)) return;
+      for (const entry of fs.readdirSync(dir)) {
+        const fullPath = path.join(dir, entry);
+        if (fs.statSync(fullPath).isDirectory()) {
+          scan(fullPath, suffix);
+        } else if (entry.endsWith(suffix)) {
+          names.add(toClassName(entry, suffix));
+        }
+      }
+    };
+
+    scan(path.join(this.srcDir, 'components'), '.component.js');
+    scan(path.join(this.srcDir, 'pages'), '.page.js');
+
+    this.componentParser.setComponentNames(names);
+    return names;
   }
 
   /**

--- a/lib/compiler/ComponentParser.js
+++ b/lib/compiler/ComponentParser.js
@@ -10,7 +10,7 @@ import { TemplateValidationError, BuildError } from './errors/index.js';
 import { reportWarning } from './utils/warningReporter.js';
 import { replaceEnvVariables } from '../env.js';
 import { processBindDirectives } from '../core/utils/templateUtils.js';
-import loadConfig, { resolvePathAlias } from '../config.js';
+import loadConfig, { resolvePathAlias, getClosestKey } from '../config.js';
 import { collectLocations } from './sourceMapTrace.js';
 import { addCachedComponentUnit } from './atlas/cache.js';
 import { collectTemplateEvents } from './templateEvents.js';
@@ -49,6 +49,56 @@ const DEFAULT_VOID_TAGS = [
 function buildVoidTagsSet(customVoidTags = []) {
   return new Set([...DEFAULT_VOID_TAGS, ...customVoidTags]);
 }
+
+/**
+ * Framework tags the compiler understands directly. These are never real
+ * components, so a reference to one must not be reported as an unresolved
+ * component (see {@link ComponentParser#validateComponentTags} / AVX_W46).
+ *
+ * The `@`-prefixed directives (`@for`, `@if`, `@suspense`, …) are handled
+ * separately: any tag beginning with `@` is skipped unconditionally, so it is
+ * enough to list the non-prefixed framework tags here.
+ * @type {Set<string>}
+ */
+const BUILTIN_TAGS = new Set([
+  'slot',
+  'resource',
+  'state',
+  'action',
+  'transition',
+  'template',
+  'component',
+  'script',
+  'style',
+]);
+
+/**
+ * A conservative set of known HTML and SVG element names. Element names are
+ * lowercase, so a PascalCase tag can practically never collide with one; this
+ * set exists only as a defensive net for an element written with an unusual
+ * case. It is deliberately not exhaustive — anything lowercase is treated as an
+ * ordinary element regardless of membership (see {@link ComponentParser#validateComponentTags}).
+ * @type {Set<string>}
+ */
+const KNOWN_ELEMENTS = new Set([
+  // Common HTML
+  'a', 'abbr', 'address', 'article', 'aside', 'audio', 'b', 'bdi', 'bdo',
+  'blockquote', 'body', 'button', 'canvas', 'caption', 'cite', 'code',
+  'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog',
+  'div', 'dl', 'dt', 'em', 'fieldset', 'figcaption', 'figure', 'footer',
+  'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup',
+  'html', 'i', 'iframe', 'ins', 'kbd', 'label', 'legend', 'li', 'main', 'map',
+  'mark', 'menu', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup',
+  'option', 'output', 'p', 'picture', 'pre', 'progress', 'q', 'rp', 'rt',
+  'ruby', 's', 'samp', 'section', 'select', 'small', 'span', 'strong', 'sub',
+  'summary', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead',
+  'time', 'tr', 'u', 'ul', 'var', 'video',
+  // SVG
+  'svg', 'circle', 'clippath', 'defs', 'ellipse', 'foreignobject', 'g',
+  'image', 'line', 'lineargradient', 'marker', 'mask', 'path', 'pattern',
+  'polygon', 'polyline', 'radialgradient', 'rect', 'stop', 'symbol', 'text',
+  'tspan', 'use',
+]);
 
 /**
  * Cache of resolved `avenx.config.json` contents, keyed by the directory
@@ -207,6 +257,15 @@ class ComponentParser {
     this.__atlasUnits = [];
 
     /**
+     * Every registered component and page name in the project, supplied by the
+     * compiler through {@link ComponentParser#setComponentNames} before any
+     * file is parsed. Used by the unresolved-component check (AVX_W46). Empty
+     * when a component is parsed standalone, which disables that check.
+     * @type {Set<string>}
+     */
+    this.__componentNames = new Set();
+
+    /**
      * The project root, when the compiler has told the parser what it is.
      *
      * `findProjectRoot` walks up from a component looking for a project
@@ -245,6 +304,23 @@ class ComponentParser {
    */
   setBridges(bridges) {
     this.bridges = bridges instanceof Map ? bridges : new Map();
+  }
+
+  /**
+   * Supplies the full set of registered component and page names, so a template
+   * tag can be validated against every name in the project rather than only the
+   * ones parsed so far.
+   *
+   * The compiler discovers all names by filename before it parses any file, and
+   * hands them over here. When it is never called — a component parsed
+   * standalone in a test or the Vite plugin — the set stays empty and the
+   * unresolved-component check does nothing, so a lone component is never
+   * flagged for referencing a sibling the parser could not see.
+   * @param {Iterable<string>} names - Registered component and page names.
+   * @returns {void}
+   */
+  setComponentNames(names) {
+    this.__componentNames = names ? new Set(names) : new Set();
   }
 
   /**
@@ -1137,6 +1213,113 @@ class ${name} extends AvenxComponent {
         checkIdentifiers(ev.expr, ev.index);
       }
     }
+
+    this.validateComponentTags(template, filePath, name, config);
+  }
+
+  /**
+   * Reports PascalCase template tags that resolve to no registered component,
+   * built-in tag, or known HTML/SVG element (AVX_W46).
+   *
+   * A misspelled or unimported component name is the most common template
+   * mistake and, unlike an undeclared identifier, it currently escapes every
+   * compile-time check — it surfaces only at runtime as AVX_R03 (or AVX_W13
+   * inside a page). This walks the parsed node tree the other passes use, so no
+   * new parse is added, and reports each unresolved tag with the file, the
+   * line, the tag and the closest registered name when one is near enough.
+   *
+   * It is a warning, not an error: a component may legitimately be registered
+   * at runtime through `app.register()`, which the compiler cannot see. The
+   * check is skipped entirely when the registry is empty (a component parsed
+   * standalone), so it never fires on a project the compiler did not scan whole.
+   * @param {string} template - The processed template HTML.
+   * @param {string} filePath - Absolute path of the file being compiled.
+   * @param {string} name - The component/page name, for the diagnostic.
+   * @param {object|null} config - Resolved project configuration.
+   * @returns {void}
+   * @private
+   */
+  validateComponentTags(template, filePath, name, config) {
+    if (!this.__componentNames || this.__componentNames.size === 0) {
+      return;
+    }
+    if (!template || template.trim() === '') {
+      return;
+    }
+
+    const filename = filePath ? path.basename(filePath) : (name || 'template');
+
+    // The project's void tags share the identifier check's escape hatch: a tag
+    // the project has declared as its own element is never reported as an
+    // unresolved component, whatever its casing.
+    const customVoidTags = [...(this.customVoidTags || []), ...getCustomVoidTags(filePath)];
+    const voidTagSet = new Set(customVoidTags.map((t) => String(t).toLowerCase()));
+
+    let nodes;
+    try {
+      nodes = parseHTML(template, customVoidTags);
+    } catch {
+      // A template that will not even parse is a different problem, reported by
+      // the passes that transform it. This check simply steps aside.
+      return;
+    }
+
+    const isPascalCase = (tag) => /^[A-Z][A-Za-z0-9]*$/.test(tag);
+
+    const walk = (list) => {
+      for (const node of list) {
+        if (node && node.type === 'element' && typeof node.tagName === 'string') {
+          const tag = node.tagName;
+
+          // A dash marks a Web Component custom element; the framework never
+          // owns it, so it is never flagged (matches the identifier check's
+          // escape hatch).
+          const isCustomElement = tag.includes('-');
+          // `<Component is="...">` is the dynamic-component built-in.
+          const isDynamic = tag === 'Component';
+
+          if (
+            isPascalCase(tag) &&
+            !isCustomElement &&
+            !isDynamic &&
+            !tag.startsWith('@') &&
+            !BUILTIN_TAGS.has(tag.toLowerCase()) &&
+            !KNOWN_ELEMENTS.has(tag.toLowerCase()) &&
+            !voidTagSet.has(tag.toLowerCase()) &&
+            !this.__componentNames.has(tag)
+          ) {
+            const suggestion = getClosestKey(tag, [...this.__componentNames]);
+            const hint = suggestion ? `\n\nDid you mean "<${suggestion}>"?` : '';
+            const err = new TemplateValidationError(
+              AvenxErrorCodes.COMPILER_UNRESOLVED_COMPONENT_REFERENCE,
+              tag,
+              filename,
+              hint,
+            );
+            if (node.line) {
+              err.setLocation({
+                source: template,
+                line: node.line,
+                column: node.column || 1,
+                filename,
+                length: tag.length,
+              });
+            }
+            reportWarning(
+              AvenxErrorCodes.COMPILER_UNRESOLVED_COMPONENT_REFERENCE,
+              err,
+              config,
+            );
+          }
+        }
+
+        if (node && Array.isArray(node.children) && node.children.length > 0) {
+          walk(node.children);
+        }
+      }
+    };
+
+    walk(nodes);
   }
 
   /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,7 +47,7 @@ function findProjectRoot(startDir = process.cwd()) {
  * @param {string} b
  * @returns {number}
  */
-function levenshtein(a, b) {
+export function levenshtein(a, b) {
   const tmp = [];
   let i, j;
   for (i = 0; i <= a.length; i++) {
@@ -75,7 +75,7 @@ function levenshtein(a, b) {
  * @param {string[]} allowedKeys
  * @returns {string|null}
  */
-function getClosestKey(key, allowedKeys) {
+export function getClosestKey(key, allowedKeys) {
   let closest = null;
   let minDistance = Infinity;
   for (const allowed of allowedKeys) {

--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -277,6 +277,25 @@ export const DIAGNOSTIC_CATALOGUE = {
     ],
     docsUrl: 'https://avenx-js.com/core-concepts/rewind#avx-w44-two-transactions-writing-the-same-state'
   },
+  AVX_W46: {
+    code: 'AVX_W46',
+    name: 'UnresolvedComponentReference',
+    severity: 'warning',
+    category: 'compiler',
+    summary: 'A PascalCase template tag resolves to no registered component, built-in tag, or known HTML/SVG element.',
+    causes: [
+      'The component name is misspelled — the single most common template mistake, e.g. <UserCrad /> for <UserCard />.',
+      'The component file was never created, or was renamed and a call site was missed.',
+      'The tag was meant to be a plain HTML element but was written in PascalCase.'
+    ],
+    remedies: [
+      'Fix the spelling — the warning names the closest registered component when one is near enough.',
+      'Create the component file (e.g. "UserCard.component.js") so the name resolves.',
+      'Use a lowercase HTML element, or a dash-containing custom element (e.g. "my-widget") which is never flagged.',
+      'If the component is registered at runtime via app.register(), silence the code with "warnings": { "AVX_W46": "off" } in avenx.config.json.'
+    ],
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w46-unresolved-component-reference'
+  },
   AVX_R29: {
     code: 'AVX_R29',
     name: 'TransactionRewindFailed',

--- a/lib/core/runtime/AvenxError.js
+++ b/lib/core/runtime/AvenxError.js
@@ -59,6 +59,7 @@
  * @property {string} COMPILER_TRANSACTION_UNBOUNDED - AVX_W42: An atomic action's write set could not be resolved completely.
  * @property {string} COMPILER_TRANSACTION_IRREVERSIBLE - AVX_W43: An atomic action performs an effect a rewind cannot undo.
  * @property {string} COMPILER_TRANSACTION_OVERLAP - AVX_W44: Two atomic actions write the same state.
+ * @property {string} COMPILER_UNRESOLVED_COMPONENT_REFERENCE - AVX_W46: A PascalCase template tag resolves to no registered component, built-in, or known HTML/SVG element.
  */
 
 /** @type {AvenxErrorCodesType} */
@@ -140,6 +141,7 @@ export const AvenxErrorCodes = {
   COMPILER_TRANSACTION_UNBOUNDED: 'AVX_W42',
   COMPILER_TRANSACTION_IRREVERSIBLE: 'AVX_W43',
   COMPILER_TRANSACTION_OVERLAP: 'AVX_W44',
+  COMPILER_UNRESOLVED_COMPONENT_REFERENCE: 'AVX_W46',
 
   // Runtime Warnings (AVX_W*)
   PAGE_ALREADY_REGISTERED: 'AVX_W07',
@@ -298,6 +300,8 @@ export const AvenxErrorMessages = {
     '{0} is atomic, but {1} effect(s) cannot be rewound:\n{2}\nEverything it writes through Avenx state will be restored; the effects above will not. Move them after the transaction, or accept that a rewind leaves them in place.',
   [AvenxErrorCodes.COMPILER_TRANSACTION_OVERLAP]:
     '{0} and {1} are both atomic and both write {2} ({3}).\nIf they can be in flight at the same time, a rewind may find a value it did not write. The "safe" conflict policy skips such a path and reports AVX_R29 rather than discarding the newer value.',
+  [AvenxErrorCodes.COMPILER_UNRESOLVED_COMPONENT_REFERENCE]:
+    'Component "<{0}>" referenced in template of {1} does not resolve to a registered component, a built-in tag, or a known HTML/SVG element.{2}\nRegister the component (add a matching ".component.js" file), fix the spelling, or use a lowercase HTML element. A dash-containing custom element (e.g. "my-widget") is never flagged. Silence this class with "warnings": { "AVX_W46": "off" } in avenx.config.json.',
 
   // Runtime Warnings
   [AvenxErrorCodes.PAGE_ALREADY_REGISTERED]:

--- a/test/unit/cliCheckJson.test.js
+++ b/test/unit/cliCheckJson.test.js
@@ -77,6 +77,37 @@ const FIXTURE_DIR = path.join(__dirname, 'fixtures-check-json');
     assert.ok(warningReport.diagnostics[0].message.includes('undeclaredUser'));
     assert.strictEqual(process.exitCode, 1);
 
+    // 5. Project with an unresolved component reference (AVX_W46) check --json
+    console.log('Testing checkProject with --json on an unresolved component reference...');
+    fs.rmSync(invalidCompPath, { force: true });
+    // A real, registered component derives its name from the filename:
+    // user-card.component.js -> UserCard.
+    fs.writeFileSync(
+      path.join(FIXTURE_DIR, 'src', 'components', 'user-card.component.js'),
+      `export default {
+        name: 'UserCard',
+        template: '<div>card</div>'
+      };`
+    );
+    // A component that references it with a typo.
+    fs.writeFileSync(
+      path.join(FIXTURE_DIR, 'src', 'components', 'home.component.js'),
+      `export default {
+        name: 'Home',
+        template: '<div><UserCrad /></div>'
+      };`
+    );
+
+    const unresolvedReport = checkProject(mockCli, ['--json']);
+    assert.strictEqual(unresolvedReport.valid, false, 'the report is not valid');
+    const w46 = unresolvedReport.diagnostics.filter((d) => d.code === 'AVX_W46');
+    assert.strictEqual(w46.length, 1, 'exactly one AVX_W46 diagnostic is emitted');
+    assert.strictEqual(w46[0].severity, 'warning');
+    assert.ok(w46[0].message.includes('UserCrad'), 'the diagnostic names the offending tag');
+    assert.ok(w46[0].message.includes('UserCard'), 'the diagnostic suggests the closest name');
+    assert.ok(w46[0].file && w46[0].file.includes('home.component.js'), 'the diagnostic carries the file');
+    assert.strictEqual(process.exitCode, 1);
+
     // Cleanup fixture
     fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
 

--- a/test/unit/unresolvedComponentReference.test.js
+++ b/test/unit/unresolvedComponentReference.test.js
@@ -1,0 +1,102 @@
+import assert from 'assert';
+
+// Set env to test so config validation throws instead of process.exit.
+process.env.NODE_ENV = 'test';
+
+import ComponentParser from '../../lib/compiler/ComponentParser.js';
+import StyleProcessor from '../../lib/compiler/StyleProcessor.js';
+import { logger } from '../../lib/core/runtime/AvenxLogger.js';
+
+try {
+  console.log('Testing unresolved component reference (AVX_W46)...');
+
+  let warnings = [];
+  const originalWarn = logger.warn;
+  logger.warn = (...args) => warnings.push(args.join(' '));
+
+  const styleProcessor = new StyleProcessor();
+
+  /**
+   * Validates a template against a known set of component names and returns
+   * whatever the compiler warned about.
+   * @param {string} template - The template to validate.
+   * @param {string[]} componentNames - Registered component/page names.
+   * @param {object} [config] - The compiler configuration.
+   * @returns {string[]} The warnings emitted.
+   */
+  function validate(template, componentNames, config = { warnings: {} }) {
+    warnings = [];
+    const parser = new ComponentParser(styleProcessor, [], config);
+    parser.setComponentNames(componentNames);
+    parser.validateTemplate(template, {}, {}, {}, {}, 'Home.component.js', 'Home');
+    return warnings;
+  }
+
+  /**
+   * Returns only the warnings for the unresolved-component code.
+   * @param {string[]} all - All captured warnings.
+   * @returns {string[]}
+   */
+  const w46 = (all) => all.filter((m) => m.includes('AVX_W46'));
+
+  try {
+    // 1. A tag that matches a registered component is accepted.
+    const matching = validate('<div><UserCard /></div>', ['UserCard']);
+    assert.deepStrictEqual(w46(matching), [], 'a registered component is not flagged');
+
+    // 2. A misspelled tag is reported, and the closest name is suggested.
+    const misspelled = validate('<div><UserCrad /></div>', ['UserCard']);
+    const misspelledW46 = w46(misspelled);
+    assert.strictEqual(misspelledW46.length, 1, 'a misspelled component is reported once');
+    assert.ok(misspelledW46[0].includes('UserCrad'), 'the warning names the offending tag');
+    assert.ok(misspelledW46[0].includes('UserCard'), 'the warning suggests the closest name');
+    assert.ok(misspelledW46[0].includes('Home.component.js'), 'the warning names the file');
+
+    // 3. A dash-containing custom element is never flagged.
+    const customElement = validate('<div><my-widget></my-widget></div>', ['UserCard']);
+    assert.deepStrictEqual(w46(customElement), [], 'a custom element is not flagged');
+
+    // 3b. A tag the project declared in voidTags is never flagged, whatever
+    //     its casing (matches the identifier check's escape hatch).
+    warnings = [];
+    const voidTagParser = new ComponentParser(styleProcessor, ['MyIcon'], { warnings: {} });
+    voidTagParser.setComponentNames(['UserCard']);
+    voidTagParser.validateTemplate('<div><MyIcon /></div>', {}, {}, {}, {}, 'Home.component.js', 'Home');
+    assert.deepStrictEqual(w46(warnings), [], 'a declared void tag is not flagged');
+
+    // 4. Built-in tags and lowercase HTML/SVG elements are not flagged.
+    const builtins = validate(
+      '<div><slot></slot><@if cond><p>hi</p></@if><svg><circle /></svg></div>',
+      ['UserCard'],
+    );
+    assert.deepStrictEqual(w46(builtins), [], 'built-ins and HTML/SVG elements are not flagged');
+
+    // 5. The dynamic <Component is="..."> built-in is not flagged.
+    const dynamic = validate('<div><Component is="{{ current }}" /></div>', ['UserCard']);
+    assert.deepStrictEqual(w46(dynamic), [], 'the dynamic component built-in is not flagged');
+
+    // 6. An unknown tag with no near match still warns, without a suggestion.
+    const noSuggestion = validate('<div><Zzzzzzzz /></div>', ['UserCard']);
+    const noSuggestionW46 = w46(noSuggestion);
+    assert.strictEqual(noSuggestionW46.length, 1, 'an unknown component with no near match is reported');
+    assert.ok(!noSuggestionW46[0].includes('Did you mean'), 'no suggestion when nothing is close');
+
+    // 7. "warnings": { "AVX_W46": "off" } silences the check.
+    const silenced = validate('<div><UserCrad /></div>', ['UserCard'], {
+      warnings: { AVX_W46: 'off' },
+    });
+    assert.deepStrictEqual(w46(silenced), [], 'the code can be silenced via warnings config');
+
+    // 8. An empty registry (standalone parse) disables the check entirely.
+    const standalone = validate('<div><UserCrad /></div>', []);
+    assert.deepStrictEqual(w46(standalone), [], 'no registry means no component-tag check');
+  } finally {
+    logger.warn = originalWarn;
+  }
+
+  console.log('unresolved component reference tests passed!');
+} catch (error) {
+  console.error('unresolved component reference tests failed!');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
Close #1249 

## Problem

A PascalCase tag naming a component that doesn't exist compiled silently. `<UserCrad />` (typo for `UserCard`) passed both `avenx build` and `avenx check`, then surfaced at runtime as `AVX_R03 COMPONENT_NOT_FOUND` — or `AVX_W13 PAGE_COMPONENT_NOT_REGISTERED` inside a page — with no file, line or suggestion. It was the one class of reference error the compiler didn't catch, even though undeclared identifiers in expressions already report with line, column and a code frame. A rename that missed one call site passed every check in CI.

## Change

A PascalCase tag that resolves to no registered component, built-in tag, or known HTML/SVG element now raises **`AVX_W46 COMPILER_UNRESOLVED_COMPONENT_REFERENCE`** at build time, naming the file, line, offending tag, and closest registered name. It's a warning, not an error — a component can be registered at runtime via `app.register()`, which the compiler can't see — so it's silenceable (`"warnings": { "AVX_W46": "off" }`) and promotable to an error through the same config.

## Changes in detail

**`lib/compiler/ComponentParser.js`** — the core of the change.

- New `validateComponentTags(template, filePath, name, config)`, called at the end of `validateTemplate()`. It runs at the point in the pipeline where PascalCase tags still exist in the template — before `processComponentTags` rewrites `<UserCard>` into `<div data-avenx-comp="UserCard">`. It walks the `parseHTML` node tree and, for each element whose tag name doesn't resolve, builds a `TemplateValidationError` with a code frame from the node's `line`/`column`, then routes it through the existing `reportWarning` (so `warnings` config severity applies uniformly).
- New `setComponentNames(names)` + `__componentNames` field — the registry the check validates against.
- New module-level `BUILTIN_TAGS` (framework tags: `slot`, `resource`, `state`, `action`, `transition`, `template`, `component`, `script`, `style`) and `KNOWN_ELEMENTS` (a conservative HTML/SVG allowlist as a defensive net).
- Reuses `getClosestKey` for the "did you mean" suggestion instead of a local copy.

**`lib/compiler.js`** — solves the ordering problem. `validateTemplate` runs per file, mid-scan, so it can't rely on the running scan having reached every sibling yet. New `collectComponentNames()` scans `src/components/*.component.js` and `src/pages/*.page.js` filenames up front (same PascalCase derivation the emit path uses) and injects the full set via `setComponentNames()`. Wired into both `build()` (after `setBridges`) and `analyze()` (as a tolerant phase, so `avenx check` gets it too). When the set is empty — a component parsed standalone in a test or the Vite plugin — the check is skipped, so a lone component is never flagged for referencing a sibling the parser couldn't see.

**`lib/config.js`** — exported `getClosestKey` and `levenshtein` (previously module-private) so the compiler reuses the same "did you mean" helper and edit-distance threshold that config-key suggestions use.

**`lib/core/runtime/AvenxError.js`** — registered `COMPILER_UNRESOLVED_COMPONENT_REFERENCE: 'AVX_W46'` in the codes, the typedef, and a message template. The message is phrased with "in template of {file}" so `avenx check`'s `parseDiagnostic` extracts the filename into the `--json` `file` field.

**`lib/core/diagnostics/catalogue.js`** — `AVX_W46` entry (name, severity, category, causes, remedies, docsUrl) so `avenx explain AVX_W46` answers.

**`docs/src/content/docs/troubleshooting/errors.md`** — summary-table row and a detailed section with the anchor the catalogue's `docsUrl` points to.

**Tests** — `test/unit/unresolvedComponentReference.test.js` (new) and an extended `--json` case in `test/unit/cliCheckJson.test.js`.

## Terminal output

<img width="1869" height="285" alt="Screenshot 2026-09-07 at 14 56 32" src="https://github.com/user-attachments/assets/21679357-ca1d-492f-ad73-3ed720e2c917" />
<img width="1739" height="341" alt="Screenshot 2026-09-07 at 14 57 05" src="https://github.com/user-attachments/assets/5ab48969-9a52-4de3-8733-48bc6a2f5319" />
<img width="2531" height="962" alt="Screenshot 2026-09-07 at 14 58 16" src="https://github.com/user-attachments/assets/690d09dd-b7b2-430a-bc93-81c68516e10c" />
