### PR TITLE
feat(diagnostics): catalogue AVX_W03 for avenx explain

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -152,6 +152,22 @@ export const DIAGNOSTIC_CATALOGUE = {
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w01-compiler-bundle-size-exceeded'
   },
+  AVX_W03: {
+    code: 'AVX_W03',
+    name: 'CompilerUndeclaredReference',
+    severity: 'warning',
+    category: 'compiler',
+    summary: 'A template references a variable or method that is not declared on the component.',
+    causes: [
+      'A typo in a variable or method name.',
+      'Referencing state, computed, actions, or bridges that were never declared.'
+    ],
+    remedies: [
+      'Verify the identifier spelling against state, computed, actions, and bridges.',
+      'Update the template after renaming a declaration.'
+    ],
+    docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w03-compiler-undeclared-reference'
+  },
   AVX_W29: {
     code: 'AVX_W29',
     name: 'MissingKeyInLoop',


### PR DESCRIPTION
avenx explain AVX_W03 returned unknown despite COMPILER_UNDECLARED_REFERENCE being a common compiler warning. Fixes part of #1256.