### PR TITLE
fix: correct AVX_W01 diagnostic catalogue entry for bundle size

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -140,15 +140,18 @@ export const DIAGNOSTIC_CATALOGUE = {
   // Warning Diagnostics (AVX_W01 - AVX_W35)
   AVX_W01: {
     code: 'AVX_W01',
-    name: 'UnusedStateVariable',
+    name: 'CompilerBundleSizeExceeded',
     severity: 'warning',
     category: 'compiler',
-    summary: 'A state variable was declared but never referenced in template or actions.',
+    summary: 'A compiled JavaScript or CSS asset exceeded the configured bundle size budget.',
     causes: [
-      '<state ... /> defines a variable that is dead code.'
+      'Large third-party dependencies are included in the application bundle.',
+      'Unused code or assets are bundled unnecessarily.',
+      'Bundle size limits are configured too aggressively for the project.'
     ],
     remedies: [
-      'Remove unused state declarations to reduce memory footprint.'
+      'Review generated assets and split or remove large dependencies.',
+      'Raise build.bundleBudget in avenx.config.json if the size is expected.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w01-compiler-bundle-size-exceeded'
   },


### PR DESCRIPTION
AVX_W01 is COMPILER_BUNDLE_SIZE_EXCEEDED in AvenxErrorCodes. The catalogue still described an unused state variable.