### PR TITLE
fix: correct AVX_W35 diagnostic catalogue for deadlock parse

### DIFF
--- a/lib/core/diagnostics/catalogue.js
+++ b/lib/core/diagnostics/catalogue.js
@@ -189,15 +189,17 @@ export const DIAGNOSTIC_CATALOGUE = {
   },
   AVX_W35: {
     code: 'AVX_W35',
-    name: 'DeprecatedLifecycleHook',
+    name: 'CompilerDeadlockParseFailed',
     severity: 'warning',
-    category: 'runtime',
-    summary: 'A deprecated lifecycle method was invoked on the component instance.',
+    category: 'compiler',
+    summary: 'The compiler could not parse a <@deadlock> tag or its attributes.',
     causes: [
-      'Using legacy lifecycle methods slated for deprecation.'
+      'Malformed or unclosed <@deadlock> / <@fallback> tags.',
+      'Invalid attribute values on a <@deadlock> boundary.'
     ],
     remedies: [
-      'Migrate to updated lifecycle hooks as specified in the migration guide.'
+      'Fix tag nesting and quoted attributes on the <@deadlock> block.',
+      'Confirm nested <@fallback as="..."> is closed with </@fallback>.'
     ],
     docsUrl: 'https://avenx-js.com/troubleshooting/errors#avx-w35-compiler-deadlock-parse-failed'
   },


### PR DESCRIPTION
AVX_W35 is COMPILER_DEADLOCK_PARSE_FAILED. The catalogue still described a deprecated lifecycle hook.

Fixes part of #1256.