### PR TITLE
fix: correct AVX_W29 diagnostic catalogue for circular imports

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -154,15 +154,17 @@ export const DIAGNOSTIC_CATALOGUE = {
   },
   AVX_W29: {
     code: 'AVX_W29',
-    name: 'MissingKeyInLoop',
+    name: 'CompilerCircularDependency',
     severity: 'warning',
     category: 'compiler',
-    summary: 'A repeated list item in <@for> does not specify a unique @key attribute.',
+    summary: 'The compiler detected a circular dependency in the component import graph.',
     causes: [
-      '<@for ...> rendering dynamic lists without unique tracking keys.'
+      'Two components import each other directly.',
+      'A longer import chain loops back to an earlier component.'
     ],
     remedies: [
-      'Add a unique @key attribute to the root repeated item (e.g., @key="item.id").'
+      'Remove imports that close a cycle.',
+      'Extract shared code into a module both sides can import without looping.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w29-compiler-circular-dependency'
   },


### PR DESCRIPTION
AVX_W29 is COMPILER_CIRCULAR_DEPENDENCY. The catalogue still described missing @key on <@for> loops.